### PR TITLE
ci: add PR Gate aggregate check for dev branch protection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,6 +257,36 @@ jobs:
     with:
       skip_tests: ${{ needs.changes.outputs.skip_tests == 'true' }}
 
+  # PR Gate — a single always-present aggregate check for branch
+  # protection. `dev` protection requires this one context instead of the
+  # individual Quality / * checks: those are only created when the
+  # `quality` job runs (it is conditional on quality-relevant paths), so
+  # requiring them directly leaves branch protection waiting forever on
+  # PRs that touch none of those paths. Scoped to pull_request events, so
+  # it never runs on aws-dev / gcp-dev / main pushes.
+  pr-gate:
+    name: PR Gate
+    needs: [changes, quality]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert required PR jobs passed
+        run: |
+          changes_result='${{ needs.changes.result }}'
+          quality_result='${{ needs.quality.result }}'
+          echo "changes=$changes_result quality=$quality_result"
+          if [ "$changes_result" != "success" ]; then
+            echo "::error::Detect Changes did not succeed (result=$changes_result)"
+            exit 1
+          fi
+          # `quality` is legitimately skipped when no quality-relevant
+          # paths changed; only a real failure or cancellation blocks.
+          if [ "$quality_result" != "success" ] && [ "$quality_result" != "skipped" ]; then
+            echo "::error::Quality did not pass (result=$quality_result)"
+            exit 1
+          fi
+          echo "PR gate passed"
+
   gcp-dev:
     name: GCP Dev
     needs: [changes, quality]


### PR DESCRIPTION
## Summary

Adds a `PR Gate` aggregate check job to `deploy.yml` so `dev` branch protection can hard-enforce the quality suite with a single stable required context.

## Background

`dev` branch protection previously required two contexts — `Deploy` and `PR title lint` — that no check run ever publishes (the workflow is *named* "Deploy" but emits per-job checks like `Detect Changes` / `Quality / …`; the PR-title check run is `Lint PR title`). Every PR to `dev` sat `BLOCKED` waiting for status that never reported. Branch protection has been corrected to `[CodeQL, Lint PR title]` to unblock.

The individual `Quality / *` checks cannot be required directly: the `quality` job is conditional on quality-relevant paths (`deploy.yml` ~line 243), so on a PR that touches none of them those check runs are never created — requiring them would reproduce the same "waiting forever" failure.

## Change

- New `pr-gate` job (`name: PR Gate`), `needs: [changes, quality]`, `if: always() && github.event_name == 'pull_request'`.
- It always produces one `PR Gate` check run on PRs, and passes only when `Detect Changes` succeeded and `Quality` succeeded **or was legitimately skipped** (no quality-relevant paths changed).
- Scoped to `pull_request` events — it does **not** run on `aws-dev` / `gcp-dev` / `main` pushes and does not change the `quality` job's own condition, so quality is not re-run on env branches.

## Follow-up (manual, after merge)

Update `dev` branch protection required status checks to `[PR Gate, Lint PR title, CodeQL]` for full quality enforcement.

## Test Plan

- [x] `actionlint` passes on `deploy.yml`
- [x] `adr_guard --all --level ci` passes (`deploy-workflow-plan-scope` included)
- [ ] PR's own `PR Gate` check reports green on this PR
