### PR TITLE
fixed: reconcile Polaris CTFd flag rows on every challenge upsert

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -120,6 +120,26 @@ jobs:
           python3 -m unittest scripts.check_tf_sg_cidrs.test_check_tf_sg_cidrs
           python3 -m unittest scripts.check_tf_kms_secrets_grant.test_check_tf_kms_secrets_grant
 
+  # Pin the behavior of the Polaris CTFd workshop sync helpers. Issue #702
+  # shipped 38/39 challenges unsubmittable because flag-row reconciliation
+  # sat behind a category allowlist; these tests exercise the flag/hint
+  # reconciliation, manifest validation, and post-sync verification with a
+  # fake CTFd client. The scripts import siblings by bare name, so the test
+  # runs from the package directory (its name contains a hyphen, so the
+  # `unittest scripts.<pkg>` form the check_tf_* tests use is unavailable).
+  # Pure stdlib — no dependency install needed.
+  ctfd-workshop-tests:
+    permissions:
+      contents: read
+    name: Test (ctfd-workshop)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Polaris CTFd sync tests
+        working-directory: scripts/ctfd-workshop
+        run: python3 -m unittest test_sync_polaris_ctfd
+
   shifter-platform-lint:
     permissions:
       contents: read

--- a/changelog.d/702.fixed.md
+++ b/changelog.d/702.fixed.md
@@ -1,0 +1,1 @@
+The Polaris CTFd board sync now reconciles flag, hint, and tag rows on every challenge upsert instead of only for a hard-coded subset of categories, so re-syncs no longer leave mission challenges unsubmittable. The sync also validates the source manifest before mutating CTFd and verifies flag/hint rows after sync, failing loudly when a challenge has none.

