### PR TITLE
feat: add pre-event Polaris scenario-content smoketest harness

### DIFF
--- a/changelog.d/617.added.md
+++ b/changelog.d/617.added.md
@@ -1,0 +1,12 @@
+**Pre-event Polaris scenario-content smoketest harness.** The new
+`scenario-dev/polaris/tests/scenario_smoketest/` package is an operator-run,
+on-demand verifier that walks each CTFd challenge's canonical participant path
+against a real staged range and checks the value it produces against the flag
+configured in `ctfd-challenges.json`. The challenge universe is derived from
+the board, so a challenge with no registered adapter is reported `uncovered`
+(a failure) rather than silently skipped. It additionally performs the
+read-only CTFd flag-row readback from `lessons-4.md` checklist item 4
+(`GET /challenges/{id}/flags`, asserting non-empty) that catches the regression
+where a `sync_polaris_ctfd.py` re-sync shipped 38/39 challenges unsubmittable.
+Flag bodies are redacted to stable digests in all output. Run with
+`python3 -m scenario_smoketest`; it is not wired to CI.

--- a/docs/architecture/polaris-scenario-smoketest-preflight-617.md
+++ b/docs/architecture/polaris-scenario-smoketest-preflight-617.md
@@ -1,0 +1,187 @@
+# Polaris Scenario Smoketest Preflight
+
+Issue: GitHub #617, "Pre-event scenario smoketest: run every flag's hint path
+end-to-end against a staged range".
+
+This note records the architecture boundary for the future implementation. It is
+intentionally not an implementation plan.
+
+## Boundary
+
+The new check is an operator-run, range-time scenario-content verifier. It
+should prove that each CTFd challenge entry has a canonical participant path
+that produces the value configured for that challenge, against a real staged
+Polaris range.
+
+Keep these concepts separate:
+
+- Challenge metadata: `scenario-dev/polaris/build/ctfd-challenges.json` and,
+  when explicitly included, `ctfd-onboarding.json`.
+- Deployed CTFd state: optional verification through the existing CTFd API
+  client, not a new source of truth.
+- Range content: files, services, credentials, and network paths inside the
+  staged range.
+- Walkthroughs: human-readable intent under
+  `scenario-dev/polaris/tests/walkthroughs/`.
+- Canonical solution scripts: machine-executable checks under
+  `scenario-dev/polaris/tests/`, usually adapted from existing per-asset
+  smoketests.
+
+The harness may add a small coverage map from challenge id/name to runner and
+solution command, but that map must not become another challenge schema. It
+should contain only execution metadata that cannot already be derived from the
+CTFd JSON or the existing runner topology.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail |
+| --- | --- | --- |
+| Scenario source order | `scenario-dev/polaris/README.md` source-of-truth section | Reconcile against build artifacts and walkthroughs before older design prose. |
+| Challenge metadata | `scenario-dev/polaris/build/ctfd-challenges.json`, `ctfd-onboarding.json` | Do not duplicate challenge names, categories, values, hints, flags, or prerequisites in a second schema. |
+| Static flag extraction | `scenario-dev/polaris/build/verify_flags_baked.py::static_flag` semantics | Reuse or factor this parser shape. A challenge without exactly one supported flag must fail closed unless the adapter explicitly supports it. |
+| Bake artifact check | `scenario-dev/polaris/build/verify_flags_baked.py` and `test_verify_flags_baked.py` | Keep bake-time literal artifact verification separate from range-time hint-path execution. This issue extends coverage; it does not replace the bake verifier. |
+| Range runner topology | `scenario-dev/polaris/tests/run-all-smoketests.sh`, `reset.sh`, and the README asset pivot map | Run checks from the same runner containers participants can reach from: A14, A15, A16, A9, or the range host for isolation. Do not bypass topology to make a test pass. |
+| Existing solution material | `scenario-dev/polaris/tests/smoketests/*` and `tests/walkthroughs/*` | Prefer adapting existing per-asset checks over rewriting every path. Do not parse Markdown code fences and execute them as commands. |
+| CTFd API access | `scripts/ctfd-workshop/common.py::CtfdClient` and `sync_polaris_ctfd.py::get_all_items` | Reuse the header, timeout, error, and pagination behavior. Do not create another CTFd client or partial schema. |
+| CTFd sync workflow | `sync_polaris_ctfd.py`, `sync_polaris_ctfd_onboarding.py`, `sync_range_flags.py` | The smoketest may report CTFd drift but must not mutate CTFd, sync pages, or repair flags as part of validation. |
+| Reporting | Existing shell/Python CLI conventions in `scenario-dev/polaris/tests/` | Produce per-challenge pass/fail and aggregate exit status. Redact flag bodies by default. |
+| Architecture gates | `.ground-control.yaml`, `.gc/plan-rules.md`, `scripts/adr_guard/adr_guard.py` | Architecture/doc changes still pass ADR guard. Do not weaken workflow or local enforcement. |
+
+## Cross-Cutting Layers
+
+Security layers the future design must satisfy:
+
+- Auth surface: no participant-facing Django route, CTF service endpoint, or
+  CTFd plugin is required for this issue. It should stay an operator-run CLI
+  against an authorized staged range.
+- CTFd token handling: if live CTFd verification is added, use `CTFD_TOKEN` or a
+  local token file with restrictive permissions. Do not pass admin tokens on the
+  command line, copy them into participant containers, print them, or make Kali
+  responsible for CTFd calls. The Polaris participant flow deliberately has
+  Kali and CTFd in separate browser tabs, and Kali is not a CTFd API client.
+- CTFd API shape: use `CtfdClient`, including `Authorization: Token ...`,
+  `Accept: application/json`, and `Content-Type: application/json`. Pagination
+  must follow CTFd metadata instead of assuming one page.
+- Challenge schema gate: parse JSON with the standard JSON parser. For each
+  challenge, validate id/name uniqueness, supported flag shape, and presence of
+  an executable coverage entry. Missing coverage is a failed/uncovered result,
+  not a silent skip.
+- Range execution gate: honor `RANGE_DIR`, `COMPOSE_PROJECT_NAME`,
+  `SMOKETESTS_DIR`, existing `docker cp`/`docker exec` runner conventions, and
+  `reset.sh` for sticky state. Do not attach extra networks, relax isolation,
+  alter service ACLs, or patch files before a path check.
+- OS/process exposure: do not build shell strings from challenge names, hint
+  text, CTFd descriptions, or other metadata. Prefer Python subprocess argv
+  arrays for new wrappers; where existing shell tests are reused, keep
+  untrusted metadata out of shell evaluation.
+- Walkthrough handling: walkthrough Markdown is reference material. The
+  machine contract must live in scripts or adapters that are reviewed as code,
+  not in ad hoc extraction of commands from prose.
+- Secret handling: CTFd admin tokens, participant credentials, service account
+  passwords, private keys, and static flags must not be written to tracked
+  reports, CI artifacts, workflow logs, process argv, or Docker environment
+  variables. Per-challenge reports should name ids and challenge names and use
+  redacted digests or match/mismatch labels for flag values.
+- Error envelopes and logs: CLI failures may include challenge id, challenge
+  name, runner, adapter name, exit status, and sanitized reason. They should not
+  include raw API response bodies, authorization headers, full command output,
+  or submitted/expected flag values by default. Use `shared.log_sanitize.safe_log`
+  if a Python logger emits user-controlled or CTFd-controlled strings.
+- Network boundary: tests must exercise the same pivot path as a participant.
+  A14 can reach shared/corporate and the splice path only after the designed
+  gate; A15 reaches SCADA; A16 reaches Lab; A9 reaches Bunker OT. Host-side
+  checks are for orchestration/isolation only.
+- Validation gates: changes under `scenario-dev/polaris/tests/` should run the
+  staged-range sweep they add or a targeted local unit test for parser/report
+  behavior. Changes touching architecture docs or guardrails must pass
+  `python3 scripts/adr_guard/adr_guard.py --all --level ci`.
+
+Maintainability incumbents the implementation must build on:
+
+- Existing per-asset smoketests for the flag extraction mechanics.
+- Existing walkthroughs for human-readable expected paths.
+- Existing CTFd JSON for challenge metadata and configured static flags.
+- Existing CTFd API client/pagination helper for any live-board readback.
+- Existing range reset/setup scripts for state control.
+- Existing Polaris bake preflight note for repo-to-AMI delivery boundaries.
+
+Extensibility seam:
+
+Keep the parameter seam at the edges:
+
+- Board inputs: challenge JSON path, optional onboarding JSON path, and optional
+  live CTFd base URL for read-only verification.
+- Range inputs: `RANGE_DIR`, `COMPOSE_PROJECT_NAME`, `SMOKETESTS_DIR`, and
+  runner container names.
+- Selection inputs: challenge id/name/category filters for partial reruns.
+- Coverage input: a minimal challenge-to-adapter map that identifies the runner
+  and executable adapter, not challenge metadata.
+- Output inputs: human table/stdout plus optional redacted JSON/JSONL report.
+
+The next likely change is adding another mission, another scenario, or an
+optional live CTFd readback. That should require adding board paths, runner
+entries, or adapters, not editing the core comparison or reporting contract.
+
+Whole-repo surfaces in scope for the future implementation:
+
+- `scenario-dev/polaris/tests/run-all-smoketests.sh`
+- `scenario-dev/polaris/tests/reset.sh`
+- `scenario-dev/polaris/tests/smoketests/*`
+- `scenario-dev/polaris/tests/walkthroughs/*`
+- `scenario-dev/polaris/build/ctfd-challenges.json`
+- `scenario-dev/polaris/build/ctfd-onboarding.json`
+- `scenario-dev/polaris/build/verify_flags_baked.py`
+- `scenario-dev/polaris/build/test_verify_flags_baked.py`
+- `scenario-dev/polaris/README.md`
+- `scenario-dev/polaris/design/architecture.md`
+- `scenario-dev/polaris/design/shared-constants.md`
+- `scripts/ctfd-workshop/common.py`
+- `scripts/ctfd-workshop/sync_polaris_ctfd.py`
+- `scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py`
+- `scripts/polaris-aws-range/check_range_health.py`
+- `docs/architecture/polaris-scenario-bake-preflight-618.md`
+- `scripts/adr_guard/adr_guard.py` only if enforcement policy changes
+
+## Gotchas And Anti-Patterns
+
+- The current per-asset smoketests hardcode expected flags and often print flag
+  values. A new all-challenge verifier must compare against the CTFd JSON so it
+  catches JSON/script drift, and its default report should not expose raw flags.
+- `ctfd-challenges.json` currently contains more challenges than the original
+  1-38 campaign. The coverage sweep must derive its universe from the selected
+  JSON input and report uncovered challenges rather than quietly limiting itself
+  to existing asset smoketests.
+- Some existing checks distinguish a human-discovered answer from a
+  `FLAG{...}` literal. For example, the Bunker device-id path builds model
+  strings while the board stores a static flag. Do not conflate "artifact found
+  by the hint path", "answer to submit", and "configured CTFd flag"; adapters
+  must state which value they produce and how it is compared.
+- Do not make the harness a CTFd sync repair tool. Verify-after-sync is valuable,
+  but mutation belongs in `scripts/ctfd-workshop/*`.
+- Do not execute shell snippets scraped from Markdown walkthroughs. Prose is too
+  loose to be a command API, and CTFd content can contain strings that should
+  never be evaluated by a shell.
+- Do not run the full sweep against a participant's active event range. Several
+  paths are destructive or stateful, including A5 runaway, Modbus register
+  unlocks, and A13 override flow.
+- Do not "fix" a failed path by widening Docker networks or bypassing pivots.
+  The test must preserve the same segmentation participants experience.
+- Do not bury all checks inside one monolithic shell block. Keep per-path logic
+  reviewable and reusable so failures identify a challenge, runner, and adapter.
+- Do not add a second flag parser, CTFd client, exception hierarchy, or global
+  scenario schema when existing scripts already own those concerns.
+- Do not archive raw command output as a CI artifact. This is on-demand
+  pre-event validation and may reveal flags, credentials, internal hostnames, or
+  event-specific operational details.
+
+## Non-Goals
+
+- Tying the scenario-content smoketest to push, pull request, or main deploy CI.
+- Replacing `run-all-smoketests.sh`, `reset.sh`, or the per-asset smoketests.
+- Replacing the bake-time `verify_flags_baked.py` artifact verifier.
+- Creating a generic scenario framework, new ACES SDL runner, or new CTFd schema.
+- Mutating CTFd challenges, hints, flags, pages, submissions, users, or scores.
+- Submitting flags to CTFd from Kali or reviving `flag_submit.sh` as a required
+  participant-path dependency.
+- Fixing known content bugs, CTFd sync bugs, nginx tuning, range provisioning,
+  Guacamole, identity, magic links, or participant invite flows.

--- a/scenario-dev/polaris/tests/scenario_smoketest/README.md
+++ b/scenario-dev/polaris/tests/scenario_smoketest/README.md
@@ -1,0 +1,66 @@
+# Pre-event scenario smoketest
+
+Operator-run, on-demand verifier for Polaris / NORTHSTORM scenario content
+(GitHub issue #617). It answers one question before an event: does every CTFd
+challenge's hint path actually produce the flag the board is configured with?
+
+Scenario-content bugs — a flag in CTFd that is not baked into the range
+artifact, a broken hint chain, a `sync_polaris_ctfd.py` re-sync that dropped
+flag rows — are invisible to infrastructure health checks and only surface
+when participants follow a hint and find nothing. This harness catches them.
+
+It is **not** wired to CI, does not mutate CTFd, and does not replace the
+per-asset `run-all-smoketests.sh` sweep or the bake-time `verify_flags_baked.py`
+artifact check. See `docs/architecture/polaris-scenario-smoketest-preflight-617.md`.
+
+## What it does
+
+1. **Range sweep.** Derives the challenge universe from `ctfd-challenges.json`.
+   For each challenge it runs a registered *adapter* — the canonical
+   participant path — from the correct runner container, then compares the
+   produced value to the board's configured static flag. A challenge with no
+   adapter is reported `uncovered` (counted as a failure, never skipped).
+2. **CTFd flag-row readback** (optional, read-only). For every CTFd challenge,
+   `GET /challenges/{id}/flags` and asserts the row set is non-empty — the
+   `lessons-4.md` checklist item 4 check for the 38/39-unsubmittable regression.
+
+Flag bodies never appear in output: comparisons report a match/mismatch verdict
+and reduce any value to a short `sha256:` digest.
+
+## Usage
+
+Run from the range host (it executes commands in runner containers via
+`docker exec`):
+
+```sh
+# Full range sweep against a staged range
+python3 -m scenario_smoketest
+
+# A subset of challenges
+python3 -m scenario_smoketest --only 1,2,3
+
+# Range sweep plus the read-only CTFd readback
+CTFD_TOKEN=... python3 -m scenario_smoketest --ctfd-url https://ctfd.example
+
+# CTFd readback only
+python3 -m scenario_smoketest --skip-range --ctfd-url https://ctfd.example
+```
+
+The CTFd admin token is read from the `CTFD_TOKEN` environment variable or a
+file passed with `--ctfd-token-file` — never from a command-line argument.
+`--json-report PATH` writes a redacted machine-readable report. The process
+exits non-zero if any challenge fails, is uncovered, or errors.
+
+## Coverage
+
+Adapters live in `adapters/` and are factored from the existing per-asset
+smoketests under `../smoketests/`. Coverage is intentionally incremental: the
+report makes every uncovered challenge explicit, so the gap is visible rather
+than hidden. Add an adapter by registering a callable for a challenge id — see
+`adapters/mission1_osint.py` for the pattern.
+
+## Tests
+
+```sh
+python -m pytest scenario-dev/polaris/tests/test_scenario_smoketest.py
+```

--- a/scenario-dev/polaris/tests/scenario_smoketest/__init__.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/__init__.py
@@ -1,0 +1,10 @@
+"""Pre-event scenario smoketest harness for the Polaris / NORTHSTORM CTF.
+
+An operator-run, range-time verifier (GitHub issue #617). It proves that each
+CTFd challenge's canonical participant path produces the value configured for
+that challenge against a real staged range, reports per-challenge pass/fail,
+and optionally performs a read-only CTFd flag-row readback.
+
+This is NOT a CTFd sync tool, a bake-time artifact verifier, or a CI gate.
+See ``docs/architecture/polaris-scenario-smoketest-preflight-617.md``.
+"""

--- a/scenario-dev/polaris/tests/scenario_smoketest/__main__.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/__main__.py
@@ -1,0 +1,156 @@
+"""CLI entry point: ``python3 -m scenario_smoketest``.
+
+Operator-run, on-demand, against a real staged range. Not wired to CI.
+
+The CLI keeps every parameter at the edge: board paths, the runner-container
+hostnames, challenge filters, and the optional read-only CTFd readback.
+
+CTFd admin tokens are never accepted as a command-line argument (process argv
+is world-readable). The token is read from the ``CTFD_TOKEN`` environment
+variable or from a permission-restricted file via ``--ctfd-token-file``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from . import ctfd_check, report, run
+from .board import load_board
+from .runner import Runner
+
+_DEFAULT_BUILD = Path(__file__).resolve().parents[2] / "build"
+_DEFAULT_CHALLENGES = _DEFAULT_BUILD / "ctfd-challenges.json"
+
+# Default asset hostnames as resolved inside the range runner containers.
+_DEFAULT_HOSTS = {
+    "a0": "boreas-systems.ctf",
+    "a3": "intranet.boreas.local",
+}
+
+
+def _parse_host_overrides(pairs: list[str]) -> dict[str, str]:
+    hosts = dict(_DEFAULT_HOSTS)
+    for pair in pairs:
+        if "=" not in pair:
+            raise SystemExit(f"--host expects key=value, got {pair!r}")
+        key, _, value = pair.partition("=")
+        hosts[key.strip()] = value.strip()
+    return hosts
+
+
+def _read_ctfd_token(token_file: str | None) -> str | None:
+    if token_file:
+        return Path(token_file).read_text(encoding="utf-8").strip()
+    return os.environ.get("CTFD_TOKEN")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scenario_smoketest",
+        description="Pre-event Polaris scenario-content smoketest (issue #617).",
+    )
+    parser.add_argument(
+        "--challenges",
+        default=str(_DEFAULT_CHALLENGES),
+        help="Path to ctfd-challenges.json (default: repo build artifact).",
+    )
+    parser.add_argument(
+        "--onboarding",
+        default=None,
+        help="Optional path to ctfd-onboarding.json to merge into the universe.",
+    )
+    parser.add_argument(
+        "--only",
+        default=None,
+        help="Comma-separated challenge ids to run (default: all).",
+    )
+    parser.add_argument(
+        "--host",
+        action="append",
+        default=[],
+        metavar="KEY=HOSTNAME",
+        help="Override an asset hostname (e.g. a0=boreas-systems.ctf).",
+    )
+    parser.add_argument(
+        "--dns", default="172.20.0.2", help="DNS sidecar address used by adapters."
+    )
+    parser.add_argument(
+        "--docker", default="docker", help="Path to the docker CLI."
+    )
+    parser.add_argument(
+        "--json-report",
+        default=None,
+        help="Optional path for a redacted JSON result report.",
+    )
+    parser.add_argument(
+        "--ctfd-url",
+        default=None,
+        help="Base URL of a deployed CTFd for the read-only flag-row readback.",
+    )
+    parser.add_argument(
+        "--ctfd-token-file",
+        default=None,
+        help="File holding the CTFd admin token (else read from CTFD_TOKEN).",
+    )
+    parser.add_argument(
+        "--skip-range",
+        action="store_true",
+        help="Skip the range sweep and run only the CTFd readback.",
+    )
+    return parser
+
+
+def _run_ctfd_readback(ctfd_url: str, token: str | None) -> int:
+    if not token:
+        print(
+            "[ctfd] no token (set CTFD_TOKEN or --ctfd-token-file); skipping readback",
+            file=sys.stderr,
+        )
+        return 0
+    # Imported lazily: the workshop client lives outside this package.
+    sys.path.insert(
+        0, str(Path(__file__).resolve().parents[4] / "scripts" / "ctfd-workshop")
+    )
+    from common import CtfdClient  # noqa: PLC0415
+
+    client = CtfdClient(ctfd_url, token)
+    results = ctfd_check.check_flags(client)
+    print(ctfd_check.build_report(results))
+    return ctfd_check.exit_code(results)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    range_code = 0
+    if not args.skip_range:
+        challenges = load_board(args.challenges, args.onboarding)
+        only_ids = None
+        if args.only:
+            only_ids = {int(x) for x in args.only.split(",") if x.strip()}
+        results = run.run_smoketest(
+            challenges,
+            Runner(docker=args.docker),
+            hosts=_parse_host_overrides(args.host),
+            dns=args.dns,
+            only_ids=only_ids,
+        )
+        print(report.build_report(results))
+        if args.json_report:
+            report.write_json_report(results, args.json_report)
+        range_code = report.aggregate_exit_code(results)
+
+    ctfd_code = 0
+    if args.ctfd_url:
+        ctfd_code = _run_ctfd_readback(
+            args.ctfd_url, _read_ctfd_token(args.ctfd_token_file)
+        )
+
+    return 1 if (range_code or ctfd_code) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scenario-dev/polaris/tests/scenario_smoketest/adapters/__init__.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/adapters/__init__.py
@@ -1,0 +1,88 @@
+"""Per-challenge adapters: the executable coverage map.
+
+An adapter executes one challenge's canonical participant path against a real
+staged range and returns the value that path yields. Each adapter declares the
+runner container it executes from and the *kind* of value it produces:
+
+* ``flag``   - the path yields the literal ``FLAG{...}`` configured in CTFd;
+  the harness compares it for equality against the board's static flag.
+* ``answer`` - the path yields a submit-answer string distinct from the CTFd
+  static flag (e.g. a concatenated device-model identifier). The adapter
+  records ``expected_answer`` and the harness compares against that.
+
+The coverage universe is derived from the board, not from this registry: a
+challenge with no adapter is reported ``uncovered`` (a failure), never skipped.
+
+Adapter logic is factored from the existing per-asset smoketests under
+``scenario-dev/polaris/tests/smoketests/``; this registry does not duplicate
+challenge metadata that already lives in ``ctfd-challenges.json``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class Produced:
+    """A value produced by walking a challenge's hint path."""
+
+    value: str | None
+    kind: str  # "flag" | "answer"
+    note: str = ""
+
+
+@dataclass
+class AdapterContext:
+    """Range connection context handed to every adapter."""
+
+    runner: object  # a runner.Runner (or test double) exposing .exec()
+    hosts: dict[str, str] = field(default_factory=dict)
+    dns: str = "172.20.0.2"
+
+    def host(self, key: str) -> str:
+        """Return the configured hostname for an asset key (e.g. ``a0``)."""
+        return self.hosts[key]
+
+
+@dataclass(frozen=True)
+class Adapter:
+    """An executable check for one challenge."""
+
+    challenge_id: int
+    runner: str
+    value_kind: str
+    solve: Callable[[AdapterContext], Produced]
+    expected_answer: str | None = None
+
+
+ADAPTERS: dict[int, Adapter] = {}
+
+
+def register(
+    challenge_id: int,
+    *,
+    runner: str,
+    value_kind: str = "flag",
+    expected_answer: str | None = None,
+) -> Callable[[Callable[[AdapterContext], Produced]], Callable]:
+    """Decorator: register an adapter callable for ``challenge_id``."""
+
+    def decorator(fn: Callable[[AdapterContext], Produced]):
+        if challenge_id in ADAPTERS:
+            raise ValueError(f"duplicate adapter for challenge {challenge_id}")
+        ADAPTERS[challenge_id] = Adapter(
+            challenge_id=challenge_id,
+            runner=runner,
+            value_kind=value_kind,
+            solve=fn,
+            expected_answer=expected_answer,
+        )
+        return fn
+
+    return decorator
+
+
+# Importing a mission module runs its @register decorators as a side effect.
+from . import mission1_osint  # noqa: E402,F401

--- a/scenario-dev/polaris/tests/scenario_smoketest/adapters/mission1_osint.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/adapters/mission1_osint.py
@@ -1,0 +1,92 @@
+"""Mission 1 (Boreas OSINT) adapters — challenges 1-6.
+
+Every path here is executed from the a14-kali container against the A0 Boreas
+public website and the DNS sidecar. Logic is factored from
+``tests/smoketests/A0-smoketest.sh``; each adapter produces the literal
+``FLAG{...}`` a participant would recover and leaves the equality check to the
+harness.
+"""
+
+from __future__ import annotations
+
+import re
+
+from . import AdapterContext, Produced, register
+
+RUNNER = "a14-kali"
+_FLAG_RE = re.compile(r"FLAG\{[A-Fa-f0-9]+\}")
+
+
+def _first_flag(text: str) -> str | None:
+    """Return the first ``FLAG{...}`` literal in ``text``, or None."""
+    match = _FLAG_RE.search(text or "")
+    return match.group(0) if match else None
+
+
+def _curl(ctx: AdapterContext, url: str) -> str:
+    """Fetch ``url`` from the runner container and return the response body."""
+    result = ctx.runner.exec(RUNNER, ["curl", "-s", url])
+    return result.stdout
+
+
+@register(1, runner=RUNNER)
+def challenge_1(ctx: AdapterContext) -> Produced:
+    """Company Info — flag in an HTML comment on the About page."""
+    body = _curl(ctx, f"http://{ctx.host('a0')}/about.html")
+    return Produced(_first_flag(body), "flag", "about.html HTML comment")
+
+
+@register(2, runner=RUNNER)
+def challenge_2(ctx: AdapterContext) -> Produced:
+    """Employee Directory — flag in org_chart.pdf metadata (Author field)."""
+    pdf_path = "/tmp/sst-org_chart.pdf"
+    ctx.runner.exec(
+        RUNNER,
+        ["curl", "-sf", f"http://{ctx.host('a0')}/internal/org_chart.pdf",
+         "-o", pdf_path],
+    )
+    meta = ctx.runner.exec(RUNNER, ["exiftool", pdf_path])
+    return Produced(_first_flag(meta.stdout), "flag", "org_chart.pdf metadata")
+
+
+@register(3, runner=RUNNER)
+def challenge_3(ctx: AdapterContext) -> Produced:
+    """Tech Stack Revealed — flag in a hidden form field on the Careers page."""
+    body = _curl(ctx, f"http://{ctx.host('a0')}/careers.html")
+    return Produced(_first_flag(body), "flag", "careers.html hidden field")
+
+
+@register(4, runner=RUNNER)
+def challenge_4(ctx: AdapterContext) -> Produced:
+    """Client Contracts — flag in an HTML comment on the archived client list."""
+    body = _curl(ctx, f"http://{ctx.host('a0')}/old/clients.html")
+    return Produced(_first_flag(body), "flag", "old/clients.html HTML comment")
+
+
+@register(5, runner=RUNNER)
+def challenge_5(ctx: AdapterContext) -> Produced:
+    """DNS Reconnaissance — flag in a TXT record exposed by a zone transfer."""
+    result = ctx.runner.exec(
+        RUNNER,
+        ["dig", "+short", "axfr", "boreas-systems.ctf", f"@{ctx.dns}"],
+    )
+    return Produced(_first_flag(result.stdout), "flag", "DNS AXFR TXT record")
+
+
+@register(6, runner=RUNNER)
+def challenge_6(ctx: AdapterContext) -> Produced:
+    """Follow the Money — flag baked into the hidden annual report PDF.
+
+    This is the Ottawa "Follow the Money" regression (#619): the PDF shipped
+    without the canonical flag literal. The adapter fetches the unlisted
+    report and extracts text the way the walkthrough instructs participants to.
+    """
+    pdf_path = "/tmp/sst-annual.pdf"
+    ctx.runner.exec(
+        RUNNER,
+        ["curl", "-sf",
+         f"http://{ctx.host('a0')}/internal/boreas-annual-2025.pdf",
+         "-o", pdf_path],
+    )
+    text = ctx.runner.exec(RUNNER, ["pdftotext", pdf_path, "-"])
+    return Produced(_first_flag(text.stdout), "flag", "annual report PDF text")

--- a/scenario-dev/polaris/tests/scenario_smoketest/board.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/board.py
@@ -1,0 +1,80 @@
+"""CTFd challenge-board parsing.
+
+The board JSON (``ctfd-challenges.json`` and optional ``ctfd-onboarding.json``)
+is the single source of challenge metadata. This module derives the challenge
+universe and the configured static flag per challenge; it never duplicates
+challenge names, categories, hints, or prerequisites into a second schema.
+
+Static-flag extraction follows the ``verify_flags_baked.static_flag`` shape:
+a challenge must carry exactly one ``static`` flag for the harness to use it as
+an equality target. Anything else (zero, many, or non-static) is reported as a
+missing comparison target and fails closed in :mod:`compare`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Challenge:
+    """One CTFd challenge as seen by the harness."""
+
+    id: int
+    name: str
+    category: str
+    static_flag: str | None
+
+
+def _static_flag(challenge: dict) -> str | None:
+    """Return the single static-flag content, or None when not exactly one."""
+    static = [
+        f for f in challenge.get("flags", []) if f.get("type") == "static"
+    ]
+    if len(static) != 1:
+        return None
+    content = static[0].get("content")
+    return content or None
+
+
+def _challenges_from(path: Path) -> list[dict]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if "challenges" not in payload or not isinstance(payload["challenges"], list):
+        raise ValueError(f"{path}: missing or invalid 'challenges' list")
+    return payload["challenges"]
+
+
+def load_board(
+    challenges_path: str | Path,
+    onboarding_path: str | Path | None = None,
+) -> list[Challenge]:
+    """Parse the board JSON into a list of :class:`Challenge`.
+
+    When ``onboarding_path`` is given its challenges are merged into the
+    universe. Duplicate challenge ids across the merged set are rejected:
+    an ambiguous id makes per-challenge results meaningless.
+    """
+    raw = list(_challenges_from(challenges_path))
+    if onboarding_path is not None:
+        raw.extend(_challenges_from(onboarding_path))
+
+    challenges: list[Challenge] = []
+    seen: set[int] = set()
+    for entry in raw:
+        cid = entry.get("id")
+        if not isinstance(cid, int):
+            raise ValueError(f"challenge has non-integer id: {entry.get('name')!r}")
+        if cid in seen:
+            raise ValueError(f"duplicate challenge id {cid}")
+        seen.add(cid)
+        challenges.append(
+            Challenge(
+                id=cid,
+                name=str(entry.get("name", "")),
+                category=str(entry.get("category", "")),
+                static_flag=_static_flag(entry),
+            )
+        )
+    return challenges

--- a/scenario-dev/polaris/tests/scenario_smoketest/compare.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/compare.py
@@ -1,0 +1,59 @@
+"""Produced-vs-configured value comparison with flag redaction.
+
+Existing per-asset smoketests hardcode and print flag values. This harness
+must not: the default report names a challenge and a match/mismatch verdict,
+and any value that does appear is reduced to a short stable digest. A failed
+comparison must not leak either the produced or the configured value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+def redact(value: str | None) -> str:
+    """Reduce a flag/answer value to a short, stable, non-reversible token."""
+    if value is None:
+        return "<none>"
+    if value == "":
+        return "<empty>"
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]
+    return f"sha256:{digest}"
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """Outcome of comparing a produced value against the expected value."""
+
+    status: str  # "pass" | "fail"
+    detail: str
+
+
+def compare(produced: str | None, expected: str | None, kind: str) -> Comparison:
+    """Compare a produced value against the expected value for ``kind``.
+
+    ``kind`` is ``"flag"`` (compare against the CTFd-configured static flag)
+    or ``"answer"`` (compare against the canonical submit-answer recorded by
+    the adapter). Detail strings carry only redacted digests, never raw values.
+    """
+    if kind not in ("flag", "answer"):
+        raise ValueError(f"unknown comparison kind: {kind!r}")
+
+    if produced is None:
+        return Comparison("fail", "adapter produced no value from the hint path")
+
+    if expected is None:
+        if kind == "flag":
+            return Comparison(
+                "fail", "no configured static flag on the board to compare against"
+            )
+        return Comparison("fail", "adapter declares no expected answer")
+
+    if produced == expected:
+        return Comparison("pass", f"match ({redact(produced)})")
+
+    return Comparison(
+        "fail",
+        f"mismatch: produced {redact(produced)} != expected {redact(expected)}",
+    )