--- a/docs/architecture/polaris-ctfd-sync-preflight-702.md
+++ b/docs/architecture/polaris-ctfd-sync-preflight-702.md
@@ -1,0 +1,193 @@
+# Polaris CTFd Sync Preflight
+
+Issue: GitHub #702, "`sync_polaris_ctfd.py` drops flag rows on re-sync
+(update path)".
+
+This note records the architecture boundary for the future implementation. It is
+intentionally not an implementation plan.
+
+## Boundary
+
+The fix belongs in the standalone workshop CTFd sync path:
+
+- `scripts/ctfd-workshop/sync_polaris_ctfd.py`
+- shared helpers in `scripts/ctfd-workshop/common.py`
+- reused or factored helpers currently in
+  `scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py`
+
+The sync contract is: the checked-in Polaris board JSON is the source of truth
+for CTFd challenge metadata, flags, hints, prerequisites, and tags. A re-sync
+must reconcile dependent CTFd rows every time a challenge is upserted, regardless
+of whether the challenge was created or updated.
+
+Keep these concepts separate:
+
+- Manifest challenge id: the logical id in `ctfd-challenges.json` /
+  `ctfd-onboarding.json`, used for ordering, prerequisites, smoketests, and
+  reporting.
+- Live CTFd challenge id: the API-generated id used in `/api/v1/challenges/*`,
+  `/flags`, `/hints`, and `/tags`.
+- CTFd flag rows: external scoreboard rows with `type`, `content`, and `data`.
+- Shifter native `CTFFlag` rows: Django-owned, hashed flags under
+  `shifter/shifter_platform/ctf`. They are a semantic reference only; they are
+  not the storage model for this standalone CTFd board.
+- Range/bake content: files and services inside Polaris ranges. CTFd row sync
+  does not prove the flag is present in a rendered artifact.
+
+Do not treat the existing category gate in `sync_polaris_ctfd.py` as the
+contract. It currently restricts flag/hint/tag sync to `Start Here` and Missions
+6-9; the source JSON contains flags and hints for every mission challenge.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail |
+| --- | --- | --- |
+| CTFd HTTP access | `scripts/ctfd-workshop/common.py::CtfdClient` | Reuse the existing headers, timeout, JSON handling, and token auth. Do not add another HTTP client or requests wrapper for the same API. |
+| CTFd pagination | `sync_polaris_ctfd.py::get_all_items` and `scenario_smoketest.ctfd_check` | CTFd silently caps list responses. Any all-board read must page until CTFd metadata says done. |
+| Board source | `scenario-dev/polaris/build/ctfd-challenges.json`, `ctfd-onboarding.json` | Do not duplicate challenge names, ids, categories, flags, hints, or tags into another schema. Validate the existing manifest instead. |
+| Page/front matter parsing | `sync_polaris_ctfd_onboarding.py::load_pages`, `parse_page`, `upsert_page` | Page sync is adjacent but not the bug. Keep page behavior unchanged unless a test proves it is coupled. |
+| Challenge upsert | `sync_polaris_ctfd_onboarding.py::upsert_challenge` and `sync_polaris_ctfd.py::build_payload` | Preserve the existing challenge payload shape and live-id return path. Reconcile child rows after every returned live id. |
+| Flag helper behavior | `ensure_static_flag` in onboarding/seed scripts | Factor rather than copying, but generalize beyond one static flag. The issue requires comparing expected rows by `(type, content)` and removing stale rows. |
+| Hint helper behavior | `ensure_hints` in onboarding script and `lessons-1.md` | Keep title/order derivation compatible, and include CTFd's polymorphic discriminator (`type: standard`) in write payloads. |
+| Live-board verification | `scenario-dev/polaris/tests/scenario_smoketest/ctfd_check.py` | Reuse the readback idea: GET challenge flag rows after sync and fail non-zero on empty required rows. Apply the same readback discipline to source hints. Mutation stays in `scripts/ctfd-workshop/*`. |
+| Bake/content verification | `verify_flags_baked.py` and `polaris-scenario-smoketest-preflight-617.md` | Keep CTFd row presence separate from rendered-artifact and participant-path verification. |
+| Architecture gates | `.ground-control.yaml`, `.gc/plan-rules.md`, `scripts/adr_guard/adr_guard.py` | Architecture/doc changes pass ADR guard. Do not weaken workflow or guardrail enforcement. |
+
+## Cross-Cutting Layers
+
+Security layers the future design must satisfy:
+
+- Auth surface: this remains an operator-run CLI using a CTFd admin API token.
+  It must not add a participant-facing Django route, CTFd plugin, browser
+  control, or Kali-side submission helper.
+- CTFd token handling: preserve `CTFD_TOKEN` as the primary path. If a new token
+  input is added, prefer a token file with restrictive permissions. Do not add
+  new docs or examples that put admin tokens in process argv; existing `--token`
+  compatibility should not be expanded.
+- CTFd API shape: all calls go through `CtfdClient`, which sets
+  `Authorization: Token`, `Accept: application/json`, and
+  `Content-Type: application/json`. Do not bypass this for ad hoc `urllib`,
+  `requests`, or shell `curl` calls.
+- Manifest validation: before mutating CTFd, reject duplicate manifest ids,
+  duplicate source names, missing names/categories, unsupported flag row shapes,
+  or expected challenges with no flags unless there is an explicit future
+  allow-empty contract. Empty source flags must be a source error, not a live
+  sync success.
+- Live identity validation: fail on duplicate live CTFd challenge names for the
+  selected board scope. Updating the first matching name is unsafe while sync is
+  still name-keyed.
+- Flag-row policy: compare expected and live rows by stable CTFd API fields,
+  starting with `(type, content)` and carrying `data` as CTFd requires. Static,
+  regex, and future supported types must use one reconciliation path instead of
+  one-off `ensure_static_flag` logic.
+- Hint-row policy: reconcile source hints on every challenge upsert. CTFd hint
+  PATCH/POST payloads must include `type: standard` as well as challenge id,
+  title, content, cost, and requirements to avoid the historical NULL
+  discriminator failure. Post-sync readback should fail when a challenge with
+  source hints has no live hint rows.
+- Dry-run gate: dry-run may print planned create/update/delete/verify actions,
+  but must not perform read-modify-write calls or claim live verification. The
+  real sync should verify after mutation.
+- Secret handling: CTFd admin tokens, participant credentials, raw static flag
+  contents, regex flag bodies, and full API response bodies must not be printed,
+  logged, archived, or placed in argv. Logs may include challenge id, challenge
+  name, row counts, row type, and action names.
+- OS/process exposure: use Python JSON request bodies through `CtfdClient`. Do
+  not shell out to `curl`, pass flags or tokens through subprocess arguments, or
+  write temporary files containing flag values unless a future operator workflow
+  explicitly owns their permissions and cleanup.
+- Error envelopes: CLI failures should exit non-zero with challenge id/name and
+  sanitized reason. Avoid dumping `argparse.Namespace`, authorization headers,
+  full request bodies, or CTFd response payloads that may contain flag content.
+- Config and validation gates: changes under `scripts/ctfd-workshop/**` should
+  have focused local tests with a fake `CtfdClient`; architecture changes pass
+  `python3 scripts/adr_guard/adr_guard.py --all --level ci`.
+
+Maintainability incumbents the implementation must build on:
+
+- `CtfdClient` and `get_all_items` for CTFd transport and pagination.
+- `load_json`, `build_payload`, `resolve_prerequisites`, and
+  `upsert_challenge` for the existing source-to-live challenge flow.
+- Existing onboarding helper semantics for default hint titles and challenge
+  payload fields.
+- `scenario_smoketest.ctfd_check` for read-only flag-row verification behavior.
+- Native CTF service tests only as concept checks for replacement semantics:
+  when a caller supplies a child collection, the existing collection is replaced
+  intentionally and atomically. Do not import native Django services into this
+  standalone CTFd script.
+
+Extensibility seam:
+
+Keep the seam at the row-reconciliation boundary: a small helper should accept a
+live challenge id, source row list, live row fetch function, row key function,
+and create/patch/delete callbacks. Flags and hints can then share the same
+"expected set vs live set" discipline without a generic framework or a second
+manifest. The next likely variation is regex/bare-hash flag rows, non-empty
+`data`, or id-keyed sync; those should be enabled by row-shape normalization and
+a future live-id mapping field, not by editing every challenge loop again.
+
+If id-keyed sync is introduced later, do not overload the existing manifest
+`id`. That id already drives prerequisites and smoketests and is not the same as
+the live CTFd database id.
+
+Whole-repo surfaces in scope for the future implementation:
+
+- `scripts/ctfd-workshop/sync_polaris_ctfd.py`
+- `scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py`
+- `scripts/ctfd-workshop/common.py`
+- `scripts/ctfd-workshop/seed_ctfd.py` if shared helpers are factored
+- `scripts/ctfd-workshop/README.md` for operator invocation and verification
+- `scenario-dev/polaris/build/ctfd-challenges.json`
+- `scenario-dev/polaris/build/ctfd-onboarding.json`
+- `scenario-dev/polaris/lessons-1.md` and `lessons-4.md`
+- `scenario-dev/polaris/tests/scenario_smoketest/ctfd_check.py`
+- `scenario-dev/polaris/tests/test_scenario_smoketest.py` for readback precedent
+- `scenario-dev/polaris/build/verify_flags_baked.py`
+- `docs/architecture/polaris-scenario-smoketest-preflight-617.md`
+- `docs/architecture/polaris-scenario-bake-preflight-618.md`
+- `shifter/shifter_platform/ctf/services/challenge.py`,
+  `ctf/services/hint.py`, and their tests as semantic references only
+- `.ground-control.yaml`, `.gc/plan-rules.md`, and `scripts/adr_guard/adr_guard.py`
+
+## Gotchas And Anti-Patterns
+
+- Do not "fix" only the create/update branch. The current full-board script
+  skips most mission flags because child-row sync is behind a category allowlist.
+- Do not keep `ensure_static_flag` as a single-row, first-flag-only helper. The
+  issue asks for source-JSON flags, plural, compared by CTFd row identity.
+- Do not delete live rows before validating the complete source manifest. A bad
+  JSON file should fail before it can remove event-critical rows.
+- Do not silently preserve stale rows that are not in the source JSON. Direct
+  live-event hotfixes must be backported into the JSON if they are intentional.
+- Do not print raw flag values in "missing", "stale", mismatch, or exception
+  output. Existing bake tooling is allowed to prove artifact presence; this sync
+  tool should keep board answers out of operator logs by default.
+- Do not create duplicate schemas for flags, hints, tags, pages, or challenges.
+  Normalize the existing JSON at the boundary, then use that normalized shape.
+- Do not treat manifest logical ids as CTFd live ids. Prerequisite resolution
+  already depends on translating manifest ids to live ids after upsert.
+- Do not bypass CTFd pagination. The event notes already record silent CTFd list
+  caps.
+- Do not patch CTFd hints without the polymorphic `type` field. That previously
+  produced NULL hint types and participant-facing 500s.
+- Do not solve this by submitting a test flag or creating participant solves.
+  Verification is row readback, not scoring-path mutation.
+- Do not make the standalone CTFd script depend on Django settings,
+  `shifter_platform` app initialization, native CTF models, or database state.
+- Do not widen the scope into page copy, CTFd user provisioning, range content,
+  AMI bake, or Guacamole fixes while repairing board row reconciliation.
+
+## Non-Goals
+
+- Implementing the issue in this preflight.
+- Migrating the board to id-keyed sync in the same fix unless a separate design
+  decides how live CTFd ids are stored and bootstrapped.
+- Changing Shifter's native CTF app, flag hashing model, hint unlock workflow,
+  participant auth, scoring, or event lifecycle.
+- Fixing the bare-hash/`FLAG{...}` submission-format request.
+- Fixing the "Follow the Money" rendered PDF content bug.
+- Replacing `verify_flags_baked.py`, the scenario smoketest, or
+  `run-all-smoketests.sh`.
+- Building a generic CTFd SDK or scenario packaging framework.
+- Mutating submissions, solves, users, teams, pages, scores, ranges, AWS, or
+  Terraform state as part of CTFd row verification.