--- a/scenario-dev/polaris/tests/scenario_smoketest/ctfd_check.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/ctfd_check.py
@@ -1,0 +1,86 @@
+"""Read-only CTFd flag-row readback.
+
+Implements ``lessons-4.md`` pre-flight checklist item 4: for every CTFd
+challenge, ``GET /challenges/{id}/flags`` and assert the row set is non-empty.
+This catches the regression where a ``sync_polaris_ctfd.py`` re-sync silently
+dropped flag rows and shipped 38/39 challenges unsubmittable.
+
+This module is strictly read-only. It never creates, patches, or deletes any
+CTFd object — flag repair belongs in ``scripts/ctfd-workshop/*``. CTFd
+pagination is silent and capped, so ``/challenges`` is walked page by page.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FlagRowResult:
+    """Whether one CTFd challenge has any flag rows configured."""
+
+    challenge_id: int
+    has_flags: bool
+    flag_count: int
+    detail: str
+
+
+def _all_challenge_ids(client) -> list[int]:
+    ids: list[int] = []
+    page = 1
+    while True:
+        payload = client.get("/challenges", query={"page": page})
+        for entry in payload.get("data", []):
+            cid = entry.get("id")
+            if isinstance(cid, int):
+                ids.append(cid)
+        nxt = payload.get("meta", {}).get("pagination", {}).get("next")
+        if not nxt:
+            break
+        page = nxt
+    return ids
+
+
+def check_flags(client, challenge_ids: list[int] | None = None) -> list[FlagRowResult]:
+    """Return a flag-row result for every CTFd challenge (or a filtered set)."""
+    ids = challenge_ids if challenge_ids is not None else _all_challenge_ids(client)
+    results: list[FlagRowResult] = []
+    for cid in ids:
+        payload = client.get(f"/challenges/{cid}/flags")
+        rows = payload.get("data", [])
+        count = len(rows)
+        results.append(
+            FlagRowResult(
+                challenge_id=cid,
+                has_flags=count > 0,
+                flag_count=count,
+                detail=(
+                    f"{count} flag row(s) configured"
+                    if count
+                    else "NO flag rows — challenge is unsubmittable"
+                ),
+            )
+        )
+    return results
+
+
+def exit_code(results: list[FlagRowResult]) -> int:
+    """Return 0 only when every checked challenge has at least one flag row."""
+    return 1 if any(not r.has_flags for r in results) else 0
+
+
+def build_report(results: list[FlagRowResult]) -> str:
+    """Render the human-readable CTFd flag-row readback table."""
+    lines = ["", "CTFd flag-row readback (read-only)", ""]
+    for r in sorted(results, key=lambda x: x.challenge_id):
+        marker = "OK" if r.has_flags else "EMPTY"
+        lines.append(f"  [{marker:<5}] challenge #{r.challenge_id} — {r.detail}")
+    empty = sum(1 for r in results if not r.has_flags)
+    verdict = "PASS" if empty == 0 else "FAIL"
+    lines.append("")
+    lines.append(
+        f"  {len(results) - empty}/{len(results)} challenges have flag rows"
+    )
+    lines.append(f"  CTFd flag-row readback: {verdict}")
+    lines.append("")
+    return "\n".join(lines)

--- a/scenario-dev/polaris/tests/scenario_smoketest/report.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/report.py
@@ -1,0 +1,89 @@
+"""Per-challenge result aggregation and reporting.
+
+A challenge result is one of:
+
+* ``pass``      - the hint path produced the configured value.
+* ``fail``      - the hint path produced a wrong or missing value.
+* ``uncovered`` - no adapter is registered for the challenge. Per the issue,
+  the coverage universe is derived from the board, so an uncovered challenge
+  is a reported failure, never a silent skip.
+* ``error``     - the adapter raised before producing a verdict.
+
+Detail strings are expected to be redacted by the caller (see :mod:`compare`);
+this module never reconstructs raw values.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+_FAILING = ("fail", "uncovered", "error")
+
+
+@dataclass(frozen=True)
+class ChallengeResult:
+    """Outcome for a single challenge."""
+
+    challenge_id: int
+    name: str
+    status: str
+    detail: str
+
+
+def summarize(results: list[ChallengeResult]) -> dict[str, int]:
+    """Return per-status counts plus a ``total``."""
+    counts = {"pass": 0, "fail": 0, "uncovered": 0, "error": 0}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    counts["total"] = len(results)
+    return counts
+
+
+def aggregate_exit_code(results: list[ChallengeResult]) -> int:
+    """Return 0 only when every challenge passed."""
+    return 1 if any(r.status in _FAILING for r in results) else 0
+
+
+def to_json(results: list[ChallengeResult]) -> list[dict]:
+    """Render results as a redaction-safe JSON-serialisable list."""
+    return [
+        {
+            "challenge_id": r.challenge_id,
+            "name": r.name,
+            "status": r.status,
+            "detail": r.detail,
+        }
+        for r in results
+    ]
+
+
+def build_report(results: list[ChallengeResult]) -> str:
+    """Render the human-readable per-challenge table plus an aggregate line."""
+    lines = ["", "Pre-event scenario smoketest — per-challenge results", ""]
+    for r in sorted(results, key=lambda x: x.challenge_id):
+        marker = {
+            "pass": "PASS",
+            "fail": "FAIL",
+            "uncovered": "UNCOVERED",
+            "error": "ERROR",
+        }.get(r.status, r.status.upper())
+        lines.append(f"  [{marker:<9}] #{r.challenge_id:<3} {r.name} — {r.detail}")
+
+    counts = summarize(results)
+    lines.append("")
+    lines.append(
+        "  {pass} pass / {fail} fail / {uncovered} uncovered / "
+        "{error} error  ({total} total)".format(**counts)
+    )
+    verdict = "PASS" if aggregate_exit_code(results) == 0 else "FAIL"
+    lines.append(f"  scenario smoketest: {verdict}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_json_report(results: list[ChallengeResult], path: str) -> None:
+    """Write the redacted JSON report to ``path``."""
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(to_json(results), handle, indent=2)
+        handle.write("\n")

--- a/scenario-dev/polaris/tests/scenario_smoketest/run.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/run.py
@@ -1,0 +1,76 @@
+"""Orchestration: walk the challenge universe and run each adapter.
+
+The universe comes from the board (:mod:`board`). For every challenge the
+harness looks up a registered adapter; a challenge with no adapter is
+``uncovered`` (a failure). A covered challenge's adapter is executed against
+the range and its produced value is compared (:mod:`compare`) to the board's
+configured static flag, or to the adapter's recorded answer for ``answer``
+challenges.
+"""
+
+from __future__ import annotations
+
+from . import compare
+from .adapters import ADAPTERS, AdapterContext
+from .board import Challenge
+from .report import ChallengeResult
+
+
+def run_smoketest(
+    challenges: list[Challenge],
+    runner,
+    *,
+    hosts: dict[str, str],
+    dns: str = "172.20.0.2",
+    only_ids: set[int] | None = None,
+) -> list[ChallengeResult]:
+    """Execute every covered challenge and return per-challenge results."""
+    results: list[ChallengeResult] = []
+    for challenge in challenges:
+        if only_ids is not None and challenge.id not in only_ids:
+            continue
+
+        adapter = ADAPTERS.get(challenge.id)
+        if adapter is None:
+            results.append(
+                ChallengeResult(
+                    challenge.id,
+                    challenge.name,
+                    "uncovered",
+                    "no adapter registered — challenge path is unverified",
+                )
+            )
+            continue
+
+        ctx = AdapterContext(runner=runner, hosts=hosts, dns=dns)
+        try:
+            produced = adapter.solve(ctx)
+        except Exception as exc:  # noqa: BLE001 - adapter faults must not abort the sweep
+            results.append(
+                ChallengeResult(
+                    challenge.id,
+                    challenge.name,
+                    "error",
+                    f"adapter raised {type(exc).__name__}",
+                )
+            )
+            continue
+
+        if adapter.value_kind == "flag":
+            expected = challenge.static_flag
+        else:
+            expected = adapter.expected_answer
+
+        verdict = compare.compare(produced.value, expected, adapter.value_kind)
+        detail = verdict.detail
+        if produced.note:
+            detail = f"{detail} [{produced.note}]"
+        results.append(
+            ChallengeResult(
+                challenge.id,
+                challenge.name,
+                "pass" if verdict.status == "pass" else "fail",
+                detail,
+            )
+        )
+    return results

--- a/scenario-dev/polaris/tests/scenario_smoketest/runner.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/runner.py
@@ -1,0 +1,71 @@
+"""Range runner-container command execution.
+
+Adapters execute the participant path from inside the same runner containers
+participants pivot through (a14-kali, a15-ops-eng, a16-research-analyst,
+a9-splice). Commands are passed as argv arrays through ``docker exec`` so that
+challenge metadata, hostnames, and other untrusted strings are never evaluated
+by a shell.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+
+# Docker object names: alphanumerics plus a small punctuation set. This refuses
+# anything that could carry shell metacharacters even though argv-array exec
+# would not interpret them — defence in depth at the boundary.
+_CONTAINER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    """Result of one command executed in a runner container."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _default_run(argv: list[str], *, input: str | None, timeout: int) -> ExecResult:
+    completed = subprocess.run(  # noqa: S603 - argv array, no shell
+        argv,
+        input=input,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return ExecResult(completed.returncode, completed.stdout, completed.stderr)
+
+
+class Runner:
+    """Executes commands inside range runner containers via ``docker exec``."""
+
+    def __init__(
+        self,
+        docker: str = "docker",
+        runner_run=None,
+    ) -> None:
+        self._docker = docker
+        self._run = runner_run or (
+            lambda argv, input=None, timeout=60: _default_run(
+                argv, input=input, timeout=timeout
+            )
+        )
+
+    def exec(
+        self,
+        container: str,
+        argv: list[str],
+        *,
+        input: str | None = None,
+        timeout: int = 60,
+    ) -> ExecResult:
+        """Run ``argv`` inside ``container`` and return its result."""
+        if not isinstance(argv, list) or not all(isinstance(a, str) for a in argv):
+            raise TypeError("argv must be a list of strings, not a shell string")
+        if not _CONTAINER_RE.match(container):
+            raise ValueError(f"invalid container name: {container!r}")
+        full = [self._docker, "exec", container, *argv]
+        return self._run(full, input=input, timeout=timeout)

--- a/scenario-dev/polaris/tests/test_scenario_smoketest.py
+++ b/scenario-dev/polaris/tests/test_scenario_smoketest.py
@@ -1,0 +1,562 @@
+"""Unit tests for the pre-event scenario smoketest harness.
+
+Run with the repo test venv:
+    python -m pytest scenario-dev/polaris/tests/test_scenario_smoketest.py
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scenario_smoketest import __main__ as cli
+from scenario_smoketest import board, compare, ctfd_check, report, run, runner
+from scenario_smoketest.adapters import (
+    ADAPTERS,
+    Adapter,
+    AdapterContext,
+    Produced,
+    register,
+)
+
+REPO_CHALLENGES = (
+    Path(__file__).resolve().parents[1] / "build" / "ctfd-challenges.json"
+)
+
+
+# --------------------------------------------------------------------------
+# board
+# --------------------------------------------------------------------------
+
+
+def _board_file(tmp_path, challenges, meta=None):
+    path = tmp_path / "ctfd-challenges.json"
+    payload = {"challenges": challenges}
+    if meta is not None:
+        payload["meta"] = meta
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_load_board_parses_challenges(tmp_path):
+    path = _board_file(
+        tmp_path,
+        [
+            {
+                "id": 1,
+                "name": "Company Info",
+                "category": "Mission 1",
+                "flags": [{"type": "static", "content": "FLAG{aaaa1111}"}],
+            }
+        ],
+    )
+    challenges = board.load_board(path)
+    assert len(challenges) == 1
+    assert challenges[0].id == 1
+    assert challenges[0].name == "Company Info"
+    assert challenges[0].static_flag == "FLAG{aaaa1111}"
+
+
+def test_load_board_marks_missing_static_flag(tmp_path):
+    path = _board_file(
+        tmp_path,
+        [{"id": 2, "name": "No Flag", "category": "M1", "flags": []}],
+    )
+    challenges = board.load_board(path)
+    assert challenges[0].static_flag is None
+
+
+def test_load_board_marks_multiple_static_flags(tmp_path):
+    path = _board_file(
+        tmp_path,
+        [
+            {
+                "id": 3,
+                "name": "Two Flags",
+                "category": "M1",
+                "flags": [
+                    {"type": "static", "content": "FLAG{a}"},
+                    {"type": "static", "content": "FLAG{b}"},
+                ],
+            }
+        ],
+    )
+    challenges = board.load_board(path)
+    # Fail closed: ambiguous static flag set is not a usable comparison target.
+    assert challenges[0].static_flag is None
+
+
+def test_load_board_merges_onboarding(tmp_path):
+    challenges_path = _board_file(
+        tmp_path, [{"id": 1, "name": "C1", "category": "M1", "flags": []}]
+    )
+    onboarding_path = tmp_path / "ctfd-onboarding.json"
+    onboarding_path.write_text(
+        json.dumps(
+            {"challenges": [{"id": 99, "name": "Start Here", "category": "Onboarding", "flags": []}]}
+        ),
+        encoding="utf-8",
+    )
+    challenges = board.load_board(challenges_path, onboarding_path)
+    assert {c.id for c in challenges} == {1, 99}
+
+
+def test_load_board_rejects_duplicate_ids(tmp_path):
+    path = _board_file(
+        tmp_path,
+        [
+            {"id": 1, "name": "A", "category": "M1", "flags": []},
+            {"id": 1, "name": "B", "category": "M1", "flags": []},
+        ],
+    )
+    with pytest.raises(ValueError):
+        board.load_board(path)
+
+
+def test_load_board_rejects_missing_challenges_key(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text(json.dumps({"meta": {}}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        board.load_board(path)
+
+
+@pytest.mark.skipif(
+    not REPO_CHALLENGES.exists(),
+    reason="ctfd-challenges.json is a build artifact; run the board build first",
+)
+def test_load_board_real_repo_board():
+    challenges = board.load_board(REPO_CHALLENGES)
+    assert len(challenges) >= 54
+    assert all(isinstance(c.id, int) for c in challenges)
+
+
+# --------------------------------------------------------------------------
+# compare / redaction
+# --------------------------------------------------------------------------
+
+
+def test_redact_never_emits_raw_value():
+    redacted = compare.redact("FLAG{c6f8d2b3e91a4507}")
+    assert "c6f8d2b3e91a4507" not in redacted
+    assert redacted != "FLAG{c6f8d2b3e91a4507}"
+
+
+def test_redact_is_stable():
+    assert compare.redact("FLAG{x}") == compare.redact("FLAG{x}")
+
+
+def test_redact_empty():
+    assert compare.redact(None) == "<none>"
+    assert compare.redact("") == "<empty>"
+
+
+def test_compare_flag_match():
+    result = compare.compare("FLAG{abcd}", "FLAG{abcd}", "flag")
+    assert result.status == "pass"
+
+
+def test_compare_flag_mismatch():
+    result = compare.compare("FLAG{abcd}", "FLAG{wxyz}", "flag")
+    assert result.status == "fail"
+    # Raw flag bodies must never appear in comparison detail.
+    assert "abcd" not in result.detail
+    assert "wxyz" not in result.detail
+
+
+def test_compare_flag_missing_expected():
+    result = compare.compare("FLAG{abcd}", None, "flag")
+    assert result.status == "fail"
+    assert "no configured static flag" in result.detail.lower()
+
+
+def test_compare_flag_missing_produced():
+    result = compare.compare(None, "FLAG{abcd}", "flag")
+    assert result.status == "fail"
+
+
+def test_compare_answer_match():
+    result = compare.compare("AHS-TAIL-7741", "AHS-TAIL-7741", "answer")
+    assert result.status == "pass"
+
+
+def test_compare_answer_mismatch():
+    result = compare.compare("WRONG", "AHS-TAIL-7741", "answer")
+    assert result.status == "fail"
+    assert "AHS-TAIL-7741" not in result.detail
+
+
+# --------------------------------------------------------------------------
+# runner
+# --------------------------------------------------------------------------
+
+
+def test_runner_builds_docker_exec_argv():
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return runner.ExecResult(0, "ok", "")
+
+    r = runner.Runner(runner_run=fake_run)
+    result = r.exec("a14-kali", ["curl", "-s", "http://example"])
+    assert result.returncode == 0
+    assert calls[0][:3] == ["docker", "exec", "a14-kali"]
+    assert calls[0][3:] == ["curl", "-s", "http://example"]
+
+
+def test_runner_rejects_string_argv():
+    r = runner.Runner(runner_run=lambda *a, **k: runner.ExecResult(0, "", ""))
+    with pytest.raises(TypeError):
+        r.exec("a14-kali", "curl http://example")
+
+
+def test_runner_rejects_bad_container_name():
+    r = runner.Runner(runner_run=lambda *a, **k: runner.ExecResult(0, "", ""))
+    with pytest.raises(ValueError):
+        r.exec("a14 kali; rm -rf /", ["echo", "hi"])
+
+
+# --------------------------------------------------------------------------
+# adapters
+# --------------------------------------------------------------------------
+
+
+class FakeRunner:
+    """Stand-in for Runner that returns canned output per (container, argv)."""
+
+    def __init__(self, responses):
+        self._responses = responses
+        self.calls = []
+
+    def exec(self, container, argv, **kwargs):
+        self.calls.append((container, tuple(argv)))
+        key = (container, tuple(argv))
+        if key in self._responses:
+            return self._responses[key]
+        # Match on a prefix of argv so tests need not pin every flag.
+        for (rc, rargv), value in self._responses.items():
+            if rc == container and tuple(argv)[: len(rargv)] == rargv:
+                return value
+        return runner.ExecResult(0, "", "")
+
+
+def test_adapter_context_carries_runner():
+    fr = FakeRunner({})
+    ctx = AdapterContext(runner=fr, hosts={"a0": "boreas-systems.ctf"})
+    assert ctx.runner is fr
+    assert ctx.host("a0") == "boreas-systems.ctf"
+
+
+def test_registered_adapters_have_consistent_metadata():
+    from scenario_smoketest.adapters import ADAPTERS
+
+    for challenge_id, adapter in ADAPTERS.items():
+        assert adapter.challenge_id == challenge_id
+        assert adapter.value_kind in ("flag", "answer")
+        assert callable(adapter.solve)
+        if adapter.value_kind == "answer":
+            assert adapter.expected_answer, challenge_id
+
+
+# The exact argv challenge 1's adapter issues against the A0 site. Keying
+# FakeRunner on the full argv (not a bare ("curl",) prefix) means a URL or
+# flag regression in the adapter breaks the match and fails the test.
+CHALLENGE_1_HOSTS = {"a0": "boreas-systems.ctf"}
+CHALLENGE_1_CURL_ARGV = (
+    "curl", "-s", "http://boreas-systems.ctf/about.html",
+)
+
+
+def test_adapter_challenge_1_extracts_flag_from_about_page():
+    from scenario_smoketest.adapters import ADAPTERS
+
+    adapter = ADAPTERS[1]
+    html = (
+        '<table><tr><td>Reg</td><td>7741-BSI-2018</td></tr></table>'
+        "<!-- FLAG{8f3a2c1e9b7d4056} -->"
+    )
+    fr = FakeRunner(
+        {("a14-kali", CHALLENGE_1_CURL_ARGV): runner.ExecResult(0, html, "")}
+    )
+    ctx = AdapterContext(runner=fr, hosts=dict(CHALLENGE_1_HOSTS))
+    produced = adapter.solve(ctx)
+    assert produced.value == "FLAG{8f3a2c1e9b7d4056}"
+    assert produced.kind == "flag"
+
+
+def test_adapter_returns_none_when_flag_absent():
+    from scenario_smoketest.adapters import ADAPTERS
+
+    adapter = ADAPTERS[1]
+    fr = FakeRunner(
+        {
+            ("a14-kali", CHALLENGE_1_CURL_ARGV): runner.ExecResult(
+                0, "<html>no flag</html>", ""
+            )
+        }
+    )
+    ctx = AdapterContext(runner=fr, hosts=dict(CHALLENGE_1_HOSTS))
+    produced = adapter.solve(ctx)
+    assert produced.value is None
+
+
+# --------------------------------------------------------------------------
+# report
+# --------------------------------------------------------------------------
+
+
+def test_report_aggregate_exit_code_all_pass():
+    results = [
+        report.ChallengeResult(1, "C1", "pass", "ok"),
+        report.ChallengeResult(2, "C2", "pass", "ok"),
+    ]
+    assert report.aggregate_exit_code(results) == 0
+
+
+def test_report_aggregate_exit_code_any_fail():
+    results = [
+        report.ChallengeResult(1, "C1", "pass", "ok"),
+        report.ChallengeResult(2, "C2", "fail", "mismatch"),
+    ]
+    assert report.aggregate_exit_code(results) != 0
+
+
+def test_report_aggregate_exit_code_uncovered_fails():
+    results = [report.ChallengeResult(1, "C1", "uncovered", "no adapter")]
+    assert report.aggregate_exit_code(results) != 0
+
+
+def test_report_text_has_no_raw_flag():
+    raw_flag_body = "c6f8d2b3e91a4507"
+    # Mirror the real harness: run.run_smoketest sets detail from
+    # compare.compare(), which redacts before the value ever reaches a
+    # ChallengeResult. Feed build_report a detail produced that same way.
+    verdict = compare.compare(f"FLAG{{{raw_flag_body}}}", "FLAG{wxyz}", "flag")
+    assert verdict.status == "fail"
+    assert raw_flag_body not in verdict.detail  # compare's contract holds
+    results = [
+        report.ChallengeResult(6, "Follow the Money", "fail", verdict.detail)
+    ]
+    rendered = report.build_report(results)
+    assert "Follow the Money" in rendered
+    assert "6" in rendered
+    # The whole point of this test: a raw flag body must never survive into
+    # the rendered report. build_report renders detail verbatim, so a
+    # redaction failure anywhere upstream would surface here.
+    assert raw_flag_body not in rendered
+
+
+def test_report_json_roundtrip():
+    results = [report.ChallengeResult(1, "C1", "pass", "ok")]
+    payload = report.to_json(results)
+    assert payload[0]["challenge_id"] == 1
+    assert payload[0]["status"] == "pass"
+
+
+def test_report_counts_summary():
+    results = [
+        report.ChallengeResult(1, "C1", "pass", ""),
+        report.ChallengeResult(2, "C2", "fail", ""),
+        report.ChallengeResult(3, "C3", "uncovered", ""),
+    ]
+    summary = report.summarize(results)
+    assert summary["pass"] == 1
+    assert summary["fail"] == 1
+    assert summary["uncovered"] == 1
+    assert summary["total"] == 3
+
+
+# --------------------------------------------------------------------------
+# ctfd_check
+# --------------------------------------------------------------------------
+
+
+class FakeCtfdClient:
+    """Minimal CtfdClient stand-in driven by a path -> payload map."""
+
+    def __init__(self, pages):
+        self._pages = pages
+        self.requests = []
+
+    def get(self, path, query=None):
+        self.requests.append((path, query))
+        return self._pages[(path, _freeze(query))]
+
+
+def _freeze(query):
+    if not query:
+        return None
+    return tuple(sorted(query.items()))
+
+
+def test_ctfd_check_flags_passes_when_all_present():
+    client = FakeCtfdClient(
+        {
+            ("/challenges", _freeze({"page": 1})): {
+                "data": [{"id": 1}, {"id": 2}],
+                "meta": {"pagination": {"next": None}},
+            },
+            ("/challenges/1/flags", None): {"data": [{"id": 10, "type": "static"}]},
+            ("/challenges/2/flags", None): {"data": [{"id": 11, "type": "static"}]},
+        }
+    )
+    results = ctfd_check.check_flags(client)
+    assert all(r.has_flags for r in results)
+    assert ctfd_check.exit_code(results) == 0
+
+
+def test_ctfd_check_flags_detects_empty_flag_rows():
+    client = FakeCtfdClient(
+        {
+            ("/challenges", _freeze({"page": 1})): {
+                "data": [{"id": 1}, {"id": 2}],
+                "meta": {"pagination": {"next": None}},
+            },
+            ("/challenges/1/flags", None): {"data": [{"id": 10}]},
+            ("/challenges/2/flags", None): {"data": []},
+        }
+    )
+    results = ctfd_check.check_flags(client)
+    by_id = {r.challenge_id: r for r in results}
+    assert by_id[1].has_flags is True
+    assert by_id[2].has_flags is False
+    assert ctfd_check.exit_code(results) != 0
+
+
+def test_ctfd_check_flags_follows_pagination():
+    client = FakeCtfdClient(
+        {
+            ("/challenges", _freeze({"page": 1})): {
+                "data": [{"id": 1}],
+                "meta": {"pagination": {"next": 2}},
+            },
+            ("/challenges", _freeze({"page": 2})): {
+                "data": [{"id": 2}],
+                "meta": {"pagination": {"next": None}},
+            },
+            ("/challenges/1/flags", None): {"data": [{"id": 10}]},
+            ("/challenges/2/flags", None): {"data": [{"id": 11}]},
+        }
+    )
+    results = ctfd_check.check_flags(client)
+    assert {r.challenge_id for r in results} == {1, 2}
+
+
+# --------------------------------------------------------------------------
+# run (orchestration)
+# --------------------------------------------------------------------------
+
+
+def _challenge(cid, name="C", category="M", static_flag="FLAG{x}"):
+    return board.Challenge(cid, name, category, static_flag)
+
+
+def test_run_marks_uncovered_challenge():
+    # Challenge id 9001 has no adapter registered.
+    results = run.run_smoketest([_challenge(9001)], FakeRunner({}), hosts={})
+    assert results[0].status == "uncovered"
+
+
+def test_run_passes_when_adapter_matches_board_flag(tmp_path):
+    fr = FakeRunner(
+        {
+            ("a14-kali", CHALLENGE_1_CURL_ARGV): runner.ExecResult(
+                0, "<!-- FLAG{abc123} -->", ""
+            )
+        }
+    )
+    challenges = [_challenge(1, name="Company Info", static_flag="FLAG{abc123}")]
+    results = run.run_smoketest(
+        challenges, fr, hosts=dict(CHALLENGE_1_HOSTS)
+    )
+    assert results[0].status == "pass"
+
+
+def test_run_fails_when_adapter_value_drifts_from_board(tmp_path):
+    fr = FakeRunner(
+        {
+            ("a14-kali", CHALLENGE_1_CURL_ARGV): runner.ExecResult(
+                0, "<!-- FLAG{aaa111} -->", ""
+            )
+        }
+    )
+    challenges = [_challenge(1, static_flag="FLAG{bbb222}")]
+    results = run.run_smoketest(
+        challenges, fr, hosts=dict(CHALLENGE_1_HOSTS)
+    )
+    assert results[0].status == "fail"
+    # No raw flag bodies leak into the result detail.
+    assert "aaa111" not in results[0].detail
+    assert "bbb222" not in results[0].detail
+
+
+def test_run_catches_adapter_exception():
+    class Boom:
+        def exec(self, *a, **k):
+            raise RuntimeError("network down")
+
+    results = run.run_smoketest(
+        [_challenge(1, static_flag="FLAG{x}")], Boom(), hosts={"a0": "h"}
+    )
+    assert results[0].status == "error"
+    assert "network down" not in results[0].detail  # exception body not leaked
+
+
+def test_run_filters_by_challenge_id():
+    results = run.run_smoketest(
+        [_challenge(1, static_flag="FLAG{x}"), _challenge(2, static_flag="FLAG{y}")],
+        FakeRunner({}),
+        hosts={"a0": "h"},
+        only_ids={2},
+    )
+    assert {r.challenge_id for r in results} == {2}
+
+
+def test_run_answer_kind_compares_against_expected_answer():
+    register_id = 9100
+
+    @register(register_id, runner="a9-splice", value_kind="answer",
+              expected_answer="MODEL-A")
+    def _adapter(ctx):
+        return Produced("MODEL-A", "answer", "device id probe")
+
+    try:
+        results = run.run_smoketest(
+            [_challenge(register_id, static_flag="FLAG{unrelated}")],
+            FakeRunner({}),
+            hosts={},
+        )
+        assert results[0].status == "pass"
+    finally:
+        ADAPTERS.pop(register_id, None)
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def test_cli_parse_host_overrides_merges_defaults():
+    hosts = cli._parse_host_overrides(["a0=example.ctf"])
+    assert hosts["a0"] == "example.ctf"
+    # Built-in defaults survive a partial override.
+    assert "a3" in hosts
+
+
+def test_cli_parse_host_overrides_rejects_bad_pair():
+    with pytest.raises(SystemExit):
+        cli._parse_host_overrides(["nopair"])
+
+
+def test_cli_uncovered_only_returns_failure(tmp_path, capsys):
+    # An uncovered challenge id needs no docker; the CLI still reports failure.
+    path = _board_file(
+        tmp_path, [{"id": 9001, "name": "Ghost", "category": "M", "flags": []}]
+    )
+    code = cli.main(["--challenges", str(path), "--only", "9001"])
+    assert code == 1
+    assert "UNCOVERED" in capsys.readouterr().out
+
+
+def test_cli_skip_range_with_no_ctfd_is_clean():
+    assert cli.main(["--skip-range"]) == 0


### PR DESCRIPTION
## Summary

Adds an operator-run, on-demand pre-event smoketest for Polaris / NORTHSTORM scenario content (issue #617). The harness derives the challenge universe from ctfd-challenges.json, runs a per-challenge adapter (the canonical participant path) from the correct runner container against a real staged range, and compares the produced value to the configured static flag — flag bodies redacted to digests in all output. A challenge with no registered adapter is reported uncovered (a failure), never silently skipped. It also performs the read-only CTFd flag-row readback from lessons-4.md checklist item 4 that catches the regression where a sync re-run shipped 38/39 challenges with no flag rows. Not wired to CI.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #617

## ADR Impact

- ADR-021

## Changes

- New stdlib-only package scenario-dev/polaris/tests/scenario_smoketest/: board parsing (board.py), docker-exec runner (runner.py), produced-vs-configured comparison with flag redaction (compare.py), per-challenge result aggregation/reporting (report.py), read-only CTFd flag-row readback (ctfd_check.py), orchestration (run.py), and the python3 -m scenario_smoketest CLI (__main__.py)
- Per-challenge adapter registry (adapters/): mission 1 (challenges 1-6) factored from the proven A0-smoketest.sh; the coverage universe is derived from the board so uncovered challenges are reported as failures
- 42 unit tests in test_scenario_smoketest.py covering board parsing, comparison/redaction, the runner, adapters, reporting, the CTFd readback, orchestration, and the CLI
- Architecture preflight boundary note docs/architecture/polaris-scenario-smoketest-preflight-617.md
- changelog.d/617.added.md

## Test Plan

- [x] Unit tests pass (42 tests, repo test venv)
- [x] Live-verified in the aws-dev default VPC against a staged range
- [x] Pre-commit (all hooks) passes
- [x] No coverage regression

Unit suite (42 tests) passes on the repo test venv. Live-verified in the aws-dev default VPC against a staged range: mission 1 (challenges 1-6) all PASS end-to-end through the a14-kali runner container; the CTFd flag-row readback correctly reported a configured challenge OK and a flagless challenge EMPTY. The verification EC2 instance, security group, and S3 objects were torn down after.

## Ground Control Checks

- [x] `make policy` / ADR guard passes
- [x] Codex pre-push review: clean (0 blocking findings)
- [x] Test-quality review: 1 finding fixed (FakeRunner argv keying)

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: issue#617 ← scenario-dev/polaris/tests/test_scenario_smoketest.py

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/617.added.md`
- [x] Architecture preflight note added