--- a/scripts/ctfd-workshop/README.md
+++ b/scripts/ctfd-workshop/README.md
@@ -63,6 +63,11 @@ python3 scripts/ctfd-workshop/sync_polaris_ctfd.py \
   --base-url https://polaris.example.com
 ```
 
+Flag, hint, and tag rows are reconciled against the source JSON on every
+challenge upsert, so re-syncs are idempotent. The source manifest is validated
+before any CTFd write, and after sync the script reads flag and hint rows back
+from CTFd and exits non-zero if any challenge that should have them has none.
+
 ## Sync Range Flags
 
 Run this after participant ranges are `ready` so the box flag files match CTFd:

--- a/scripts/ctfd-workshop/sync_polaris_ctfd.py
+++ b/scripts/ctfd-workshop/sync_polaris_ctfd.py
@@ -10,8 +10,8 @@ from common import CtfdClient
 from sync_polaris_ctfd_onboarding import (
     DEFAULT_ONBOARDING_PATH,
     DEFAULT_PAGES_DIR,
+    ensure_flags,
     ensure_hints,
-    ensure_static_flag,
     find_by_key,
     load_json,
     load_pages,
@@ -22,13 +22,7 @@ from sync_polaris_ctfd_onboarding import (
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CHALLENGE_PATH = REPO_ROOT / "scenario-dev/polaris/build/ctfd-challenges.json"
-EXTRA_SYNC_CATEGORIES = {
-    "Start Here",
-    "Mission 6 — Exposure",
-    "Mission 7 — Counterintel",
-    "Mission 8 — Delivery Denied",
-    "Mission 9 — Safety Case",
-}
+SUPPORTED_FLAG_TYPES = {"static", "regex"}
 STALE_CHALLENGE_NAMES = {
     "Mission 0 — Kali Warm-Up",
 }
@@ -89,6 +83,105 @@ ORDERED_CHALLENGE_NAMES = [
     "Safe Mode Sequence",
     "Cold Shutdown",
 ]
+
+
+class SyncError(RuntimeError):
+    """Raised when the source manifest or live CTFd board fails validation."""
+
+
+def validate_manifest(challenges: list[dict[str, Any]]) -> None:
+    """Validate the merged source manifest before any CTFd mutation.
+
+    A malformed manifest must fail loudly here, before stale-row deletion can
+    remove event-critical live rows. Flag content is never echoed.
+    """
+    seen_ids: set[Any] = set()
+    seen_names: set[str] = set()
+    errors: list[str] = []
+
+    for challenge in challenges:
+        name = challenge.get("name")
+        if not name:
+            errors.append(
+                f"challenge missing name (category={challenge.get('category')!r})"
+            )
+            continue
+        if name in seen_names:
+            errors.append(f"duplicate challenge name {name!r}")
+        seen_names.add(name)
+
+        if not challenge.get("category"):
+            errors.append(f"challenge {name!r} missing category")
+
+        manifest_id = challenge.get("id")
+        if manifest_id is not None:
+            if manifest_id in seen_ids:
+                errors.append(f"duplicate manifest id {manifest_id!r} ({name})")
+            seen_ids.add(manifest_id)
+
+        flags = challenge.get("flags", [])
+        if not flags:
+            errors.append(f"challenge {name!r} has no flags — it would be unsubmittable")
+        for flag in flags:
+            flag_type = flag.get("type", "static")
+            if flag_type not in SUPPORTED_FLAG_TYPES:
+                errors.append(
+                    f"challenge {name!r} has unsupported flag type {flag_type!r}"
+                )
+            if not flag.get("content"):
+                errors.append(f"challenge {name!r} has a flag with empty content")
+
+    if errors:
+        raise SyncError("manifest validation failed:\n  " + "\n  ".join(errors))
+
+
+def validate_live_challenge_names(existing_challenges: list[dict[str, Any]]) -> None:
+    """Fail when the live board has duplicate challenge names.
+
+    Sync is name-keyed, so a duplicate live name makes every upsert ambiguous.
+    """
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for challenge in existing_challenges:
+        name = challenge.get("name")
+        if name in seen:
+            duplicates.add(name)
+        seen.add(name)
+    if duplicates:
+        raise SyncError(
+            "duplicate live CTFd challenge names make name-keyed sync unsafe: "
+            + ", ".join(sorted(duplicates))
+        )
+
+
+def verify_challenge_rows(
+    client: CtfdClient,
+    *,
+    challenges: list[dict[str, Any]],
+    name_to_live_id: dict[str, int | None],
+) -> None:
+    """Read flag and hint rows back from CTFd after sync.
+
+    Raises if a challenge with source flags (or hints) shows zero live rows —
+    the exact regression that shipped 38/39 challenges unsubmittable.
+    """
+    failures: list[str] = []
+    for challenge in challenges:
+        name = challenge["name"]
+        live_id = name_to_live_id.get(name)
+        if live_id is None:
+            failures.append(f"{name}: no live challenge id after sync")
+            continue
+        if challenge.get("flags"):
+            rows = client.get(f"/challenges/{live_id}/flags").get("data", [])
+            if not rows:
+                failures.append(f"{name} (id {live_id}): 0 flag rows — unsubmittable")
+        if challenge.get("hints"):
+            rows = client.get(f"/challenges/{live_id}/hints").get("data", [])
+            if not rows:
+                failures.append(f"{name} (id {live_id}): 0 hint rows")
+    if failures:
+        raise SyncError("post-sync verification failed:\n  " + "\n  ".join(failures))
 
 
 def parse_args() -> argparse.Namespace:
@@ -294,7 +387,11 @@ def sync_challenges(
     existing_challenges: list[dict[str, Any]],
     manifest_id_to_name: dict[int, str],
     dry_run: bool,
-) -> None:
+) -> dict[str, int | None]:
+    """Upsert every challenge and reconcile its flags, hints, and tags.
+
+    Returns the challenge-name to live-CTFd-id map for the verification pass.
+    """
     synced_by_name: dict[str, dict[str, Any]] = {}
 
     for position, challenge in enumerate(challenges, start=1):
@@ -334,18 +431,13 @@ def sync_challenges(
             dry_run=dry_run,
         )
 
-        if payload["category"] not in EXTRA_SYNC_CATEGORIES:
-            continue
-
-        flag_entries = challenge.get("flags", [])
-        if flag_entries:
-            ensure_static_flag(
-                client,
-                challenge_id=synced.get("id"),
-                challenge_name=payload["name"],
-                flag_value=flag_entries[0]["content"],
-                dry_run=dry_run,
-            )
+        ensure_flags(
+            client,
+            challenge_id=synced.get("id"),
+            challenge_name=payload["name"],
+            flags=challenge.get("flags", []),
+            dry_run=dry_run,
+        )
 
         ensure_hints(
             client,
@@ -363,6 +455,8 @@ def sync_challenges(
             dry_run=dry_run,
         )
 
+    return name_to_live_id
+
 
 def main() -> int:
     args = parse_args()
@@ -375,6 +469,7 @@ def main() -> int:
     main_challenges = manifest.get("challenges", [])
     onboarding_challenges = onboarding.get("challenges", [])
     all_challenges = sort_challenges(main_challenges + onboarding_challenges)
+    validate_manifest(all_challenges)
     manifest_id_to_name = build_manifest_id_to_name(all_challenges)
 
     client = CtfdClient(args.base_url, args.token)
@@ -385,13 +480,14 @@ def main() -> int:
     existing_challenges: list[dict[str, Any]] = []
     if not args.dry_run:
         existing_challenges = get_all_items(client, "/challenges", {"view": "admin"})
+        validate_live_challenge_names(existing_challenges)
         existing_challenges = delete_stale_challenges(
             client,
             existing_challenges=existing_challenges,
             dry_run=args.dry_run,
         )
 
-    sync_challenges(
+    name_to_live_id = sync_challenges(
         client,
         challenges=all_challenges,
         existing_challenges=existing_challenges,
@@ -399,9 +495,19 @@ def main() -> int:
         dry_run=args.dry_run,
     )
 
+    if not args.dry_run:
+        verify_challenge_rows(
+            client,
+            challenges=all_challenges,
+            name_to_live_id=name_to_live_id,
+        )
+
     print("Polaris CTFd sync complete")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        raise SystemExit(main())
+    except SyncError as err:
+        raise SystemExit(f"error: {err}") from err

--- a/scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py
+++ b/scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from common import CtfdClient
 
@@ -197,36 +197,108 @@ def upsert_challenge(
     return created
 
 
-def ensure_static_flag(
+def reconcile_rows(
+    *,
+    source_rows: list[dict[str, Any]],
+    live_rows: list[dict[str, Any]],
+    row_key: Callable[[dict[str, Any]], Any],
+    on_create: Callable[[dict[str, Any]], None],
+    on_match: Callable[[dict[str, Any], dict[str, Any]], None],
+    on_delete: Callable[[dict[str, Any]], None],
+) -> None:
+    """Reconcile a set of CTFd child rows against the source manifest.
+
+    Add-missing / patch-on-match / delete-stale, keyed by ``row_key``. This is
+    the shared seam so flags and hints follow the same expected-vs-live
+    discipline instead of one-off per-row helpers.
+    """
+    live_by_key: dict[Any, dict[str, Any]] = {}
+    for row in live_rows:
+        live_by_key.setdefault(row_key(row), row)
+
+    expected_keys: set[Any] = set()
+    for source in source_rows:
+        key = row_key(source)
+        expected_keys.add(key)
+        match = live_by_key.get(key)
+        if match is None:
+            on_create(source)
+        else:
+            on_match(match, source)
+
+    for key, row in live_by_key.items():
+        if key not in expected_keys:
+            on_delete(row)
+
+
+def normalize_flag(flag: dict[str, Any]) -> dict[str, Any]:
+    """Return a CTFd flag-row body from a source-JSON flag entry."""
+    return {
+        "type": flag.get("type", "static"),
+        "content": flag["content"],
+        "data": flag.get("data", ""),
+    }
+
+
+def normalize_hints(hints: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return CTFd hint-row bodies, deriving default titles by position."""
+    normalized: list[dict[str, Any]] = []
+    for index, hint in enumerate(hints, start=1):
+        normalized.append(
+            {
+                "title": hint.get("title", f"Hint {index}"),
+                "content": hint["content"],
+                "cost": hint.get("cost", 0),
+                "requirements": hint.get("requirements", []),
+            }
+        )
+    return normalized
+
+
+def ensure_flags(
     client: CtfdClient,
     *,
     challenge_id: int | None,
     challenge_name: str,
-    flag_value: str,
+    flags: list[dict[str, Any]],
     dry_run: bool,
 ) -> None:
-    print(f"sync flag: {challenge_name}")
+    """Reconcile every source flag against the challenge's live CTFd flag rows.
+
+    Idempotent across re-syncs: flags are keyed by ``(type, content)``, missing
+    rows are created, stale rows removed. Flag content is never logged.
+    """
+    expected = [normalize_flag(flag) for flag in flags]
     if dry_run or challenge_id is None:
+        for flag in expected:
+            print(f"sync flag: {challenge_name} :: {flag['type']}")
         return
 
-    flags = client.get("/flags", {"challenge_id": challenge_id}).get("data", [])
-    payload = {
-        "challenge_id": challenge_id,
-        "type": "static",
-        "content": flag_value,
-        "data": "",
-    }
+    live_flags = client.get("/flags", {"challenge_id": challenge_id}).get("data", [])
 
-    keeper = None
-    for flag in flags:
-        if keeper is None:
-            keeper = flag
-            client.patch(f"/flags/{flag['id']}", payload)
+    def on_create(flag: dict[str, Any]) -> None:
+        print(f"create flag: {challenge_name} :: {flag['type']}")
+        client.post("/flags", {"challenge_id": challenge_id, **flag})
+
+    def on_match(live_flag: dict[str, Any], flag: dict[str, Any]) -> None:
+        if live_flag.get("data", "") != flag["data"]:
+            print(f"update flag: {challenge_name} :: {flag['type']}")
+            client.patch(f"/flags/{live_flag['id']}", {"challenge_id": challenge_id, **flag})
         else:
-            client.delete(f"/flags/{flag['id']}")
+            print(f"keep flag: {challenge_name} :: {flag['type']}")
 
-    if keeper is None:
-        client.post("/flags", payload)
+    def on_delete(live_flag: dict[str, Any]) -> None:
+        print(f"delete stale flag: {challenge_name} :: {live_flag.get('type')}")
+        client.delete(f"/flags/{live_flag['id']}")
+
+    reconcile_rows(
+        source_rows=expected,
+        live_rows=live_flags,
+        row_key=lambda flag: (flag.get("type", "static"), flag.get("content")),
+        on_create=on_create,
+        on_match=on_match,
+        on_delete=on_delete,
+    )
 
 
 def ensure_hints(
@@ -237,37 +309,49 @@ def ensure_hints(
     hints: list[dict[str, Any]],
     dry_run: bool,
 ) -> None:
+    """Reconcile source hints against the challenge's live CTFd hint rows.
+
+    Hint write payloads carry the polymorphic ``type: standard`` discriminator;
+    omitting it produced NULL hint types and participant-facing 500s.
+    """
+    expected = normalize_hints(hints)
     if dry_run or challenge_id is None:
-        for index, _hint in enumerate(hints, start=1):
-            print(f"sync hint: {challenge_name} :: Hint {index}")
+        for hint in expected:
+            print(f"sync hint: {challenge_name} :: {hint['title']}")
         return
 
-    existing_hints = client.get(f"/challenges/{challenge_id}/hints").get("data", [])
-    expected_titles: set[str] = set()
+    live_hints = client.get(f"/challenges/{challenge_id}/hints").get("data", [])
 
-    for index, hint in enumerate(hints, start=1):
-        title = hint.get("title", f"Hint {index}")
-        expected_titles.add(title)
-        payload = {
+    def body(hint: dict[str, Any]) -> dict[str, Any]:
+        return {
             "challenge_id": challenge_id,
-            "title": title,
+            "type": "standard",
+            "title": hint["title"],
             "content": hint["content"],
-            "cost": hint.get("cost", 0),
-            "requirements": hint.get("requirements", []),
+            "cost": hint["cost"],
+            "requirements": hint["requirements"],
         }
-        existing = find_by_key(existing_hints, key="title", value=title)
-        if existing:
-            print(f"sync hint: {challenge_name} :: {title}")
-            client.patch(f"/hints/{existing['id']}", payload)
-        else:
-            print(f"create hint: {challenge_name} :: {title}")
-            response = client.post("/hints", payload)
-            existing_hints.append(response["data"])
 
-    for hint in existing_hints:
-        if hint.get("title") not in expected_titles:
-            print(f"delete stale hint: {challenge_name} :: {hint.get('title')}")
-            client.delete(f"/hints/{hint['id']}")
+    def on_create(hint: dict[str, Any]) -> None:
+        print(f"create hint: {challenge_name} :: {hint['title']}")
+        client.post("/hints", body(hint))
+
+    def on_match(live_hint: dict[str, Any], hint: dict[str, Any]) -> None:
+        print(f"sync hint: {challenge_name} :: {hint['title']}")
+        client.patch(f"/hints/{live_hint['id']}", body(hint))
+
+    def on_delete(live_hint: dict[str, Any]) -> None:
+        print(f"delete stale hint: {challenge_name} :: {live_hint.get('title')}")
+        client.delete(f"/hints/{live_hint['id']}")
+
+    reconcile_rows(
+        source_rows=expected,
+        live_rows=live_hints,
+        row_key=lambda hint: hint["title"],
+        on_create=on_create,
+        on_match=on_match,
+        on_delete=on_delete,
+    )
 
 
 def main() -> int:
@@ -314,15 +398,13 @@ def main() -> int:
             payload=payload,
             dry_run=args.dry_run,
         )
-        flag_entries = challenge.get("flags", [])
-        if flag_entries:
-            ensure_static_flag(
-                client,
-                challenge_id=synced.get("id"),
-                challenge_name=payload["name"],
-                flag_value=flag_entries[0]["content"],
-                dry_run=args.dry_run,
-            )
+        ensure_flags(
+            client,
+            challenge_id=synced.get("id"),
+            challenge_name=payload["name"],
+            flags=challenge.get("flags", []),
+            dry_run=args.dry_run,
+        )
         ensure_hints(
             client,
             challenge_id=synced.get("id"),

--- a/scripts/ctfd-workshop/test_sync_polaris_ctfd.py
+++ b/scripts/ctfd-workshop/test_sync_polaris_ctfd.py
@@ -1,0 +1,374 @@
+"""Tests for the Polaris CTFd sync flag/hint reconciliation (issue #702).
+
+Run from this directory:
+    python3 -m unittest test_sync_polaris_ctfd -v
+
+The scripts import sibling modules by bare name, so the directory must be on
+sys.path; running with `-m unittest` from here satisfies that.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from sync_polaris_ctfd import (
+    SUPPORTED_FLAG_TYPES,
+    SyncError,
+    sync_challenges,
+    validate_live_challenge_names,
+    validate_manifest,
+    verify_challenge_rows,
+)
+from sync_polaris_ctfd_onboarding import (
+    ensure_flags,
+    ensure_hints,
+    reconcile_rows,
+)
+
+
+class FakeCtfdClient:
+    """In-memory CTFd emulator covering challenges, flags, and hints.
+
+    Stateful so reconciliation idempotency is observable across calls.
+    """
+
+    def __init__(self) -> None:
+        self.challenges: dict[int, dict] = {}
+        self.flags: dict[int, dict] = {}
+        self.hints: dict[int, dict] = {}
+        self.tags: dict[int, dict] = {}
+        self._next_id = 1
+        self.calls: list[tuple[str, str]] = []
+
+    def _new_id(self) -> int:
+        ident = self._next_id
+        self._next_id += 1
+        return ident
+
+    def seed_challenge(self, name: str, **fields) -> int:
+        cid = self._new_id()
+        self.challenges[cid] = {"id": cid, "name": name, **fields}
+        return cid
+
+    def seed_flag(self, challenge_id: int, *, type: str, content: str, data: str = "") -> int:
+        fid = self._new_id()
+        self.flags[fid] = {
+            "id": fid,
+            "challenge_id": challenge_id,
+            "type": type,
+            "content": content,
+            "data": data,
+        }
+        return fid
+
+    def seed_hint(self, challenge_id: int, *, title: str, content: str) -> int:
+        hid = self._new_id()
+        self.hints[hid] = {
+            "id": hid,
+            "challenge_id": challenge_id,
+            "title": title,
+            "content": content,
+        }
+        return hid
+
+    def count(self, method: str, prefix: str) -> int:
+        return sum(1 for m, path in self.calls if m == method and path.startswith(prefix))
+
+    def get(self, path: str, query: dict | None = None) -> dict:
+        self.calls.append(("GET", path))
+        parts = path.strip("/").split("/")
+        if path == "/flags":
+            cid = (query or {}).get("challenge_id")
+            return {"data": [dict(f) for f in self.flags.values() if cid is None or f["challenge_id"] == cid]}
+        if path == "/challenges":
+            return {"data": [dict(c) for c in self.challenges.values()]}
+        if path == "/pages":
+            return {"data": []}
+        if len(parts) == 3 and parts[0] == "challenges" and parts[2] == "flags":
+            cid = int(parts[1])
+            return {"data": [dict(f) for f in self.flags.values() if f["challenge_id"] == cid]}
+        if len(parts) == 3 and parts[0] == "challenges" and parts[2] == "hints":
+            cid = int(parts[1])
+            return {"data": [dict(h) for h in self.hints.values() if h["challenge_id"] == cid]}
+        if len(parts) == 3 and parts[0] == "challenges" and parts[2] == "tags":
+            cid = int(parts[1])
+            return {"data": [dict(t) for t in self.tags.values() if t["challenge_id"] == cid]}
+        raise AssertionError(f"unexpected GET {path}")
+
+    def post(self, path: str, body: dict) -> dict:
+        self.calls.append(("POST", path))
+        store, defaults = {
+            "/flags": (self.flags, {"data": ""}),
+            "/hints": (self.hints, {}),
+            "/tags": (self.tags, {}),
+            "/challenges": (self.challenges, {}),
+        }[path]
+        ident = self._new_id()
+        store[ident] = {"id": ident, **defaults, **body}
+        return {"success": True, "data": dict(store[ident])}
+
+    def patch(self, path: str, body: dict) -> dict:
+        self.calls.append(("PATCH", path))
+        parts = path.strip("/").split("/")
+        store = {"flags": self.flags, "hints": self.hints, "challenges": self.challenges}[parts[0]]
+        store[int(parts[1])].update(body)
+        return {"success": True, "data": dict(store[int(parts[1])])}
+
+    def delete(self, path: str) -> dict:
+        self.calls.append(("DELETE", path))
+        parts = path.strip("/").split("/")
+        store = {
+            "flags": self.flags,
+            "hints": self.hints,
+            "tags": self.tags,
+            "challenges": self.challenges,
+        }[parts[0]]
+        store.pop(int(parts[1]), None)
+        return {"success": True}
+
+
+class ReconcileRowsTest(unittest.TestCase):
+    def test_add_missing_keep_match_delete_stale(self) -> None:
+        created: list = []
+        matched: list = []
+        deleted: list = []
+        reconcile_rows(
+            source_rows=[{"k": "a"}, {"k": "b"}],
+            live_rows=[{"k": "b"}, {"k": "c"}],
+            row_key=lambda row: row["k"],
+            on_create=created.append,
+            on_match=lambda live, src: matched.append((live, src)),
+            on_delete=deleted.append,
+        )
+        self.assertEqual([row["k"] for row in created], ["a"])
+        self.assertEqual([src["k"] for _, src in matched], ["b"])
+        self.assertEqual([row["k"] for row in deleted], ["c"])
+
+
+class EnsureFlagsTest(unittest.TestCase):
+    def test_creates_every_source_flag(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        ensure_flags(
+            client,
+            challenge_id=cid,
+            challenge_name="Company Info",
+            flags=[
+                {"type": "static", "content": "FLAG{aaa}"},
+                {"type": "static", "content": "FLAG{bbb}"},
+            ],
+            dry_run=False,
+        )
+        contents = sorted(f["content"] for f in client.flags.values())
+        self.assertEqual(contents, ["FLAG{aaa}", "FLAG{bbb}"])
+        self.assertEqual(client.count("POST", "/flags"), 2)
+
+    def test_removes_stale_flag(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        client.seed_flag(cid, type="static", content="FLAG{old}")
+        ensure_flags(
+            client,
+            challenge_id=cid,
+            challenge_name="Company Info",
+            flags=[{"type": "static", "content": "FLAG{new}"}],
+            dry_run=False,
+        )
+        self.assertEqual([f["content"] for f in client.flags.values()], ["FLAG{new}"])
+        self.assertEqual(client.count("DELETE", "/flags/"), 1)
+        self.assertEqual(client.count("POST", "/flags"), 1)
+
+    def test_idempotent_resync_makes_no_writes(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        flags = [{"type": "static", "content": "FLAG{aaa}"}]
+        ensure_flags(client, challenge_id=cid, challenge_name="Company Info", flags=flags, dry_run=False)
+        writes_before = len(client.calls)
+        ensure_flags(client, challenge_id=cid, challenge_name="Company Info", flags=flags, dry_run=False)
+        for method, path in client.calls[writes_before:]:
+            self.assertEqual(method, "GET", f"re-sync issued a write: {method} {path}")
+        self.assertEqual([f["content"] for f in client.flags.values()], ["FLAG{aaa}"])
+
+    def test_dry_run_and_missing_id_make_no_calls(self) -> None:
+        client = FakeCtfdClient()
+        ensure_flags(
+            client,
+            challenge_id=5,
+            challenge_name="Company Info",
+            flags=[{"type": "static", "content": "FLAG{aaa}"}],
+            dry_run=True,
+        )
+        ensure_flags(
+            client,
+            challenge_id=None,
+            challenge_name="Company Info",
+            flags=[{"type": "static", "content": "FLAG{aaa}"}],
+            dry_run=False,
+        )
+        self.assertEqual(client.calls, [])
+
+
+class EnsureHintsTest(unittest.TestCase):
+    def test_create_carries_polymorphic_type(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        ensure_hints(
+            client,
+            challenge_id=cid,
+            challenge_name="Company Info",
+            hints=[{"content": "look here", "cost": 10}],
+            dry_run=False,
+        )
+        self.assertEqual(len(client.hints), 1)
+        for hint in client.hints.values():
+            self.assertEqual(hint["type"], "standard")
+
+    def test_patch_carries_polymorphic_type(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        client.seed_hint(cid, title="Hint 1", content="stale")
+        ensure_hints(
+            client,
+            challenge_id=cid,
+            challenge_name="Company Info",
+            hints=[{"content": "fresh", "cost": 10}],
+            dry_run=False,
+        )
+        self.assertEqual(client.count("PATCH", "/hints/"), 1)
+        self.assertEqual(client.count("POST", "/hints"), 0)
+        for hint in client.hints.values():
+            self.assertEqual(hint["type"], "standard")
+            self.assertEqual(hint["content"], "fresh")
+
+    def test_deletes_stale_hint(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        client.seed_hint(cid, title="Hint 1", content="keep")
+        client.seed_hint(cid, title="Hint 2", content="stale")
+        ensure_hints(
+            client,
+            challenge_id=cid,
+            challenge_name="Company Info",
+            hints=[{"title": "Hint 1", "content": "keep", "cost": 0}],
+            dry_run=False,
+        )
+        self.assertEqual(client.count("DELETE", "/hints/"), 1)
+        self.assertEqual({h["title"] for h in client.hints.values()}, {"Hint 1"})
+
+
+class ValidateManifestTest(unittest.TestCase):
+    def _challenge(self, **overrides) -> dict:
+        challenge = {
+            "id": 1,
+            "name": "Company Info",
+            "category": "Mission 1 — Boreas",
+            "flags": [{"type": "static", "content": "FLAG{aaa}"}],
+        }
+        challenge.update(overrides)
+        return challenge
+
+    def test_valid_manifest_passes(self) -> None:
+        validate_manifest([self._challenge(id=1, name="A"), self._challenge(id=2, name="B")])
+
+    def test_rejects_duplicate_id(self) -> None:
+        with self.assertRaises(SyncError):
+            validate_manifest([self._challenge(id=1, name="A"), self._challenge(id=1, name="B")])
+
+    def test_rejects_duplicate_name(self) -> None:
+        with self.assertRaises(SyncError):
+            validate_manifest([self._challenge(id=1, name="A"), self._challenge(id=2, name="A")])
+
+    def test_rejects_missing_category(self) -> None:
+        with self.assertRaises(SyncError):
+            validate_manifest([self._challenge(category="")])
+
+    def test_rejects_empty_flags(self) -> None:
+        with self.assertRaises(SyncError):
+            validate_manifest([self._challenge(flags=[])])
+
+    def test_rejects_unsupported_flag_type(self) -> None:
+        with self.assertRaises(SyncError):
+            validate_manifest([self._challenge(flags=[{"type": "bogus", "content": "x"}])])
+        self.assertIn("static", SUPPORTED_FLAG_TYPES)
+
+
+class ValidateLiveChallengeNamesTest(unittest.TestCase):
+    def test_unique_names_pass(self) -> None:
+        validate_live_challenge_names([{"name": "A"}, {"name": "B"}])
+
+    def test_duplicate_live_name_rejected(self) -> None:
+        with self.assertRaises(SyncError):
+            validate_live_challenge_names([{"name": "A"}, {"name": "A"}])
+
+
+class VerifyChallengeRowsTest(unittest.TestCase):
+    def test_passes_when_rows_present(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        client.seed_flag(cid, type="static", content="FLAG{aaa}")
+        verify_challenge_rows(
+            client,
+            challenges=[{"name": "Company Info", "flags": [{"type": "static", "content": "FLAG{aaa}"}]}],
+            name_to_live_id={"Company Info": cid},
+        )
+
+    def test_fails_when_flag_rows_empty(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        with self.assertRaises(SyncError):
+            verify_challenge_rows(
+                client,
+                challenges=[{"name": "Company Info", "flags": [{"type": "static", "content": "FLAG{aaa}"}]}],
+                name_to_live_id={"Company Info": cid},
+            )
+
+    def test_fails_when_hint_rows_empty(self) -> None:
+        client = FakeCtfdClient()
+        cid = client.seed_challenge("Company Info")
+        client.seed_flag(cid, type="static", content="FLAG{aaa}")
+        with self.assertRaises(SyncError):
+            verify_challenge_rows(
+                client,
+                challenges=[
+                    {
+                        "name": "Company Info",
+                        "flags": [{"type": "static", "content": "FLAG{aaa}"}],
+                        "hints": [{"content": "h", "cost": 0}],
+                    }
+                ],
+                name_to_live_id={"Company Info": cid},
+            )
+
+
+class SyncChallengesTest(unittest.TestCase):
+    def test_mission_one_challenge_gets_its_flag(self) -> None:
+        """Regression: Missions 1-5 were skipped by the old category allowlist."""
+        client = FakeCtfdClient()
+        challenges = [
+            {
+                "id": 1,
+                "name": "Company Info",
+                "description": "d",
+                "category": "Mission 1 — Boreas",
+                "value": 100,
+                "flags": [{"type": "static", "content": "FLAG{m1}"}],
+                "hints": [{"content": "hint", "cost": 10}],
+                "tags": ["recon"],
+            }
+        ]
+        name_to_live_id = sync_challenges(
+            client,
+            challenges=challenges,
+            existing_challenges=[],
+            manifest_id_to_name={1: "Company Info"},
+            dry_run=False,
+        )
+        live_id = name_to_live_id["Company Info"]
+        flag_contents = [f["content"] for f in client.flags.values() if f["challenge_id"] == live_id]
+        self.assertEqual(flag_contents, ["FLAG{m1}"])
+        hint_count = sum(1 for h in client.hints.values() if h["challenge_id"] == live_id)
+        self.assertEqual(hint_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The Polaris CTFd full-board sync gated flag, hint, and tag reconciliation behind a category allowlist (EXTRA_SYNC_CATEGORIES), so Missions 1-5 challenges never had their flag rows synced on either the create or update path — 38/39 challenges shipped unsubmittable during the May 2026 event. This removes the allowlist so child rows reconcile on every challenge upsert, generalizes single-flag sync into a reusable (type, content)-keyed reconciliation seam, and adds pre-mutation manifest validation plus a post-sync verification readback that fails loudly when a challenge that should have flag/hint rows has none.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #702

## ADR Impact

- ADR-021

## Changes

- Remove the EXTRA_SYNC_CATEGORIES allowlist and its skip guard in sync_polaris_ctfd.py::sync_challenges so flags, hints, and tags reconcile on every challenge upsert (create or update path)
- Add reconcile_rows in sync_polaris_ctfd_onboarding.py — a generic add-missing / patch-on-match / delete-stale seam parameterized by row key and create/match/delete callbacks
- Replace the single-flag ensure_static_flag with ensure_flags, which reconciles every source flag keyed by (type, content) and never logs raw flag content
- Rewrite ensure_hints onto reconcile_rows and carry the polymorphic type: standard discriminator on hint POST/PATCH payloads
- Add validate_manifest (pre-mutation: rejects duplicate ids/names, missing name/category, empty or malformed flags) and validate_live_challenge_names (rejects duplicate live names that make name-keyed sync ambiguous)
- Add verify_challenge_rows: a post-sync readback that GETs flag and hint rows for every challenge and exits non-zero naming any challenge that has none
- Add scripts/ctfd-workshop/test_sync_polaris_ctfd.py — 20 unittest tests with a stateful fake CTFd client — and a Test (ctfd-workshop) CI job in _quality.yml

## Test Plan

- [x] `python3 -m unittest test_sync_polaris_ctfd` passes (20 tests, run from scripts/ctfd-workshop)
- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci` passes
- [x] `pre-commit run --all-files` passes
- [x] Both sync scripts dry-run cleanly against the real ctfd-challenges.json manifest

New tests run pure-stdlib (no dependency install) with a stateful fake CTFd client. They cover reconcile_rows, multi-flag/idempotent/stale ensure_flags, the hint type discriminator, manifest and live-name validation, the verification readback, and a sync_challenges regression proving a Mission 1 challenge now gets its flag.

## Ground Control Checks

- [x] `make policy` passes
- [x] Quality gates unchanged by this scripts-only change
- [x] Codex and test-quality pre-push reviews returned clean

## Traceability

- IMPLEMENTS: #702 ← scripts/ctfd-workshop/sync_polaris_ctfd.py, #702 ← scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py
- TESTS: #702 ← scripts/ctfd-workshop/test_sync_polaris_ctfd.py

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/702.fixed.md`
- [x] Architecture preflight note added at `docs/architecture/polaris-ctfd-sync-preflight-702.md`
