### PR TITLE
refactor: decompose polaris support scripts onto shared helpers

### DIFF
--- a/changelog.d/691.changed.md
+++ b/changelog.d/691.changed.md
@@ -1,0 +1,14 @@
+**Polaris operator and CTFd sync scripts now share AWS/SSM and reconcile
+helpers instead of duplicating them.** `scripts/polaris-aws-range/common.py`
+owns the boto3 session, EC2 portal-instance discovery, SSM
+``send_command``/poll loop, Django-shell-via-SSM transport, JSON envelope
+parsing, and a sensitive-output redaction helper; provisioning state,
+batch state-machine, and range-health probe model are now their own
+modules. `scripts/ctfd-workshop/ctfd_reconcile.py` owns the generic CTFd
+row-reconciliation surface (page/challenge upsert, flag/hint reconcile,
+manifest readers); `scripts/ctfd-workshop/polaris_manifest.py` owns
+Polaris-specific challenge ordering, validation, and prerequisite
+resolution. `seed_ctfd.py`, `sync_polaris_ctfd.py`,
+`sync_polaris_ctfd_onboarding.py`, `orchestrate_provisioning.py`,
+`check_range_health.py`, and `cleanup_non_keepers.py` are now thin CLI
+entrypoints over these shared helpers.

--- a/docs/architecture/polaris-support-decomposition-preflight-691.md
+++ b/docs/architecture/polaris-support-decomposition-preflight-691.md
@@ -1,0 +1,176 @@
+# Polaris Support Decomposition Preflight
+
+Issue: GitHub #691, "Refactor Polaris scenario support scripts and large
+scenario assets".
+
+This note records the architecture boundary for the future refactor. It is
+intentionally not an implementation plan.
+
+## Boundary
+
+This issue is a concrete decomposition issue, not the scenario expressiveness
+parent. Long-term declarative scenario behavior remains owned by #620 and the
+aces-sdl path documented in
+`scenario-dev/polaris/design/aces-sdl-validation-path.md`.
+
+The refactor must preserve the existing ownership split:
+
+- Runtime per-range mutation belongs in
+  `shifter/engine/provisioner/plans/polaris_range_bootstrap.py`, executed
+  through `SetupOrchestrator` and `SSMExecutor`.
+- Operator fleet scripts under `scripts/polaris-aws-range/` may orchestrate,
+  inspect, or remediate already-provisioned ranges, but they must not become a
+  second source of truth for behavior that new ranges need.
+- Standalone CTFd board/page/user sync stays under `scripts/ctfd-workshop/`
+  and uses the existing CTFd client and manifest validation paths.
+- Polaris scenario content remains under `scenario-dev/polaris/`; the deployed
+  live-event path is still `build/`, while `sdl/` plus `containers/` is the
+  aces-sdl/APTL validation path.
+
+Two historical hotfix sources named in the migrated issue,
+`apply_kali_bedrock_shard.py` and `apply_splice_watcher.py`, are not present
+as source in this checkout. Treat their source-removal as intentional unless
+Git history proves otherwise. Do not resurrect them as top-level one-off
+scripts; portable logic for new ranges belongs in `PolarisRangeBootstrapPlan`.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail |
+| --- | --- | --- |
+| Range bootstrap behavior | `PolarisRangeBootstrapPlan`, `SetupStep`, `SetupOrchestrator`, `SSMExecutor` | Keep splice watcher, Bedrock shard, DNS override, Kali key, and tests fetch on the provisioner path for new ranges. |
+| Provisioner template validation | `tests/test_plan_template_tokens.py`, `SetupOrchestrator._render_script` | Any moved setup script still passes the existing `{{word}}` placeholder lint. Do not introduce a parallel renderer. |
+| SSM execution and output masking | `SSMExecutor`, `SetupOrchestrator._mask_sensitive_output` | New provisioner-owned execution should use the executor/orchestrator instead of ad hoc `send_command` loops. |
+| Polaris AWS operator scripts | existing `orchestrate_provisioning.py`, `check_range_health.py`, `cleanup_non_keepers.py`, `sync_range_flags.py` conventions | Shared helpers should cover AWS session/client construction, instance discovery, SSM send/poll, JSON/event parsing, and sanitized reporting only. |
+| CTFd API access | `scripts/ctfd-workshop/common.py::CtfdClient`, `sync_polaris_ctfd.py::get_all_items` | Reuse token auth, JSON requests, timeout handling, and pagination. Do not add `curl`, `requests`, or another CTFd client. |
+| CTFd source manifests | `ctfd-challenges.json`, `ctfd-onboarding.json`, `ctfd-pages/` | Do not duplicate challenge names, flags, hints, prerequisites, pages, or tags into another schema. Validate and normalize the existing manifests. |
+| Scenario smoke/UAT | `scenario-dev/polaris/tests/run-all-smoketests.sh`, `scenario_smoketest`, per-asset smoketests, `check_range_health.py` | Keep smoke tests exercising participant topology. Do not widen networks or bypass pivots to make tests pass. |
+| Bake drift checks | `verify_flags_baked.py`, `test_verify_flags_baked.py`, `polaris-repo-to-ami-drift-audit.md` | Keep generated artifact verification separate from CTFd row sync and range-time smoke checks. |
+| Scenario source order | `scenario-dev/polaris/README.md` | Reconcile against `build/`, CTFd JSON, and walkthroughs before older design prose. |
+| Shared contracts | `shared.schemas` re-exporting `cyberscript.schemas`, `cms.scenarios.schema`, `cms.scenarios.hydrator` | Do not add a third range/scenario DTO stack inside Polaris support scripts. |
+
+## Cross-Cutting Layers
+
+Security layers the future design must satisfy:
+
+- Auth surface: scripts remain operator-run CLIs or provisioner-internal setup
+  steps. Do not add participant-facing Django routes, CTFd plugins, or browser
+  controls for this refactor.
+- CTFd token handling: preserve `CTFD_TOKEN` and token-file patterns. Do not
+  expand process-argv token usage, print admin tokens, or copy tokens into
+  participant containers.
+- AWS credential selection: use boto3's credential chain or explicit
+  `--profile` / `AWS_PROFILE` for operator scripts. Provisioner path should use
+  instance profiles. Do not commit static AWS keys or pass them through argv,
+  SSM parameters, or tracked reports.
+- SSM command boundary: when code is provisioner-owned, run through
+  `SetupStep`/`SSMExecutor`; when it remains an operator script, centralize
+  send/poll behavior and keep command payloads JSON/base64-delimited rather
+  than assembled from untrusted free-form text. Command failures may name
+  command ids, instance ids, range ids, and step names, but not secrets.
+- OS/process exposure: new subprocess calls must use argv arrays. Do not pass
+  CTFd admin tokens, raw static flags, AWS secrets, participant credentials, or
+  generated command bodies in process argv. Shell text sent to SSM must be
+  generated from validated fields or fixed reviewed script bodies.
+- Config/schema gates: CMS scenario YAML continues through
+  `cms.scenarios.schema` and hydration into `shared.schemas.RangeSpec`.
+  Aces-SDL files remain source-controlled scenario artifacts, not a replacement
+  schema for live provisioning in this issue.
+- Secret handling: CTFd admin tokens, AWS credentials, participant credentials,
+  static flags, private keys, and Bedrock credentials must not be logged,
+  committed as generated state, written to workflow artifacts, or echoed in
+  error messages. Scenario-intent credentials that are deliberately part of the
+  CTF content must stay documented as scenario content, not operational secrets.
+- Error envelopes and logs: CLI errors should identify sanitized actor-neutral
+  context such as range id, participant id, instance id, challenge id/name, row
+  count, and action. Do not dump full API responses, shell scripts, traceback
+  payloads containing generated scripts, authorization headers, or flag bodies.
+- Repository validators: architecture/doc changes pass
+  `python3 scripts/adr_guard/adr_guard.py --all --level ci`. Workflow edits
+  also pass `actionlint`; Terraform edits pass the relevant TFLint gate; changes
+  touching `shifter/shifter_platform` Python or imports pass the existing Ruff
+  and import-linter gates.
+
+Maintainability incumbents the implementation must build on:
+
+- `PolarisRangeBootstrapPlan` for new-range runtime behavior.
+- `scripts/ctfd-workshop/common.py`, `sync_polaris_ctfd.py`, and
+  `sync_polaris_ctfd_onboarding.py` for CTFd transport and row reconciliation.
+- `scenario_smoketest` and per-asset smoketests for range validation.
+- `verify_flags_baked.py` for bake-time generated-artifact checks.
+- `scenario-dev/polaris/README.md`, `design/shared-constants.md`, and
+  `design/architecture.md` for scenario intent and cross-asset constants.
+
+Extensibility seams:
+
+- Put shared Polaris AWS helpers at the transport/target boundary: AWS session,
+  EC2 target discovery, SSM send/poll, portal-container Django-shell transport,
+  markdown/JSON status persistence, and sanitized event parsing. Do not make the
+  helper a scenario orchestration framework.
+- Keep script entrypoints as thin argparse subcommands or focused wrappers over
+  those helpers: provision/batch control, health, cleanup, CTFd sync, and flag
+  sync remain distinct lifecycles.
+- Parameterize event id, region, profile, portal tag, AMI SSM parameter,
+  batch/failure thresholds, output paths, and selected ranges. Do not hardcode
+  the next event's constants into shared helper code.
+- For large assets, split around stable review units: asset, mission, page, or
+  generated-input package. If an artifact is generated/static and intentionally
+  large, document its generator/source and verification gate rather than hiding
+  it in an opaque blob.
+
+Whole-repo surfaces in scope for the future implementation:
+
+- `scripts/polaris-aws-range/**`
+- `scripts/ctfd-workshop/**`
+- `scenario-dev/polaris/build/**`
+- `scenario-dev/polaris/sdl/**`
+- `scenario-dev/polaris/briefing-deck/**`
+- `scenario-dev/polaris/content-packages/**`
+- `scenario-dev/polaris/containers/**`
+- `scenario-dev/polaris/tests/**`
+- `scenario-dev/polaris/design/**`
+- `shifter/engine/provisioner/plans/polaris_range_bootstrap.py`
+- `shifter/engine/provisioner/orchestrators/setup_orchestrator.py`
+- `shifter/engine/provisioner/executors/ssm_executor.py`
+- `shifter/shifter_platform/cms/scenarios/**`
+- `shifter/shifter_platform/ctf/services/range.py`
+- `.github/workflows/polaris-scenario-bake.yml` and related workflow checks if
+  validation wiring changes
+- ADR guardrails and `.gc/plan-rules.md` if enforcement policy changes
+
+## Gotchas And Anti-Patterns
+
+- Do not measure success by LOC alone. The refactor must remove duplicate
+  lifecycle logic and improve review boundaries without hiding behavior behind a
+  broad generic framework.
+- Do not dual-own Bedrock shard, splice watcher, DNS override, Kali SSH key, or
+  tests-fetch logic between operator scripts and `PolarisRangeBootstrapPlan`.
+- Do not create duplicate CTFd schemas, range DTOs, challenge metadata models,
+  exception hierarchies, logging wrappers, or validation layers.
+- Do not make standalone CTFd scripts import Django settings, native CTF models,
+  or database state. Semantic comparisons to native CTF services are fine;
+  runtime coupling is not.
+- Do not make Polaris operator scripts a new public API. They are event/support
+  tooling around existing service/provisioner boundaries.
+- Do not parse walkthrough Markdown and execute code fences. Walkthroughs are
+  human-readable reference material; executable contracts live in scripts or
+  adapters.
+- Do not solve reviewability of SDL or briefing assets by moving scenario
+  intent out of source control. Split or generate only when the source,
+  generator, and verification path stay reviewable.
+- Do not commit local Terraform state, provider caches, `.terraform/`, pyc
+  files, generated reports, or provisioning state as part of this refactor.
+- Do not weaken CI, ADR guardrails, TFLint, actionlint, import-linter, Ruff,
+  gitleaks, or Kubernetes validators to make the decomposition land.
+
+## Non-Goals
+
+- Implementing the decomposition in this preflight.
+- Delivering #620's scenario expressiveness work, replacing cyberscript with
+  aces-sdl, or extracting generic APTL image templates.
+- Replacing the range provisioner, `SetupOrchestrator`, `SSMExecutor`, CTFd
+  sync scripts, smoke-test harnesses, or bake workflow architecture.
+- Changing participant-facing challenge content, flags, hints, scoring,
+  prerequisites, invite flows, auth, or event lifecycle except where a later
+  implementation must preserve behavior during refactor.
+- Rebaking AMIs, mutating live CTFd state, destroying ranges, creating new
+  tracking issues, or running live AWS/CTFd operations.

--- a/scenario-dev/polaris/briefing-deck/README.md
+++ b/scenario-dev/polaris/briefing-deck/README.md
@@ -1,0 +1,37 @@
+# Polaris briefing deck
+
+Static, hand-authored HTML/CSS/JS slide deck used at event briefing time.
+
+- `index.html` — slide content; each slide is one `<section class="slide">`
+  with a `data-title` attribute. Add a slide by appending another
+  `<section>` in the order it should appear.
+- `styles.css` — single sheet scoped to the slide-component class hierarchy
+  (`.slide`, `.slide--brief`, `.slide--mission`, `.slide--classification`,
+  etc.). Add a new variant by adding a class and styling it under that
+  selector; do not split per-slide.
+- `deck.js` — keyboard navigation + simple ARIA progress hookup.
+- `serve.sh` — `python3 -m http.server` wrapper so you can preview locally.
+- `asset-inventory.md`, `script.md` — speaker notes and asset reference.
+
+## Why this is left as a single HTML file
+
+Issue #691 asks that large scenario assets either be **split for review**
+or be **explicitly justified as authored/static artifacts**.
+
+The deck is already split at the natural review unit: each `<section
+class="slide">` is one slide, scanned independently. Each new slide is one
+contiguous edit. CSS variants are scoped to slide-component classes so
+adding a new variant touches one place. There is no compose / build step
+to insert.
+
+Splitting `index.html` into per-slide partials would require introducing
+a template engine and a build target purely to produce the same HTML the
+browser already loads in one request. That trade is not justified for a
+deck that ships once per event and has no participant-facing dynamic
+behavior.
+
+If you find yourself wanting a build step here, that signals a real
+component / template stack should appear instead (likely co-evolving with
+#620's scenario-expressiveness work). Until then: append a `<section>`,
+add a variant class if you need a new look, and re-run `./serve.sh` to
+preview.

--- a/scenario-dev/polaris/sdl/README.md
+++ b/scenario-dev/polaris/sdl/README.md
@@ -1,0 +1,51 @@
+# Polaris SDL — design rationale
+
+This directory holds the Polaris Operation Northstorm scenario in
+[aces-sdl][aces-sdl] form:
+
+- `polaris-operation-northstorm.sdl.yaml` — full event scenario (~1.7k LOC,
+  17 nodes: domain controller + 16 mission assets).
+- `polaris-demo-minimal.sdl.yaml` — small smoke variant used by the
+  scenario-content smoketest harness (issue #617).
+
+## Why a single monolithic file
+
+Issue #691 ("Refactor Polaris scenario support scripts and large scenario
+assets") asks that large scenario assets either be **split for review** or
+be **explicitly justified as authored/static artifacts**. The Polaris SDL
+takes the second path:
+
+1. **The SDL is the source of truth.** Splitting it into per-asset or
+   per-mission files would create a generator / merge step. The aces-sdl
+   loader does not own one today; the live-event deploy and the scenario
+   smoketest both read the YAML directly.
+2. **No generator means no verification gate for splits.** A multi-file
+   layout that is hand-merged loses the topology and credential-coupling
+   invariants the YAML enforces today. The preflight note for this issue
+   (`docs/architecture/polaris-support-decomposition-preflight-691.md`,
+   §157) is explicit that "split or generate only when the source,
+   generator, and verification path stay reviewable."
+3. **#620 is the path forward.** The scenario-expressiveness work tracked
+   in #620 owns the long-term move toward declarative composition (and
+   away from monolithic SDL). When that lands, an aces-sdl generator and
+   per-asset review surface fall out of it; until then, this file stays as
+   the authored single source.
+4. **Review is already mission-scoped.** Every block has a `name:` /
+   `category:` aligned with the mission table in
+   `../design/architecture.md`, so reviewers can locate a mission's nodes
+   by jumping to its name. The intent is reviewable as-is.
+
+If you change a Polaris asset, change it here. Do not generate this file
+from a parallel source until #620 supplies the generator.
+
+[aces-sdl]: ../design/aces-sdl-validation-path.md
+
+## Related
+
+- `../README.md` — overall Polaris layout (build/ vs sdl/ vs containers/).
+- `../design/architecture.md` — zone map and per-mission asset table.
+- `../design/shared-constants.md` — cross-asset constants and credentials.
+- `../tests/run-all-smoketests.sh` — per-asset smoketests; topology
+  assertions live here and must keep passing after any SDL edit.
+- Live-event deploy path stays through `build/`, not `sdl/`; this
+  directory feeds the aces-sdl / APTL validation path.

--- a/scenario-dev/polaris/tests/smoketests/A14-smoketest.sh
+++ b/scenario-dev/polaris/tests/smoketests/A14-smoketest.sh
@@ -23,12 +23,17 @@ echo "A14 smoketest - Kali attack platform"
 
 echo
 echo "--- Content files ---"
-for f in /home/kali/README.md /home/kali/mission_brief.txt /home/kali/mission_brief.pdf \
-         /home/kali/tools/flag_submit.sh /home/kali/tools/modbus_scan.py \
-         /home/kali/.config/claude/system_prompt.txt; do
+# README.md, mission_brief.{txt,pdf}, and tools/flag_submit.sh were removed
+# in 2026-04 (see scenario-dev/polaris/build/a14/Dockerfile:85): they were
+# stale relative to the CTFd board and Kali has no route to CTFd, so a
+# Kali-side submission helper is broken by design. CTFd is the reference.
+# The remaining content drops are modbus_scan.py (Mission 4 helper), the
+# Claude POLARIS system prompt, and the warm-up challenge target.
+for f in /home/kali/tools/modbus_scan.py \
+         /home/kali/.config/claude/system_prompt.txt \
+         /home/kali/.polaris/welcome.txt; do
     [[ -f "$f" ]] && pass "$f present" || fail "$f missing"
 done
-[[ -x /home/kali/tools/flag_submit.sh ]] && pass "flag_submit.sh executable" || fail "flag_submit.sh not exec"
 [[ -x /home/kali/tools/modbus_scan.py ]] && pass "modbus_scan.py executable" || fail "modbus_scan.py not exec"
 
 echo

--- a/scripts/ctfd-workshop/ctfd_reconcile.py
+++ b/scripts/ctfd-workshop/ctfd_reconcile.py
@@ -1,0 +1,433 @@
+"""Generic CTFd reconciliation helpers (issue #691).
+
+These helpers were duplicated across ``sync_polaris_ctfd_onboarding.py``
+(authoritative version), ``sync_polaris_ctfd.py`` (re-imported wrappers
+plus its own page sync), and ``seed_ctfd.py`` (parallel re-implementation
+with slightly different flag/hint semantics).
+
+The module owns the **generic** CTFd row-reconciliation surface:
+
+- ``find_by_key`` / ``reconcile_rows`` — add/match/delete keyed on a
+  caller-supplied ``row_key``.
+- ``upsert_page`` / ``upsert_challenge`` / ``build_challenge_payload`` —
+  CTFd object upsert keyed by ``route`` and ``name`` respectively.
+- ``normalize_flag`` / ``normalize_hints`` — manifest-shape to CTFd-row
+  shape.
+- ``ensure_flags`` / ``ensure_hints`` — full reconcile on
+  ``(type, content)`` and ``title`` respectively, with deletion of stale
+  rows. The hint write payload carries the polymorphic ``type: standard``
+  discriminator (skipping it shipped NULL hint types and participant-side
+  500s on a previous regression).
+- ``parse_scalar`` / ``parse_page`` / ``load_pages`` / ``load_json`` —
+  source-manifest readers used by every page+challenge sync flow.
+
+Anything Polaris-specific (challenge ordering, prereq resolution, manifest
+validation rules) lives in ``polaris_manifest.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+from common import CtfdClient
+
+
+# -----------------------------------------------------------------------------
+# Source-manifest readers
+# -----------------------------------------------------------------------------
+
+
+def load_json(path: str) -> dict[str, Any]:
+    with Path(path).open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def parse_scalar(raw: str) -> Any:
+    text = raw.strip()
+    lowered = text.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered == "null":
+        return None
+    return text
+
+
+def parse_page(path: Path) -> dict[str, Any]:
+    """Parse a CTFd page Markdown file with front-matter into a page body."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        raise ValueError(f"{path} is missing front matter")
+
+    meta: dict[str, Any] = {}
+    index = 1
+    while index < len(lines):
+        line = lines[index]
+        if line.strip() == "---":
+            index += 1
+            break
+        if line.strip():
+            key, sep, value = line.partition(":")
+            if not sep:
+                raise ValueError(f"{path} has invalid front matter line: {line!r}")
+            meta[key.strip()] = parse_scalar(value)
+        index += 1
+
+    body = "\n".join(lines[index:]).lstrip("\n")
+    for key in ("title", "route"):
+        if key not in meta:
+            raise ValueError(f"{path} front matter is missing {key!r}")
+
+    return {
+        "title": meta["title"],
+        "route": meta["route"],
+        "content": body,
+        "draft": bool(meta.get("draft", False)),
+        "hidden": bool(meta.get("hidden", False)),
+        "auth_required": bool(meta.get("auth_required", False)),
+        "format": meta.get("format", "markdown"),
+    }
+
+
+def load_pages(pages_dir: str) -> list[dict[str, Any]]:
+    page_root = Path(pages_dir)
+    if not page_root.exists():
+        raise FileNotFoundError(f"pages dir does not exist: {page_root}")
+    return [parse_page(path) for path in sorted(page_root.glob("*.md"))]
+
+
+# -----------------------------------------------------------------------------
+# Row-set reconciliation
+# -----------------------------------------------------------------------------
+
+
+def find_by_key(
+    items: list[dict[str, Any]],
+    *,
+    key: str,
+    value: str,
+) -> dict[str, Any] | None:
+    for item in items:
+        if item.get(key) == value:
+            return item
+    return None
+
+
+def reconcile_rows(
+    *,
+    source_rows: list[dict[str, Any]],
+    live_rows: list[dict[str, Any]],
+    row_key: Callable[[dict[str, Any]], Any],
+    on_create: Callable[[dict[str, Any]], None],
+    on_match: Callable[[dict[str, Any], dict[str, Any]], None],
+    on_delete: Callable[[dict[str, Any]], None],
+) -> None:
+    """Reconcile a set of CTFd child rows against the source manifest.
+
+    Add-missing / patch-on-match / delete-stale, keyed by ``row_key``. This is
+    the shared seam so flags and hints follow the same expected-vs-live
+    discipline instead of one-off per-row helpers.
+    """
+    live_by_key: dict[Any, dict[str, Any]] = {}
+    for row in live_rows:
+        live_by_key.setdefault(row_key(row), row)
+
+    expected_keys: set[Any] = set()
+    for source in source_rows:
+        key = row_key(source)
+        expected_keys.add(key)
+        match = live_by_key.get(key)
+        if match is None:
+            on_create(source)
+        else:
+            on_match(match, source)
+
+    for key, row in live_by_key.items():
+        if key not in expected_keys:
+            on_delete(row)
+
+
+# -----------------------------------------------------------------------------
+# CTFd-row builders + upserts
+# -----------------------------------------------------------------------------
+
+
+def upsert_page(
+    client: CtfdClient,
+    *,
+    existing_pages: list[dict[str, Any]],
+    page: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    existing = find_by_key(existing_pages, key="route", value=page["route"])
+    if existing:
+        print(f"update page: {page['route']}")
+        if dry_run:
+            updated = dict(existing)
+            updated.update(page)
+            return updated
+        response = client.patch(f"/pages/{existing['id']}", page)
+        return response["data"]
+
+    print(f"create page: {page['route']}")
+    if dry_run:
+        created = {"id": None, **page}
+        existing_pages.append(created)
+        return created
+    response = client.post("/pages", page)
+    created = response["data"]
+    existing_pages.append(created)
+    return created
+
+
+def build_challenge_payload(
+    *,
+    challenge: dict[str, Any],
+    position: int,
+    next_id: int | None = None,
+    requirements: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the CTFd ``/challenges`` payload body from a source-manifest entry.
+
+    Source manifests for both the Polaris board and the agentic workshop
+    flow through this builder. Callers always own the ``requirements`` policy
+    they want CTFd to persist:
+
+    - Polaris first pass writes ``{"prerequisites": []}`` so unresolved
+      source-manifest ids never reach the live CTFd authorization gate.
+    - Polaris second pass passes ``resolve_prerequisites(...)`` so live
+      CTFd ids are written once every challenge id exists.
+    - Workshop seeding passes explicit ``prerequisites`` (empty for the
+      first pass, [user_challenge_id] for the second).
+
+    When a caller omits ``requirements`` the builder defaults to empty
+    prerequisites, NOT a copy of ``challenge["requirements"]``. Copying raw
+    source-manifest requirements through this shared helper would persist
+    pre-resolution manifest ids as live CTFd prerequisite ids, which can
+    bypass intended challenge gates if a sync is interrupted before the
+    resolved pass runs.
+    """
+    payload = {
+        "name": challenge["name"],
+        "description": challenge["description"],
+        "category": challenge["category"],
+        "value": challenge["value"],
+        "type": challenge.get("type", "standard"),
+        "state": challenge.get("state", "visible"),
+        "max_attempts": challenge.get("max_attempts", 0),
+        "function": challenge.get("function", "static"),
+        "logic": challenge.get("logic", "any"),
+        "position": challenge.get("position", position),
+        "requirements": (
+            requirements if requirements is not None else {"prerequisites": []}
+        ),
+    }
+    if "connection_info" in challenge:
+        payload["connection_info"] = challenge["connection_info"]
+    if next_id is not None:
+        payload["next_id"] = next_id
+    return payload
+
+
+def upsert_challenge(
+    client: CtfdClient,
+    *,
+    existing_challenges: list[dict[str, Any]],
+    payload: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    existing = find_by_key(existing_challenges, key="name", value=payload["name"])
+    if existing:
+        print(f"update challenge: {payload['name']}")
+        if dry_run:
+            updated = dict(existing)
+            updated.update(payload)
+            return updated
+        response = client.patch(f"/challenges/{existing['id']}", payload)
+        return response["data"]
+
+    print(f"create challenge: {payload['name']}")
+    if dry_run:
+        created = {"id": None, **payload}
+        existing_challenges.append(created)
+        return created
+    response = client.post("/challenges", payload)
+    created = response["data"]
+    existing_challenges.append(created)
+    return created
+
+
+# -----------------------------------------------------------------------------
+# Flag / hint shape normalizers + reconcilers
+# -----------------------------------------------------------------------------
+
+
+def normalize_flag(flag: dict[str, Any]) -> dict[str, Any]:
+    """Return a CTFd flag-row body from a source-JSON flag entry."""
+    return {
+        "type": flag.get("type", "static"),
+        "content": flag["content"],
+        "data": flag.get("data", ""),
+    }
+
+
+def normalize_hints(hints: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return CTFd hint-row bodies, deriving default titles by position."""
+    normalized: list[dict[str, Any]] = []
+    for index, hint in enumerate(hints, start=1):
+        normalized.append(
+            {
+                "title": hint.get("title", f"Hint {index}"),
+                "content": hint["content"],
+                "cost": hint.get("cost", 0),
+                "requirements": hint.get("requirements", []),
+            }
+        )
+    return normalized
+
+
+def ensure_flags(
+    client: CtfdClient,
+    *,
+    challenge_id: int | None,
+    challenge_name: str,
+    flags: list[dict[str, Any]],
+    dry_run: bool,
+) -> None:
+    """Reconcile every source flag against the challenge's live CTFd flag rows.
+
+    Idempotent across re-syncs: flags are keyed by ``(type, content)``, missing
+    rows are created, stale rows removed. Flag content is never logged.
+    """
+    expected = [normalize_flag(flag) for flag in flags]
+    if dry_run or challenge_id is None:
+        for flag in expected:
+            print(f"sync flag: {challenge_name} :: {flag['type']}")
+        return
+
+    live_flags = client.get("/flags", {"challenge_id": challenge_id}).get("data", [])
+
+    def on_create(flag: dict[str, Any]) -> None:
+        print(f"create flag: {challenge_name} :: {flag['type']}")
+        client.post("/flags", {"challenge_id": challenge_id, **flag})
+
+    def on_match(live_flag: dict[str, Any], flag: dict[str, Any]) -> None:
+        if live_flag.get("data", "") != flag["data"]:
+            print(f"update flag: {challenge_name} :: {flag['type']}")
+            client.patch(f"/flags/{live_flag['id']}", {"challenge_id": challenge_id, **flag})
+        else:
+            print(f"keep flag: {challenge_name} :: {flag['type']}")
+
+    def on_delete(live_flag: dict[str, Any]) -> None:
+        print(f"delete stale flag: {challenge_name} :: {live_flag.get('type')}")
+        client.delete(f"/flags/{live_flag['id']}")
+
+    reconcile_rows(
+        source_rows=expected,
+        live_rows=live_flags,
+        row_key=lambda flag: (flag.get("type", "static"), flag.get("content")),
+        on_create=on_create,
+        on_match=on_match,
+        on_delete=on_delete,
+    )
+
+
+def ensure_hints(
+    client: CtfdClient,
+    *,
+    challenge_id: int | None,
+    challenge_name: str,
+    hints: list[dict[str, Any]],
+    dry_run: bool,
+) -> None:
+    """Reconcile source hints against the challenge's live CTFd hint rows.
+
+    Hint write payloads carry the polymorphic ``type: standard`` discriminator;
+    omitting it produced NULL hint types and participant-facing 500s.
+    """
+    expected = normalize_hints(hints)
+    if dry_run or challenge_id is None:
+        for hint in expected:
+            print(f"sync hint: {challenge_name} :: {hint['title']}")
+        return
+
+    live_hints = client.get(f"/challenges/{challenge_id}/hints").get("data", [])
+
+    def body(hint: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "challenge_id": challenge_id,
+            "type": "standard",
+            "title": hint["title"],
+            "content": hint["content"],
+            "cost": hint["cost"],
+            "requirements": hint["requirements"],
+        }
+
+    def on_create(hint: dict[str, Any]) -> None:
+        print(f"create hint: {challenge_name} :: {hint['title']}")
+        client.post("/hints", body(hint))
+
+    def on_match(live_hint: dict[str, Any], hint: dict[str, Any]) -> None:
+        print(f"sync hint: {challenge_name} :: {hint['title']}")
+        client.patch(f"/hints/{live_hint['id']}", body(hint))
+
+    def on_delete(live_hint: dict[str, Any]) -> None:
+        print(f"delete stale hint: {challenge_name} :: {live_hint.get('title')}")
+        client.delete(f"/hints/{live_hint['id']}")
+
+    reconcile_rows(
+        source_rows=expected,
+        live_rows=live_hints,
+        row_key=lambda hint: hint["title"],
+        on_create=on_create,
+        on_match=on_match,
+        on_delete=on_delete,
+    )
+
+
+def get_all_items(
+    client: CtfdClient,
+    path: str,
+    query: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Paginate through a CTFd list endpoint and return all rows."""
+    page = 1
+    items: list[dict[str, Any]] = []
+    base_query = dict(query or {})
+
+    while True:
+        payload = client.get(path, {**base_query, "page": page})
+        data = payload.get("data", [])
+        if not isinstance(data, list):
+            return data
+        items.extend(data)
+
+        pagination = payload.get("meta", {}).get("pagination", {})
+        total_pages = pagination.get("pages")
+        if not total_pages or page >= total_pages:
+            break
+        page += 1
+
+    return items
+
+
+__all__ = [
+    "build_challenge_payload",
+    "ensure_flags",
+    "ensure_hints",
+    "find_by_key",
+    "get_all_items",
+    "load_json",
+    "load_pages",
+    "normalize_flag",
+    "normalize_hints",
+    "parse_page",
+    "parse_scalar",
+    "reconcile_rows",
+    "upsert_challenge",
+    "upsert_page",
+]

--- a/scripts/ctfd-workshop/polaris_manifest.py
+++ b/scripts/ctfd-workshop/polaris_manifest.py
@@ -1,0 +1,240 @@
+"""Polaris-specific CTFd manifest helpers (issue #691).
+
+These were tangled into ``sync_polaris_ctfd.py``. The split is by
+specificity: ``ctfd_reconcile`` is generic CTFd row-reconciliation; this
+module is Polaris-event constants and validation that only the Polaris
+board cares about.
+
+Owns:
+
+- Authoritative challenge ordering for the Polaris board UI.
+- Stale challenge names that the live board should delete on every sync.
+- Source-manifest validation (``validate_manifest`` /
+  ``validate_live_challenge_names``).
+- Post-sync flag/hint verification (``verify_challenge_rows``).
+- Prerequisite resolution (manifest id -> live CTFd id).
+- ``SyncError`` — the dedicated exit-class the CLI catches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from common import CtfdClient
+
+SUPPORTED_FLAG_TYPES = {"static", "regex"}
+
+STALE_CHALLENGE_NAMES = {
+    "Mission 0 — Kali Warm-Up",
+}
+
+ORDERED_CHALLENGE_NAMES = [
+    "Start Here — Kali Warm-Up",
+    "Company Info",
+    "Employee Directory",
+    "Tech Stack Revealed",
+    "Client Contracts",
+    "DNS Reconnaissance",
+    "Follow the Money",
+    "Configuration Leak",
+    "Project Hints",
+    "Terminated Engineer",
+    "Password Reuse",
+    "Mundane File Share",
+    "The Project",
+    "Procurement Trail",
+    "Hidden Group",
+    "Lateral Movement",
+    "Unreliable Guard",
+    "Domain Admin",
+    "The Analyst's Desk",
+    "Old Defaults",
+    "Compartment A",
+    "Heavy Delivery",
+    "MIDNIGHT-7",
+    "What Git Remembers",
+    "After Hours",
+    "Balance Point",
+    "Compartment B",
+    "What's Built",
+    "What Was Erased",
+    "Full Run",
+    "On Call",
+    "Control Room",
+    "Lights Out",
+    "Underground Signals",
+    "First Motion",
+    "Walking Pattern",
+    "Response Window",
+    "Control Channel",
+    "Full Override",
+    "Q4 Risk Review",
+    "Redacted Minutes",
+    "Sanitized Diagram",
+    "Press Drop",
+    "Badge Clone",
+    "Mailbox Rule",
+    "Burner Visit",
+    "Report the Mole",
+    "Shipping Slot",
+    "Approval Client",
+    "Freeze Template",
+    "Delivery Halt",
+    "Maintenance Manual",
+    "Diagnostic Channel",
+    "Safe Mode Sequence",
+    "Cold Shutdown",
+]
+
+
+class SyncError(RuntimeError):
+    """Raised when the source manifest or live CTFd board fails validation."""
+
+
+def validate_manifest(challenges: list[dict[str, Any]]) -> None:
+    """Validate the merged source manifest before any CTFd mutation.
+
+    A malformed manifest must fail loudly here, before stale-row deletion can
+    remove event-critical live rows. Flag content is never echoed.
+    """
+    seen_ids: set[Any] = set()
+    seen_names: set[str] = set()
+    errors: list[str] = []
+
+    for challenge in challenges:
+        name = challenge.get("name")
+        if not name:
+            errors.append(
+                f"challenge missing name (category={challenge.get('category')!r})"
+            )
+            continue
+        if name in seen_names:
+            errors.append(f"duplicate challenge name {name!r}")
+        seen_names.add(name)
+
+        if not challenge.get("category"):
+            errors.append(f"challenge {name!r} missing category")
+
+        manifest_id = challenge.get("id")
+        if manifest_id is not None:
+            if manifest_id in seen_ids:
+                errors.append(f"duplicate manifest id {manifest_id!r} ({name})")
+            seen_ids.add(manifest_id)
+
+        flags = challenge.get("flags", [])
+        if not flags:
+            errors.append(f"challenge {name!r} has no flags — it would be unsubmittable")
+        for flag in flags:
+            flag_type = flag.get("type", "static")
+            if flag_type not in SUPPORTED_FLAG_TYPES:
+                errors.append(
+                    f"challenge {name!r} has unsupported flag type {flag_type!r}"
+                )
+            if not flag.get("content"):
+                errors.append(f"challenge {name!r} has a flag with empty content")
+
+    if errors:
+        raise SyncError("manifest validation failed:\n  " + "\n  ".join(errors))
+
+
+def validate_live_challenge_names(existing_challenges: list[dict[str, Any]]) -> None:
+    """Fail when the live board has duplicate challenge names.
+
+    Sync is name-keyed, so a duplicate live name makes every upsert ambiguous.
+    """
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for challenge in existing_challenges:
+        name = challenge.get("name")
+        if name in seen:
+            duplicates.add(name)
+        seen.add(name)
+    if duplicates:
+        raise SyncError(
+            "duplicate live CTFd challenge names make name-keyed sync unsafe: "
+            + ", ".join(sorted(duplicates))
+        )
+
+
+def verify_challenge_rows(
+    client: CtfdClient,
+    *,
+    challenges: list[dict[str, Any]],
+    name_to_live_id: dict[str, int | None],
+) -> None:
+    """Read flag and hint rows back from CTFd after sync.
+
+    Raises if a challenge with source flags (or hints) shows zero live rows —
+    the exact regression that shipped 38/39 challenges unsubmittable.
+    """
+    failures: list[str] = []
+    for challenge in challenges:
+        name = challenge["name"]
+        live_id = name_to_live_id.get(name)
+        if live_id is None:
+            failures.append(f"{name}: no live challenge id after sync")
+            continue
+        if challenge.get("flags"):
+            rows = client.get(f"/challenges/{live_id}/flags").get("data", [])
+            if not rows:
+                failures.append(f"{name} (id {live_id}): 0 flag rows — unsubmittable")
+        if challenge.get("hints"):
+            rows = client.get(f"/challenges/{live_id}/hints").get("data", [])
+            if not rows:
+                failures.append(f"{name} (id {live_id}): 0 hint rows")
+    if failures:
+        raise SyncError("post-sync verification failed:\n  " + "\n  ".join(failures))
+
+
+def build_manifest_id_to_name(challenges: list[dict[str, Any]]) -> dict[int, str]:
+    return {challenge["id"]: challenge["name"] for challenge in challenges if "id" in challenge}
+
+
+def sort_challenges(challenges: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    name_order = {name: index for index, name in enumerate(ORDERED_CHALLENGE_NAMES, start=1)}
+    fallback_index = len(name_order) + 1000
+    return sorted(
+        challenges,
+        key=lambda challenge: (
+            name_order.get(challenge["name"], fallback_index),
+            challenge.get("category", ""),
+            challenge.get("id", 0),
+        ),
+    )
+
+
+def resolve_prerequisites(
+    *,
+    challenge: dict[str, Any],
+    manifest_id_to_name: dict[int, str],
+    name_to_live_id: dict[str, int | None],
+) -> dict[str, Any]:
+    """Translate manifest-id prerequisites into live CTFd ids."""
+    raw_requirements = challenge.get("requirements", {})
+    prerequisite_ids: list[int] = []
+    for manifest_id in raw_requirements.get("prerequisites", []):
+        challenge_name = manifest_id_to_name.get(manifest_id)
+        if not challenge_name:
+            print(f"warn: prerequisite id {manifest_id!r} not found in manifest")
+            continue
+        live_id = name_to_live_id.get(challenge_name)
+        if live_id is None:
+            print(f"warn: prerequisite {challenge_name!r} has no live id yet")
+            continue
+        prerequisite_ids.append(live_id)
+
+    return {"prerequisites": prerequisite_ids}
+
+
+__all__ = [
+    "ORDERED_CHALLENGE_NAMES",
+    "STALE_CHALLENGE_NAMES",
+    "SUPPORTED_FLAG_TYPES",
+    "SyncError",
+    "build_manifest_id_to_name",
+    "resolve_prerequisites",
+    "sort_challenges",
+    "validate_live_challenge_names",
+    "validate_manifest",
+    "verify_challenge_rows",
+]

--- a/scripts/ctfd-workshop/seed_ctfd.py
+++ b/scripts/ctfd-workshop/seed_ctfd.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+"""Seed the standalone workshop CTFd with challenges, flags, and baseline config.
+
+Challenge upsert and the generic ``find_by_key`` lookup live in
+:mod:`ctfd_reconcile` and are shared with the Polaris sync paths. The
+single-flag "keeper" semantics and the standalone-only solution helper
+stay here because they're specific to this seeder (the Polaris board uses
+``ctfd_reconcile.ensure_flags`` instead).
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -6,6 +15,7 @@ import os
 from typing import Any
 
 from common import CtfdClient, load_event_config
+from ctfd_reconcile import build_challenge_payload, find_by_key, upsert_challenge
 
 
 def parse_args() -> argparse.Namespace:
@@ -30,58 +40,33 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def build_challenge_payload(
+def _workshop_challenge_payload(
     *,
     challenge: dict[str, Any],
     category: str,
     requirements: dict[str, Any],
 ) -> dict[str, Any]:
-    return {
-        "name": challenge["challenge_name"],
-        "description": challenge["description"],
-        "category": category,
-        "value": challenge["value"],
-        "type": "standard",
-        "state": "visible",
-        "max_attempts": 0,
-        "function": "static",
-        "logic": "any",
-        "position": challenge["position"],
-        "requirements": requirements,
-    }
+    """Workshop-shaped manifest -> CTFd payload (challenge_name key).
 
-
-def find_challenge(existing_challenges: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
-    for challenge in existing_challenges:
-        if challenge.get("name") == name:
-            return challenge
-    return None
-
-
-def upsert_challenge(
-    client: CtfdClient,
-    *,
-    existing_challenges: list[dict[str, Any]],
-    payload: dict[str, Any],
-    dry_run: bool,
-) -> dict[str, Any]:
-    existing = find_challenge(existing_challenges, payload["name"])
-    if existing:
-        print(f"update challenge: {payload['name']}")
-        if dry_run:
-            updated = dict(existing)
-            updated.update(payload)
-            return updated
-        response = client.patch(f"/challenges/{existing['id']}", payload)
-        return response["data"]
-
-    print(f"create challenge: {payload['name']}")
-    if dry_run:
-        return {"id": None, **payload}
-    response = client.post("/challenges", payload)
-    created = response["data"]
-    existing_challenges.append(created)
-    return created
+    The workshop manifest uses ``challenge_name`` where the Polaris manifest
+    uses ``name``, and stores ``category`` at the top of the event JSON
+    rather than per-challenge. ``build_challenge_payload`` expects both
+    ``name`` and ``category`` on the challenge dict, so we bridge them
+    here without forking the shared builder.
+    """
+    bridged = dict(challenge)
+    bridged["name"] = challenge["challenge_name"]
+    bridged["category"] = category
+    bridged.setdefault("type", "standard")
+    bridged.setdefault("state", "visible")
+    bridged.setdefault("max_attempts", 0)
+    bridged.setdefault("function", "static")
+    bridged.setdefault("logic", "any")
+    return build_challenge_payload(
+        challenge=bridged,
+        position=challenge["position"],
+        requirements=requirements,
+    )
 
 
 def ensure_static_flag(
@@ -92,6 +77,12 @@ def ensure_static_flag(
     flag_value: str,
     dry_run: bool,
 ) -> None:
+    """Keep one static flag per challenge.
+
+    Differs from ``ctfd_reconcile.ensure_flags`` deliberately: this preserves
+    the live flag row id by patching the first existing flag and deleting the
+    rest, instead of delete-then-create when the content changes.
+    """
     print(f"sync flag: {challenge_name}")
     if dry_run:
         return
@@ -116,13 +107,6 @@ def ensure_static_flag(
         client.post("/flags", payload)
 
 
-def find_hint(existing_hints: list[dict[str, Any]], title: str) -> dict[str, Any] | None:
-    for hint in existing_hints:
-        if hint.get("title") == title:
-            return hint
-    return None
-
-
 def ensure_hints(
     client: CtfdClient,
     *,
@@ -131,6 +115,9 @@ def ensure_hints(
     hints: list[dict[str, Any]],
     dry_run: bool,
 ) -> None:
+    """Workshop hint upsert. Does NOT delete stale hints (different from the
+    Polaris ``ctfd_reconcile.ensure_hints`` behavior, which is keyed by
+    ``title`` and removes anything not in the manifest)."""
     if not hints:
         return
 
@@ -146,7 +133,7 @@ def ensure_hints(
             "cost": hint.get("cost", 0),
             "requirements": hint.get("requirements", []),
         }
-        existing = find_hint(existing_hints, hint["title"])
+        existing = find_by_key(existing_hints, key="title", value=hint["title"])
         if existing:
             print(f"sync hint: {challenge_name} :: {hint['title']}")
             if not dry_run:
@@ -157,13 +144,6 @@ def ensure_hints(
         if not dry_run:
             response = client.post("/hints", payload)
             existing_hints.append(response["data"])
-
-
-def find_solution(existing_solutions: list[dict[str, Any]], challenge_id: int) -> dict[str, Any] | None:
-    for solution in existing_solutions:
-        if solution.get("challenge_id") == challenge_id:
-            return solution
-    return None
 
 
 def ensure_solution(
@@ -187,7 +167,7 @@ def ensure_solution(
         "content": solution["content"],
         "state": solution.get("state", "hidden"),
     }
-    existing = find_solution(existing_solutions, challenge_id)
+    existing = find_by_key(existing_solutions, key="challenge_id", value=challenge_id)
     if existing:
         response = client.patch(f"/solutions/{existing['id']}", payload)
         updated = response["data"]
@@ -224,7 +204,7 @@ def main() -> int:
 
     for box in event["boxes"]:
         user_challenge = box["user"]
-        payload = build_challenge_payload(
+        payload = _workshop_challenge_payload(
             challenge=user_challenge,
             category=category,
             requirements={"prerequisites": []},
@@ -264,7 +244,7 @@ def main() -> int:
         root_challenge = box["root"]
         prereq_id = user_ids[box["instance_name"]]
         requirements = {"prerequisites": [prereq_id], "anonymize": False}
-        payload = build_challenge_payload(
+        payload = _workshop_challenge_payload(
             challenge=root_challenge,
             category=category,
             requirements=requirements,

--- a/scripts/ctfd-workshop/sync_polaris_ctfd.py
+++ b/scripts/ctfd-workshop/sync_polaris_ctfd.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+"""Sync the live Polaris CTFd board, onboarding challenge, and pages.
+
+Generic CTFd reconciliation lives in :mod:`ctfd_reconcile`; Polaris-specific
+ordering, validation, prereq resolution, and stale-name policy live in
+:mod:`polaris_manifest`. This script wires the two layers together.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -7,181 +14,33 @@ from pathlib import Path
 from typing import Any
 
 from common import CtfdClient
-from sync_polaris_ctfd_onboarding import (
-    DEFAULT_ONBOARDING_PATH,
-    DEFAULT_PAGES_DIR,
+from ctfd_reconcile import (
+    build_challenge_payload,
     ensure_flags,
     ensure_hints,
-    find_by_key,
+    get_all_items,
     load_json,
     load_pages,
     upsert_challenge,
     upsert_page,
 )
+from polaris_manifest import (
+    STALE_CHALLENGE_NAMES,
+    SyncError,
+    build_manifest_id_to_name,
+    resolve_prerequisites,
+    sort_challenges,
+    validate_live_challenge_names,
+    validate_manifest,
+    verify_challenge_rows,
+)
+from sync_polaris_ctfd_onboarding import DEFAULT_ONBOARDING_PATH, DEFAULT_PAGES_DIR
 
+# Re-export so existing tests/imports keep working without churn.
+from polaris_manifest import SUPPORTED_FLAG_TYPES, ORDERED_CHALLENGE_NAMES  # noqa: F401
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CHALLENGE_PATH = REPO_ROOT / "scenario-dev/polaris/build/ctfd-challenges.json"
-SUPPORTED_FLAG_TYPES = {"static", "regex"}
-STALE_CHALLENGE_NAMES = {
-    "Mission 0 — Kali Warm-Up",
-}
-ORDERED_CHALLENGE_NAMES = [
-    "Start Here — Kali Warm-Up",
-    "Company Info",
-    "Employee Directory",
-    "Tech Stack Revealed",
-    "Client Contracts",
-    "DNS Reconnaissance",
-    "Follow the Money",
-    "Configuration Leak",
-    "Project Hints",
-    "Terminated Engineer",
-    "Password Reuse",
-    "Mundane File Share",
-    "The Project",
-    "Procurement Trail",
-    "Hidden Group",
-    "Lateral Movement",
-    "Unreliable Guard",
-    "Domain Admin",
-    "The Analyst's Desk",
-    "Old Defaults",
-    "Compartment A",
-    "Heavy Delivery",
-    "MIDNIGHT-7",
-    "What Git Remembers",
-    "After Hours",
-    "Balance Point",
-    "Compartment B",
-    "What's Built",
-    "What Was Erased",
-    "Full Run",
-    "On Call",
-    "Control Room",
-    "Lights Out",
-    "Underground Signals",
-    "First Motion",
-    "Walking Pattern",
-    "Response Window",
-    "Control Channel",
-    "Full Override",
-    "Q4 Risk Review",
-    "Redacted Minutes",
-    "Sanitized Diagram",
-    "Press Drop",
-    "Badge Clone",
-    "Mailbox Rule",
-    "Burner Visit",
-    "Report the Mole",
-    "Shipping Slot",
-    "Approval Client",
-    "Freeze Template",
-    "Delivery Halt",
-    "Maintenance Manual",
-    "Diagnostic Channel",
-    "Safe Mode Sequence",
-    "Cold Shutdown",
-]
-
-
-class SyncError(RuntimeError):
-    """Raised when the source manifest or live CTFd board fails validation."""
-
-
-def validate_manifest(challenges: list[dict[str, Any]]) -> None:
-    """Validate the merged source manifest before any CTFd mutation.
-
-    A malformed manifest must fail loudly here, before stale-row deletion can
-    remove event-critical live rows. Flag content is never echoed.
-    """
-    seen_ids: set[Any] = set()
-    seen_names: set[str] = set()
-    errors: list[str] = []
-
-    for challenge in challenges:
-        name = challenge.get("name")
-        if not name:
-            errors.append(
-                f"challenge missing name (category={challenge.get('category')!r})"
-            )
-            continue
-        if name in seen_names:
-            errors.append(f"duplicate challenge name {name!r}")
-        seen_names.add(name)
-
-        if not challenge.get("category"):
-            errors.append(f"challenge {name!r} missing category")
-
-        manifest_id = challenge.get("id")
-        if manifest_id is not None:
-            if manifest_id in seen_ids:
-                errors.append(f"duplicate manifest id {manifest_id!r} ({name})")
-            seen_ids.add(manifest_id)
-
-        flags = challenge.get("flags", [])
-        if not flags:
-            errors.append(f"challenge {name!r} has no flags — it would be unsubmittable")
-        for flag in flags:
-            flag_type = flag.get("type", "static")
-            if flag_type not in SUPPORTED_FLAG_TYPES:
-                errors.append(
-                    f"challenge {name!r} has unsupported flag type {flag_type!r}"
-                )
-            if not flag.get("content"):
-                errors.append(f"challenge {name!r} has a flag with empty content")
-
-    if errors:
-        raise SyncError("manifest validation failed:\n  " + "\n  ".join(errors))
-
-
-def validate_live_challenge_names(existing_challenges: list[dict[str, Any]]) -> None:
-    """Fail when the live board has duplicate challenge names.
-
-    Sync is name-keyed, so a duplicate live name makes every upsert ambiguous.
-    """
-    seen: set[str] = set()
-    duplicates: set[str] = set()
-    for challenge in existing_challenges:
-        name = challenge.get("name")
-        if name in seen:
-            duplicates.add(name)
-        seen.add(name)
-    if duplicates:
-        raise SyncError(
-            "duplicate live CTFd challenge names make name-keyed sync unsafe: "
-            + ", ".join(sorted(duplicates))
-        )
-
-
-def verify_challenge_rows(
-    client: CtfdClient,
-    *,
-    challenges: list[dict[str, Any]],
-    name_to_live_id: dict[str, int | None],
-) -> None:
-    """Read flag and hint rows back from CTFd after sync.
-
-    Raises if a challenge with source flags (or hints) shows zero live rows —
-    the exact regression that shipped 38/39 challenges unsubmittable.
-    """
-    failures: list[str] = []
-    for challenge in challenges:
-        name = challenge["name"]
-        live_id = name_to_live_id.get(name)
-        if live_id is None:
-            failures.append(f"{name}: no live challenge id after sync")
-            continue
-        if challenge.get("flags"):
-            rows = client.get(f"/challenges/{live_id}/flags").get("data", [])
-            if not rows:
-                failures.append(f"{name} (id {live_id}): 0 flag rows — unsubmittable")
-        if challenge.get("hints"):
-            rows = client.get(f"/challenges/{live_id}/hints").get("data", [])
-            if not rows:
-                failures.append(f"{name} (id {live_id}): 0 hint rows")
-    if failures:
-        raise SyncError("post-sync verification failed:\n  " + "\n  ".join(failures))
 
 
 def parse_args() -> argparse.Namespace:
@@ -222,97 +81,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def get_all_items(
-    client: CtfdClient,
-    path: str,
-    query: dict[str, Any] | None = None,
-) -> list[dict[str, Any]]:
-    page = 1
-    items: list[dict[str, Any]] = []
-    base_query = dict(query or {})
-
-    while True:
-        payload = client.get(path, {**base_query, "page": page})
-        data = payload.get("data", [])
-        if not isinstance(data, list):
-            return data
-        items.extend(data)
-
-        pagination = payload.get("meta", {}).get("pagination", {})
-        total_pages = pagination.get("pages")
-        if not total_pages or page >= total_pages:
-            break
-        page += 1
-
-    return items
-
-
-def build_manifest_id_to_name(challenges: list[dict[str, Any]]) -> dict[int, str]:
-    return {challenge["id"]: challenge["name"] for challenge in challenges if "id" in challenge}
-
-
-def sort_challenges(challenges: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    name_order = {name: index for index, name in enumerate(ORDERED_CHALLENGE_NAMES, start=1)}
-    fallback_index = len(name_order) + 1000
-    return sorted(
-        challenges,
-        key=lambda challenge: (
-            name_order.get(challenge["name"], fallback_index),
-            challenge.get("category", ""),
-            challenge.get("id", 0),
-        ),
-    )
-
-
-def build_payload(
-    *,
-    challenge: dict[str, Any],
-    position: int,
-    requirements: dict[str, Any] | None = None,
-    next_id: int | None = None,
-) -> dict[str, Any]:
-    payload = {
-        "name": challenge["name"],
-        "description": challenge["description"],
-        "category": challenge["category"],
-        "value": challenge["value"],
-        "type": challenge.get("type", "standard"),
-        "state": challenge.get("state", "visible"),
-        "max_attempts": challenge.get("max_attempts", 0),
-        "function": challenge.get("function", "static"),
-        "logic": challenge.get("logic", "any"),
-        "position": challenge.get("position", position),
-        "requirements": requirements if requirements is not None else {"prerequisites": []},
-    }
-    if "connection_info" in challenge:
-        payload["connection_info"] = challenge["connection_info"]
-    if next_id is not None:
-        payload["next_id"] = next_id
-    return payload
-
-
-def resolve_prerequisites(
-    *,
-    challenge: dict[str, Any],
-    manifest_id_to_name: dict[int, str],
-    name_to_live_id: dict[str, int | None],
-) -> dict[str, Any]:
-    raw_requirements = challenge.get("requirements", {})
-    prerequisite_ids = []
-    for manifest_id in raw_requirements.get("prerequisites", []):
-        challenge_name = manifest_id_to_name.get(manifest_id)
-        if not challenge_name:
-            print(f"warn: prerequisite id {manifest_id!r} not found in manifest")
-            continue
-        live_id = name_to_live_id.get(challenge_name)
-        if live_id is None:
-            print(f"warn: prerequisite {challenge_name!r} has no live id yet")
-            continue
-        prerequisite_ids.append(live_id)
-
-    return {"prerequisites": prerequisite_ids}
-
-
 def ensure_tags(
     client: CtfdClient,
     *,
@@ -321,6 +89,12 @@ def ensure_tags(
     tags: list[str],
     dry_run: bool,
 ) -> None:
+    """Reconcile tag rows for a challenge against the manifest's tag list.
+
+    Stays in this script rather than ``ctfd_reconcile`` because the live tag
+    surface uses a flat ``value`` key (not a row-keyed ``reconcile_rows``
+    shape) and only the Polaris board uses it today.
+    """
     if dry_run or challenge_id is None:
         for tag in tags:
             print(f"sync tag: {challenge_name} :: {tag}")
@@ -395,7 +169,17 @@ def sync_challenges(
     synced_by_name: dict[str, dict[str, Any]] = {}
 
     for position, challenge in enumerate(challenges, start=1):
-        payload = build_payload(challenge=challenge, position=position)
+        # First pass: write empty prerequisites so unresolved manifest ids
+        # never reach the live CTFd authorization gate. Pass two patches in
+        # resolved live ids via resolve_prerequisites once every challenge
+        # exists; if the sync aborts between the two passes, CTFd is left
+        # with safe-by-default empty prereqs instead of stale manifest ids
+        # that happen to collide with unrelated live challenge ids.
+        payload = build_challenge_payload(
+            challenge=challenge,
+            position=position,
+            requirements={"prerequisites": []},
+        )
         synced = upsert_challenge(
             client,
             existing_challenges=existing_challenges,
@@ -414,7 +198,7 @@ def sync_challenges(
             if next_id is None:
                 print(f"warn: next challenge {next_name!r} not found; leaving next_id unset")
 
-        payload = build_payload(
+        payload = build_challenge_payload(
             challenge=challenge,
             position=position,
             requirements=resolve_prerequisites(

--- a/scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py
+++ b/scripts/ctfd-workshop/sync_polaris_ctfd_onboarding.py
@@ -1,13 +1,29 @@
 #!/usr/bin/env python3
+"""Sync the Polaris CTFd onboarding pages and the Start Here warm-up challenge.
+
+Page and challenge upserts, row reconciliation, source-manifest readers,
+and the generic ``ensure_flags`` / ``ensure_hints`` helpers all live in
+:mod:`ctfd_reconcile`. This script is the thin orchestrator that loads
+the onboarding manifest + pages and walks them through those helpers.
+"""
+
 from __future__ import annotations
 
 import argparse
-import json
 import os
 from pathlib import Path
-from typing import Any, Callable
 
 from common import CtfdClient
+from ctfd_reconcile import (
+    build_challenge_payload,
+    ensure_flags,
+    ensure_hints,
+    find_by_key,
+    load_json,
+    load_pages,
+    upsert_challenge,
+    upsert_page,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -43,317 +59,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_json(path: str) -> dict[str, Any]:
-    with Path(path).open("r", encoding="utf-8") as handle:
-        return json.load(handle)
-
-
-def parse_scalar(raw: str) -> Any:
-    text = raw.strip()
-    lowered = text.lower()
-    if lowered == "true":
-        return True
-    if lowered == "false":
-        return False
-    if lowered == "null":
-        return None
-    return text
-
-
-def parse_page(path: Path) -> dict[str, Any]:
-    text = path.read_text(encoding="utf-8")
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        raise ValueError(f"{path} is missing front matter")
-
-    meta: dict[str, Any] = {}
-    index = 1
-    while index < len(lines):
-        line = lines[index]
-        if line.strip() == "---":
-            index += 1
-            break
-        if line.strip():
-            key, sep, value = line.partition(":")
-            if not sep:
-                raise ValueError(f"{path} has invalid front matter line: {line!r}")
-            meta[key.strip()] = parse_scalar(value)
-        index += 1
-
-    body = "\n".join(lines[index:]).lstrip("\n")
-    for key in ("title", "route"):
-        if key not in meta:
-            raise ValueError(f"{path} front matter is missing {key!r}")
-
-    return {
-        "title": meta["title"],
-        "route": meta["route"],
-        "content": body,
-        "draft": bool(meta.get("draft", False)),
-        "hidden": bool(meta.get("hidden", False)),
-        "auth_required": bool(meta.get("auth_required", False)),
-        "format": meta.get("format", "markdown"),
-    }
-
-
-def load_pages(pages_dir: str) -> list[dict[str, Any]]:
-    page_root = Path(pages_dir)
-    if not page_root.exists():
-        raise FileNotFoundError(f"pages dir does not exist: {page_root}")
-    return [parse_page(path) for path in sorted(page_root.glob("*.md"))]
-
-
-def find_by_key(
-    items: list[dict[str, Any]],
-    *,
-    key: str,
-    value: str,
-) -> dict[str, Any] | None:
-    for item in items:
-        if item.get(key) == value:
-            return item
-    return None
-
-
-def upsert_page(
-    client: CtfdClient,
-    *,
-    existing_pages: list[dict[str, Any]],
-    page: dict[str, Any],
-    dry_run: bool,
-) -> dict[str, Any]:
-    existing = find_by_key(existing_pages, key="route", value=page["route"])
-    if existing:
-        print(f"update page: {page['route']}")
-        if dry_run:
-            updated = dict(existing)
-            updated.update(page)
-            return updated
-        response = client.patch(f"/pages/{existing['id']}", page)
-        return response["data"]
-
-    print(f"create page: {page['route']}")
-    if dry_run:
-        created = {"id": None, **page}
-        existing_pages.append(created)
-        return created
-    response = client.post("/pages", page)
-    created = response["data"]
-    existing_pages.append(created)
-    return created
-
-
-def build_challenge_payload(
-    *,
-    challenge: dict[str, Any],
-    position: int,
-    next_id: int | None,
-) -> dict[str, Any]:
-    payload = {
-        "name": challenge["name"],
-        "description": challenge["description"],
-        "category": challenge["category"],
-        "value": challenge["value"],
-        "type": challenge.get("type", "standard"),
-        "state": challenge.get("state", "visible"),
-        "max_attempts": challenge.get("max_attempts", 0),
-        "function": challenge.get("function", "static"),
-        "logic": challenge.get("logic", "any"),
-        "position": challenge.get("position", position),
-        "requirements": challenge.get("requirements", {"prerequisites": []}),
-    }
-    if "connection_info" in challenge:
-        payload["connection_info"] = challenge["connection_info"]
-    if next_id is not None:
-        payload["next_id"] = next_id
-    return payload
-
-
-def upsert_challenge(
-    client: CtfdClient,
-    *,
-    existing_challenges: list[dict[str, Any]],
-    payload: dict[str, Any],
-    dry_run: bool,
-) -> dict[str, Any]:
-    existing = find_by_key(existing_challenges, key="name", value=payload["name"])
-    if existing:
-        print(f"update challenge: {payload['name']}")
-        if dry_run:
-            updated = dict(existing)
-            updated.update(payload)
-            return updated
-        response = client.patch(f"/challenges/{existing['id']}", payload)
-        return response["data"]
-
-    print(f"create challenge: {payload['name']}")
-    if dry_run:
-        created = {"id": None, **payload}
-        existing_challenges.append(created)
-        return created
-    response = client.post("/challenges", payload)
-    created = response["data"]
-    existing_challenges.append(created)
-    return created
-
-
-def reconcile_rows(
-    *,
-    source_rows: list[dict[str, Any]],
-    live_rows: list[dict[str, Any]],
-    row_key: Callable[[dict[str, Any]], Any],
-    on_create: Callable[[dict[str, Any]], None],
-    on_match: Callable[[dict[str, Any], dict[str, Any]], None],
-    on_delete: Callable[[dict[str, Any]], None],
-) -> None:
-    """Reconcile a set of CTFd child rows against the source manifest.
-
-    Add-missing / patch-on-match / delete-stale, keyed by ``row_key``. This is
-    the shared seam so flags and hints follow the same expected-vs-live
-    discipline instead of one-off per-row helpers.
-    """
-    live_by_key: dict[Any, dict[str, Any]] = {}
-    for row in live_rows:
-        live_by_key.setdefault(row_key(row), row)
-
-    expected_keys: set[Any] = set()
-    for source in source_rows:
-        key = row_key(source)
-        expected_keys.add(key)
-        match = live_by_key.get(key)
-        if match is None:
-            on_create(source)
-        else:
-            on_match(match, source)
-
-    for key, row in live_by_key.items():
-        if key not in expected_keys:
-            on_delete(row)
-
-
-def normalize_flag(flag: dict[str, Any]) -> dict[str, Any]:
-    """Return a CTFd flag-row body from a source-JSON flag entry."""
-    return {
-        "type": flag.get("type", "static"),
-        "content": flag["content"],
-        "data": flag.get("data", ""),
-    }
-
-
-def normalize_hints(hints: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Return CTFd hint-row bodies, deriving default titles by position."""
-    normalized: list[dict[str, Any]] = []
-    for index, hint in enumerate(hints, start=1):
-        normalized.append(
-            {
-                "title": hint.get("title", f"Hint {index}"),
-                "content": hint["content"],
-                "cost": hint.get("cost", 0),
-                "requirements": hint.get("requirements", []),
-            }
-        )
-    return normalized
-
-
-def ensure_flags(
-    client: CtfdClient,
-    *,
-    challenge_id: int | None,
-    challenge_name: str,
-    flags: list[dict[str, Any]],
-    dry_run: bool,
-) -> None:
-    """Reconcile every source flag against the challenge's live CTFd flag rows.
-
-    Idempotent across re-syncs: flags are keyed by ``(type, content)``, missing
-    rows are created, stale rows removed. Flag content is never logged.
-    """
-    expected = [normalize_flag(flag) for flag in flags]
-    if dry_run or challenge_id is None:
-        for flag in expected:
-            print(f"sync flag: {challenge_name} :: {flag['type']}")
-        return
-
-    live_flags = client.get("/flags", {"challenge_id": challenge_id}).get("data", [])
-
-    def on_create(flag: dict[str, Any]) -> None:
-        print(f"create flag: {challenge_name} :: {flag['type']}")
-        client.post("/flags", {"challenge_id": challenge_id, **flag})
-
-    def on_match(live_flag: dict[str, Any], flag: dict[str, Any]) -> None:
-        if live_flag.get("data", "") != flag["data"]:
-            print(f"update flag: {challenge_name} :: {flag['type']}")
-            client.patch(f"/flags/{live_flag['id']}", {"challenge_id": challenge_id, **flag})
-        else:
-            print(f"keep flag: {challenge_name} :: {flag['type']}")
-
-    def on_delete(live_flag: dict[str, Any]) -> None:
-        print(f"delete stale flag: {challenge_name} :: {live_flag.get('type')}")
-        client.delete(f"/flags/{live_flag['id']}")
-
-    reconcile_rows(
-        source_rows=expected,
-        live_rows=live_flags,
-        row_key=lambda flag: (flag.get("type", "static"), flag.get("content")),
-        on_create=on_create,
-        on_match=on_match,
-        on_delete=on_delete,
-    )
-
-
-def ensure_hints(
-    client: CtfdClient,
-    *,
-    challenge_id: int | None,
-    challenge_name: str,
-    hints: list[dict[str, Any]],
-    dry_run: bool,
-) -> None:
-    """Reconcile source hints against the challenge's live CTFd hint rows.
-
-    Hint write payloads carry the polymorphic ``type: standard`` discriminator;
-    omitting it produced NULL hint types and participant-facing 500s.
-    """
-    expected = normalize_hints(hints)
-    if dry_run or challenge_id is None:
-        for hint in expected:
-            print(f"sync hint: {challenge_name} :: {hint['title']}")
-        return
-
-    live_hints = client.get(f"/challenges/{challenge_id}/hints").get("data", [])
-
-    def body(hint: dict[str, Any]) -> dict[str, Any]:
-        return {
-            "challenge_id": challenge_id,
-            "type": "standard",
-            "title": hint["title"],
-            "content": hint["content"],
-            "cost": hint["cost"],
-            "requirements": hint["requirements"],
-        }
-
-    def on_create(hint: dict[str, Any]) -> None:
-        print(f"create hint: {challenge_name} :: {hint['title']}")
-        client.post("/hints", body(hint))
-
-    def on_match(live_hint: dict[str, Any], hint: dict[str, Any]) -> None:
-        print(f"sync hint: {challenge_name} :: {hint['title']}")
-        client.patch(f"/hints/{live_hint['id']}", body(hint))
-
-    def on_delete(live_hint: dict[str, Any]) -> None:
-        print(f"delete stale hint: {challenge_name} :: {live_hint.get('title')}")
-        client.delete(f"/hints/{live_hint['id']}")
-
-    reconcile_rows(
-        source_rows=expected,
-        live_rows=live_hints,
-        row_key=lambda hint: hint["title"],
-        on_create=on_create,
-        on_match=on_match,
-        on_delete=on_delete,
-    )
-
-
 def main() -> int:
     args = parse_args()
     if not args.token:
@@ -363,8 +68,8 @@ def main() -> int:
     pages = load_pages(args.pages_dir)
     client = CtfdClient(args.base_url, args.token)
 
-    existing_pages: list[dict[str, Any]] = []
-    existing_challenges: list[dict[str, Any]] = []
+    existing_pages: list[dict] = []
+    existing_challenges: list[dict] = []
     if not args.dry_run:
         existing_pages = client.get("/pages").get("data", [])
         existing_challenges = client.get("/challenges", {"view": "admin"}).get("data", [])

--- a/scripts/ctfd-workshop/test_sync_polaris_ctfd.py
+++ b/scripts/ctfd-workshop/test_sync_polaris_ctfd.py
@@ -11,19 +11,15 @@ from __future__ import annotations
 
 import unittest
 
-from sync_polaris_ctfd import (
+from ctfd_reconcile import ensure_flags, ensure_hints, reconcile_rows
+from polaris_manifest import (
     SUPPORTED_FLAG_TYPES,
     SyncError,
-    sync_challenges,
     validate_live_challenge_names,
     validate_manifest,
     verify_challenge_rows,
 )
-from sync_polaris_ctfd_onboarding import (
-    ensure_flags,
-    ensure_hints,
-    reconcile_rows,
-)
+from sync_polaris_ctfd import sync_challenges
 
 
 class FakeCtfdClient:

--- a/scripts/polaris-aws-range/check_range_health.py
+++ b/scripts/polaris-aws-range/check_range_health.py
@@ -30,6 +30,11 @@ values (keys are boolean-present only).
 Targeting: AMI-based discovery against the /shifter/ami/polaris-vm SSM
 parameter. Alternatively pass --instance-ids.
 
+Per-host probe script, target discovery, report writer, and the issue
+model live in :mod:`range_health`; the shared AWS / SSM transport lives in
+:mod:`common`. This entrypoint just wires CLI args, runs the SSM fan-out
+in batches, and writes the report.
+
 Usage::
 
     python3 check_range_health.py --profile panw-shifter-dev-workstation
@@ -45,318 +50,25 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import base64
-import json
 import sys
-import time
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
-import boto3
 from botocore.exceptions import ClientError
 
-EXPECTED_CONTAINER_COUNT = 22
-FLAG_CRITICAL_CONTAINERS = ["a5-scada", "a9-splice", "a0-website", "a14-kali"]
-KALI_ENV_KEYS = [
-    "CLAUDE_CODE_USE_BEDROCK",
-    "AWS_REGION",
-    "ANTHROPIC_MODEL",
-    "ANTHROPIC_SMALL_FAST_MODEL",
-]
+from common import PolarisAwsContext, SsmExecutor, SsmTimeout
+from range_health import (
+    HEALTH_PROBE_SCRIPT,
+    RangeReport,
+    Target,
+    batched,
+    discover_targets,
+    parse_record,
+    resolve_polaris_ami_id,
+    write_report,
+)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 DEFAULT_OUTPUT = SCRIPT_DIR / "health_report.md"
-
-# Bash run on each polaris-vm. Emits key=value|key=value|... record to stdout.
-# Boolean-ish fields use 1/0; string fields are space-free tokens.
-INNER = r"""#!/bin/bash
-set -u
-
-out=""
-add() { out="${out}${out:+|}${1}=${2}"; }
-
-# host identity
-add host "$(hostname)"
-inst_id=$(curl -s --max-time 3 -H "X-aws-ec2-metadata-token: $(curl -s --max-time 3 -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)" http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null || echo "?")
-add instance_id "$inst_id"
-
-# docker container count
-running=$(sudo docker ps -q | wc -l | tr -d ' ')
-add container_count "$running"
-exited=$(sudo docker ps -a --filter status=exited --filter status=dead --format '{{.Names}}' | paste -sd, - )
-exited=${exited:-none}
-add exited_containers "$exited"
-
-# a14-kali container running
-kali_state=$(sudo docker inspect -f '{{.State.Status}}' a14-kali 2>/dev/null || echo missing)
-add a14_state "$kali_state"
-
-# a14-kali on splice-link?
-if [[ "$kali_state" == "running" ]]; then
-  on_splice=$(sudo docker inspect a14-kali --format '{{json .NetworkSettings.Networks}}' 2>/dev/null | grep -q 'splice-link' && echo 1 || echo 0)
-else
-  on_splice=0
-fi
-add a14_on_splice "$on_splice"
-
-# a14-kali profile.d file
-if [[ "$kali_state" == "running" ]]; then
-  profile_ok=$(sudo docker exec a14-kali test -r /etc/profile.d/claude-bedrock.sh && echo 1 || echo 0)
-else
-  profile_ok=0
-fi
-add bedrock_profile "$profile_ok"
-
-# presence of each required env key (no values, just 1/0)
-if [[ "$profile_ok" == "1" ]]; then
-  for key in CLAUDE_CODE_USE_BEDROCK AWS_REGION ANTHROPIC_MODEL ANTHROPIC_SMALL_FAST_MODEL; do
-    present=$(sudo docker exec a14-kali grep -q "^export ${key}=" /etc/profile.d/claude-bedrock.sh && echo 1 || echo 0)
-    add "env_${key}" "$present"
-  done
-  # static keys are only set for Account B shards — don't require them
-  has_ak=$(sudo docker exec a14-kali grep -q '^export AWS_ACCESS_KEY_ID=' /etc/profile.d/claude-bedrock.sh && echo 1 || echo 0)
-  add env_AWS_ACCESS_KEY_ID "$has_ak"
-else
-  for key in CLAUDE_CODE_USE_BEDROCK AWS_REGION ANTHROPIC_MODEL ANTHROPIC_SMALL_FAST_MODEL AWS_ACCESS_KEY_ID; do
-    add "env_${key}" 0
-  done
-fi
-
-# /etc/hosts entry
-if [[ "$kali_state" == "running" ]]; then
-  hosts_ok=$(sudo docker exec a14-kali grep -q 'bedrock-runtime.us-east-2.amazonaws.com' /etc/hosts && echo 1 || echo 0)
-else
-  hosts_ok=0
-fi
-add hosts_override "$hosts_ok"
-
-# splice watcher systemd
-sv_state=$(systemctl is-active polaris-splice-watcher.service 2>/dev/null || echo missing)
-add splice_watcher "$sv_state"
-
-# flag-critical containers
-for name in a5-scada a9-splice a0-website; do
-  state=$(sudo docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo missing)
-  add "${name//-/_}_state" "$state"
-done
-
-echo "__RECORD__${out}__END__"
-"""
-
-
-@dataclass(frozen=True)
-class Target:
-    instance_id: str
-    vpc_id: str
-    name: str
-    range_id: str
-    user_id: str
-
-
-@dataclass
-class RangeReport:
-    instance_id: str
-    range_id: str
-    user_id: str
-    fields: dict[str, str]
-
-    @property
-    def ok(self) -> bool:
-        return not self.issues()
-
-    def issues(self) -> list[str]:
-        probs: list[str] = []
-        probs.extend(self._container_count_issue())
-        probs.extend(self._exited_containers_issue())
-        probs.extend(self._a14_kali_issues())
-        probs.extend(self._bedrock_env_issues())
-        probs.extend(self._splice_watcher_issue())
-        probs.extend(self._other_container_state_issues())
-        return probs
-
-    def _container_count_issue(self) -> list[str]:
-        cc = self.fields.get("container_count", "?")
-        if cc != str(EXPECTED_CONTAINER_COUNT):
-            return [f"container_count={cc}/{EXPECTED_CONTAINER_COUNT}"]
-        return []
-
-    def _exited_containers_issue(self) -> list[str]:
-        ex = self.fields.get("exited_containers", "")
-        if ex and ex != "none":
-            return [f"exited=[{ex}]"]
-        return []
-
-    def _a14_kali_issues(self) -> list[str]:
-        probs: list[str] = []
-        if self.fields.get("a14_state") != "running":
-            probs.append(f"a14-kali={self.fields.get('a14_state')}")
-        if self.fields.get("a14_on_splice") == "1":
-            probs.append("a14 still on splice-link (watcher didn't disconnect)")
-        return probs
-
-    def _bedrock_env_issues(self) -> list[str]:
-        probs: list[str] = []
-        if self.fields.get("bedrock_profile") != "1":
-            probs.append("missing /etc/profile.d/claude-bedrock.sh")
-        for k in KALI_ENV_KEYS:
-            if self.fields.get(f"env_{k}") != "1":
-                probs.append(f"missing env {k}")
-        if self.fields.get("hosts_override") != "1":
-            probs.append("missing /etc/hosts bedrock-runtime entry")
-        return probs
-
-    def _splice_watcher_issue(self) -> list[str]:
-        sw = self.fields.get("splice_watcher")
-        if sw != "active":
-            return [f"splice-watcher={sw}"]
-        return []
-
-    def _other_container_state_issues(self) -> list[str]:
-        probs: list[str] = []
-        for name in ("a5_scada_state", "a9_splice_state", "a0_website_state"):
-            if self.fields.get(name) != "running":
-                probs.append(f"{name.replace('_state', '')}={self.fields.get(name)}")
-        return probs
-
-
-def resolve_polaris_ami_id(ssm_client) -> str:
-    try:
-        resp = ssm_client.get_parameter(Name="/shifter/ami/polaris-vm")
-    except ClientError as e:
-        raise SystemExit(f"failed to read SSM /shifter/ami/polaris-vm: {e}") from e
-    return resp["Parameter"]["Value"]
-
-
-def discover_targets(ec2_client, ami_id: str, vpc_id: str | None) -> list[Target]:
-    filters = [
-        {"Name": "image-id", "Values": [ami_id]},
-        {"Name": "instance-state-name", "Values": ["running"]},
-    ]
-    if vpc_id:
-        filters.append({"Name": "vpc-id", "Values": [vpc_id]})
-    targets: list[Target] = []
-    paginator = ec2_client.get_paginator("describe_instances")
-    for page in paginator.paginate(Filters=filters):
-        for reservation in page["Reservations"]:
-            for inst in reservation["Instances"]:
-                tags = {t["Key"]: t["Value"] for t in (inst.get("Tags") or [])}
-                targets.append(
-                    Target(
-                        instance_id=inst["InstanceId"],
-                        vpc_id=inst["VpcId"],
-                        name=tags.get("Name", ""),
-                        range_id=tags.get("shifter:range_id", ""),
-                        user_id=tags.get("shifter:user_id", ""),
-                    )
-                )
-    return targets
-
-
-def batched(seq: list[str], size: int) -> Iterable[list[str]]:
-    for i in range(0, len(seq), size):
-        yield seq[i : i + size]
-
-
-def send_and_wait(ssm_client, instance_ids: list[str], script: str, timeout_s: int = 300) -> dict[str, dict]:
-    resp = ssm_client.send_command(
-        InstanceIds=instance_ids,
-        DocumentName="AWS-RunShellScript",
-        Comment="polaris range health check",
-        Parameters={"commands": [script], "executionTimeout": [str(timeout_s)]},
-        MaxConcurrency="50",
-        MaxErrors="100%",
-        TimeoutSeconds=timeout_s,
-    )
-    cmd_id = resp["Command"]["CommandId"]
-    terminal = {"Success", "Cancelled", "TimedOut", "Failed"}
-    time.sleep(2.0)
-    results: dict[str, dict] = {}
-    while True:
-        results.clear()
-        paginator = ssm_client.get_paginator("list_command_invocations")
-        for page in paginator.paginate(CommandId=cmd_id, Details=True, MaxResults=50):
-            for inv in page["CommandInvocations"]:
-                plugin_out = ""
-                plugin_err = ""
-                for plugin in inv.get("CommandPlugins") or []:
-                    plugin_out = plugin.get("Output", "") or plugin_out
-                    plugin_err = plugin.get("StandardErrorContent", "") or plugin_err
-                results[inv["InstanceId"]] = {
-                    "Status": inv["Status"],
-                    "StandardOutputContent": plugin_out,
-                    "StandardErrorContent": plugin_err,
-                }
-        pending = [iid for iid, r in results.items() if r["Status"] not in terminal]
-        if not pending and results:
-            return results
-        time.sleep(5)
-
-
-def parse_record(stdout: str) -> dict[str, str]:
-    start = stdout.find("__RECORD__")
-    end = stdout.find("__END__")
-    if start == -1 or end == -1:
-        return {}
-    body = stdout[start + len("__RECORD__") : end]
-    out: dict[str, str] = {}
-    for part in body.split("|"):
-        if "=" in part:
-            k, v = part.split("=", 1)
-            out[k] = v
-    return out
-
-
-def write_report(targets: list[Target], reports: list[RangeReport], out_path: Path, verbose: bool) -> None:
-    ok = [r for r in reports if r.ok]
-    bad = [r for r in reports if not r.ok]
-
-    lines: list[str] = []
-    lines.append("# Polaris range health report")
-    lines.append("")
-    from datetime import datetime, timezone, timedelta
-    now_utc = datetime.now(tz=timezone.utc).replace(microsecond=0)
-    now_edt = now_utc - timedelta(hours=4)
-    lines.append(f"Generated: {now_utc.isoformat()} / {now_edt.strftime('%H:%M EDT')}")
-    lines.append("")
-    lines.append("## Summary")
-    lines.append("")
-    lines.append(f"- Discovered polaris-vm ranges: {len(targets)}")
-    lines.append(f"- Checked: {len(reports)}")
-    lines.append(f"- Healthy: **{len(ok)}**")
-    lines.append(f"- With issues: **{len(bad)}**")
-    lines.append(f"- Unreachable (SSM failure): {len(targets) - len(reports)}")
-    lines.append("")
-
-    if bad:
-        lines.append("## Issues")
-        lines.append("")
-        lines.append("| range | user | instance | problems |")
-        lines.append("|---|---|---|---|")
-        for r in sorted(bad, key=lambda x: (int(x.range_id) if x.range_id.isdigit() else 999, x.instance_id)):
-            probs = "; ".join(r.issues())
-            lines.append(f"| {r.range_id} | {r.user_id} | {r.instance_id} | {probs} |")
-        lines.append("")
-    else:
-        lines.append("## Issues")
-        lines.append("")
-        lines.append("None. 🟢")
-        lines.append("")
-
-    if verbose:
-        lines.append("## All ranges")
-        lines.append("")
-        lines.append("| range | user | instance | ok | containers | a14 | splice-watcher | shard model |")
-        lines.append("|---|---|---|---|---|---|---|---|")
-        for r in sorted(reports, key=lambda x: (int(x.range_id) if x.range_id.isdigit() else 999, x.instance_id)):
-            ok_m = "🟢" if r.ok else "🔴"
-            cc = r.fields.get("container_count", "?")
-            a14 = r.fields.get("a14_state", "?")
-            sw = r.fields.get("splice_watcher", "?")
-            lines.append(f"| {r.range_id} | {r.user_id} | {r.instance_id} | {ok_m} | {cc}/22 | {a14} | {sw} | - |")
-        lines.append("")
-
-    out_path.write_text("\n".join(lines) + "\n")
 
 
 def parse_args() -> argparse.Namespace:
@@ -374,15 +86,15 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    session = boto3.Session(profile_name=args.profile, region_name=args.region)
-    ec2 = session.client("ec2")
-    ssm = session.client("ssm")
+    ctx = PolarisAwsContext(profile=args.profile, region=args.region)
+    ec2 = ctx.ec2()
+    executor = SsmExecutor(ctx.ssm(), poll_interval_s=5.0, default_timeout_s=300)
 
     if args.instance_ids:
         ids = [s.strip() for s in args.instance_ids.split(",") if s.strip()]
         targets = [Target(instance_id=i, vpc_id="?", name="?", range_id="?", user_id="?") for i in ids]
     else:
-        ami = args.ami_id or resolve_polaris_ami_id(ssm)
+        ami = args.ami_id or resolve_polaris_ami_id(ctx.ssm())
         print(f"discovering polaris-vms (ami={ami})...", flush=True)
         targets = discover_targets(ec2, ami, args.vpc_id)
     print(f"{len(targets)} target(s)", flush=True)
@@ -396,14 +108,26 @@ def main() -> int:
     for batch_num, chunk in enumerate(batched(ids, args.batch_size), start=1):
         print(f"batch {batch_num}: {len(chunk)} instance(s)...", flush=True)
         try:
-            results = send_and_wait(ssm, chunk, INNER)
+            results = executor.run_bash_batch(
+                chunk,
+                HEALTH_PROBE_SCRIPT,
+                timeout_s=300,
+                comment="polaris range health check",
+            )
         except ClientError as e:
             print(f"  SendCommand failed: {e}", file=sys.stderr)
             continue
+        except SsmTimeout as e:
+            # One bad/missing instance must not suppress the fleet report.
+            # The report contract already tracks any target without a record
+            # as "Unreachable (SSM failure)" via len(targets) - len(reports),
+            # so we drop the batch and keep going.
+            print(f"  batch timed out, treating affected instances as unreachable: {e}", file=sys.stderr)
+            continue
         for iid, res in results.items():
-            if res["Status"] != "Success":
+            if res.status != "Success":
                 continue
-            rec = parse_record(res.get("StandardOutputContent", ""))
+            rec = parse_record(res.stdout)
             if not rec:
                 continue
             t = id_to_target[iid]

--- a/scripts/polaris-aws-range/cleanup_non_keepers.py
+++ b/scripts/polaris-aws-range/cleanup_non_keepers.py
@@ -17,18 +17,21 @@ Usage (from your workstation):
     python3 scripts/polaris-aws-range/cleanup_non_keepers.py --execute       # real
 
 The script fires an SSM command that runs the actual Django work inside
-the portal container. See cleanup-plan.md for the policy rationale and
-full keep/destroy lists.
+the portal container via :mod:`common.PortalShellTransport`. See
+cleanup-plan.md for the policy rationale and full keep/destroy lists.
 """
 from __future__ import annotations
 
 import argparse
-import base64
 import json
 import sys
-import time
 
-import boto3
+from common import (
+    PolarisAwsContext,
+    PortalShellTransport,
+    SsmExecutor,
+    find_portal_instance,
+)
 
 # -----------------------------------------------------------------------------
 # Hard-coded safety config — DO NOT edit without cross-checking cleanup-plan.md
@@ -62,7 +65,6 @@ EXPECTED_DESTROY_MAX = 110  # defense: never destroy more than this many
 
 AWS_PROFILE = "panw-shifter-dev-workstation"
 AWS_REGION = "us-east-2"
-PORTAL_INSTANCE_TAG_NAME = "dev-portal-ec2"
 
 # -----------------------------------------------------------------------------
 # The Django-shell snippet that runs inside the portal container.
@@ -126,47 +128,9 @@ except Exception:
 """
 
 
-def find_portal_instance(ec2) -> str:
-    resp = ec2.describe_instances(Filters=[
-        {"Name": "tag:Name", "Values": [PORTAL_INSTANCE_TAG_NAME]},
-        {"Name": "instance-state-name", "Values": ["running"]},
-    ])
-    for r in resp["Reservations"]:
-        for i in r["Instances"]:
-            return i["InstanceId"]
-    raise RuntimeError(f"no running instance tagged Name={PORTAL_INSTANCE_TAG_NAME}")
-
-
-def run_in_portal(ssm, instance_id: str, script: str) -> tuple[str, str]:
-    """Ship the script into the portal container via SSM and return (stdout, stderr)."""
-    py_b64 = base64.b64encode(script.encode("utf-8")).decode("ascii")
-    wrapper = rf"""
-set -euo pipefail
-echo "{py_b64}" | base64 -d > /tmp/cnk.py
-sudo docker cp /tmp/cnk.py portal:/tmp/cnk.py
-sudo docker exec portal bash -c 'while IFS= read -r -d "" kv; do export "$kv"; done < /proc/1/environ && cd /app && python manage.py shell < /tmp/cnk.py'
-sudo docker exec portal rm -f /tmp/cnk.py || true
-rm -f /tmp/cnk.py || true
-"""
-    resp = ssm.send_command(
-        InstanceIds=[instance_id],
-        DocumentName="AWS-RunShellScript",
-        Comment="polaris cleanup non-keepers",
-        Parameters={"commands": [wrapper], "executionTimeout": ["900"]},
-        TimeoutSeconds=900,
-    )
-    cid = resp["Command"]["CommandId"]
-    # poll
-    for _ in range(180):
-        time.sleep(5)
-        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=instance_id)
-        if inv["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
-            break
-    return inv.get("StandardOutputContent", ""), inv.get("StandardErrorContent", "")
-
-
 def parse_events(stdout: str) -> list[dict]:
-    events = []
+    """Extract structured ``SHELL_EVENT|...`` records from raw SSM stdout."""
+    events: list[dict] = []
     for line in stdout.splitlines():
         if line.startswith("SHELL_EVENT|"):
             try:
@@ -200,19 +164,22 @@ def main() -> int:
     else:
         print("Running in DRY-RUN mode (no changes will be made). Pass --execute to destroy.")
 
-    session = boto3.Session(profile_name=args.profile, region_name=args.region)
-    ec2 = session.client("ec2")
-    ssm = session.client("ssm")
-    portal = find_portal_instance(ec2)
+    ctx = PolarisAwsContext(profile=args.profile, region=args.region)
+    portal = find_portal_instance(ctx.ec2())
     print(f"portal instance: {portal}")
 
+    transport = PortalShellTransport(
+        executor=SsmExecutor(ctx.ssm(), poll_interval_s=5.0, default_timeout_s=900),
+        portal_instance_id=portal,
+        tmp_name="cnk",
+    )
     inner = INNER_SCRIPT.format(
         event_id=EVENT_ID,
         keep_emails_list=sorted(KEEP_EMAILS),
         dry_run=not args.execute,
     )
-    stdout, stderr = run_in_portal(ssm, portal, inner)
-    events = parse_events(stdout)
+    result = transport.run_raw(inner, timeout_s=900, comment="polaris cleanup non-keepers")
+    events = parse_events(result.stdout)
 
     return _summarize_events(events, execute=args.execute)
 

--- a/scripts/polaris-aws-range/common.py
+++ b/scripts/polaris-aws-range/common.py
@@ -1,0 +1,474 @@
+"""Shared AWS/SSM helpers for the Polaris operator scripts (issue #691).
+
+Before this module existed, ``orchestrate_provisioning.py``,
+``cleanup_non_keepers.py``, and ``check_range_health.py`` each rolled their
+own boto3 session wiring, portal-instance discovery, SSM ``send_command``
+poll loop, Django-shell-via-SSM wrapper, and JSON-envelope parser.
+
+The seam belongs at the AWS transport / target boundary (per the
+``polaris-support-decomposition-preflight-691.md`` architecture note):
+
+- ``PolarisAwsContext`` — owns the boto3 session and per-service client
+  caching.
+- ``find_portal_instance`` — name-tag EC2 lookup of a portal host.
+- ``SsmExecutor`` — single-instance and batched SSM ``send_command`` /
+  ``get_command_invocation`` poll loop with shared retry rules.
+- ``PortalShellTransport`` — operator-side ``manage.py shell`` wrapper that
+  ships a Python snippet into the ``portal`` container via SSM and parses
+  the ``__JSON_START__``/``__JSON_END__`` envelope the in-container snippet
+  writes.
+- ``parse_json_envelope`` / ``mask_sensitive_output`` — pure helpers shared
+  across scripts that ingest SSM stdout.
+
+Provisioner-owned runtime mutation (Bedrock shard, splice watcher, DNS
+override, Kali key) does NOT belong here — it lives in
+``shifter/engine/provisioner/plans/polaris_range_bootstrap.py`` and runs via
+``SetupOrchestrator`` / ``SSMExecutor``. These helpers are for the operator
+fleet scripts that inspect, orchestrate, or remediate already-provisioned
+ranges.
+
+``SsmResult`` returns sanitized ``stdout`` / ``stderr`` strings — callers
+are expected to feed those through ``mask_sensitive_output`` before
+serializing them into status documents or error logs. No CTFd admin tokens,
+AWS credentials, participant credentials, static flags, or generated
+Bedrock secrets ever land in command argv or in the ``str()`` of an error
+raised from here.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+import boto3
+from botocore.exceptions import ClientError
+
+DEFAULT_REGION = "us-east-2"
+PORTAL_INSTANCE_TAG_NAME = "dev-portal-ec2"
+
+DEFAULT_JSON_START = "__JSON_START__"
+DEFAULT_JSON_END = "__JSON_END__"
+
+REDACTION = "***REDACTED***"
+
+
+# -----------------------------------------------------------------------------
+# Pure helpers
+# -----------------------------------------------------------------------------
+
+
+def parse_json_envelope(
+    stdout: str,
+    *,
+    start: str = DEFAULT_JSON_START,
+    end: str = DEFAULT_JSON_END,
+) -> Any:
+    """Return the JSON object delimited by ``start`` / ``end`` in ``stdout``.
+
+    Raises ``RuntimeError`` if either marker is missing or the body between
+    them isn't parseable JSON. Surrounding whitespace inside the envelope is
+    tolerated so callers can write Python that prints with a leading
+    newline.
+    """
+    start_at = stdout.find(start)
+    end_at = stdout.find(end)
+    if start_at == -1 or end_at == -1:
+        raise RuntimeError(
+            f"JSON markers missing in stdout (start={start!r}, end={end!r})"
+        )
+    block = stdout[start_at + len(start) : end_at].strip()
+    try:
+        return json.loads(block)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"bad JSON in payload: {exc}: {block[:500]}") from exc
+
+
+def mask_sensitive_output(text: str, secrets: Iterable[str | None]) -> str:
+    """Replace every non-empty entry in ``secrets`` with the redaction marker.
+
+    Used before any SSM output is written to status documents, error logs,
+    or printed to stdout. Empty / ``None`` secrets are silently skipped — an
+    empty needle would match everywhere and a ``None`` is treated as
+    "nothing to redact for this slot".
+    """
+    out = text
+    for secret in secrets:
+        if not secret:
+            continue
+        out = out.replace(secret, REDACTION)
+    return out
+
+
+# -----------------------------------------------------------------------------
+# AWS context
+# -----------------------------------------------------------------------------
+
+
+class PolarisAwsContext:
+    """boto3 session plus cached service clients.
+
+    The session is built lazily so dry-run paths that never touch AWS can
+    instantiate a context without credentials. ``profile`` follows the
+    boto3 chain when ``None``.
+
+    ``_session`` and ``_session_factory`` are test-only injection seams;
+    production callers should leave them at their defaults.
+    """
+
+    def __init__(
+        self,
+        *,
+        profile: str | None = None,
+        region: str = DEFAULT_REGION,
+        _session: Any | None = None,
+        _session_factory: Callable[..., Any] | None = None,
+    ) -> None:
+        self.profile = profile
+        self.region = region
+        self._cached_session = _session
+        self._session_factory = _session_factory or boto3.Session
+        self._clients: dict[str, Any] = {}
+
+    def session(self):
+        if self._cached_session is None:
+            self._cached_session = self._session_factory(
+                profile_name=self.profile,
+                region_name=self.region,
+            )
+        return self._cached_session
+
+    def client(self, service: str):
+        cached = self._clients.get(service)
+        if cached is not None:
+            return cached
+        cached = self.session().client(service)
+        self._clients[service] = cached
+        return cached
+
+    def ec2(self):
+        return self.client("ec2")
+
+    def ssm(self):
+        return self.client("ssm")
+
+
+# -----------------------------------------------------------------------------
+# Portal discovery
+# -----------------------------------------------------------------------------
+
+
+def find_portal_instance(ec2_client, *, name_tag: str = PORTAL_INSTANCE_TAG_NAME) -> str:
+    """Return the first running EC2 instance id tagged ``Name=<name_tag>``.
+
+    Existing operator behavior is "any running one" — multiple portal hosts
+    are interchangeable for SSM purposes. Raises if no running instance
+    matches; callers that want a specific instance should not use this.
+    """
+    resp = ec2_client.describe_instances(
+        Filters=[
+            {"Name": "tag:Name", "Values": [name_tag]},
+            {"Name": "instance-state-name", "Values": ["running"]},
+        ]
+    )
+    for reservation in resp.get("Reservations", []):
+        for instance in reservation.get("Instances", []):
+            return instance["InstanceId"]
+    raise RuntimeError(f"no running instance tagged Name={name_tag}")
+
+
+# -----------------------------------------------------------------------------
+# SSM execution
+# -----------------------------------------------------------------------------
+
+
+class SsmTimeout(RuntimeError):
+    """Raised when an SSM invocation does not reach a terminal state in time."""
+
+
+SSM_TERMINAL_STATUSES = ("Success", "Failed", "TimedOut", "Cancelled")
+
+
+@dataclass(frozen=True)
+class SsmResult:
+    """Sanitized SSM ``get_command_invocation`` outcome.
+
+    Carries only ``command_id``, ``instance_id``, ``status``, and the
+    ``stdout`` / ``stderr`` content. Callers that need to expose any of
+    these to a status doc should run the strings through
+    ``mask_sensitive_output`` first.
+    """
+
+    command_id: str
+    instance_id: str
+    status: str
+    stdout: str
+    stderr: str
+
+
+@dataclass
+class SsmExecutor:
+    """Thin shared wrapper over the SSM ``send_command`` / poll loop.
+
+    Single-instance ``run_bash`` / ``poll_invocation`` and batched
+    ``run_bash_batch`` collapse three near-duplicate copies of this loop
+    that previously lived in the operator scripts. The defaults match the
+    longest-running operator script (5-minute timeout, 3-second poll) so a
+    drop-in replacement does not change observable timing.
+    """
+
+    ssm_client: Any
+    poll_interval_s: float = 3.0
+    default_timeout_s: int = 300
+    poll_grace_s: int = 30
+    invocation_max_concurrency: str = "50"
+    invocation_max_errors: str = "100%"
+
+    def run_bash(
+        self,
+        instance_id: str,
+        script: str,
+        *,
+        timeout_s: int | None = None,
+        comment: str | None = None,
+    ) -> SsmResult:
+        """Run ``script`` on ``instance_id`` and wait for terminal status."""
+        timeout = timeout_s if timeout_s is not None else self.default_timeout_s
+        params: dict[str, Any] = {
+            "InstanceIds": [instance_id],
+            "DocumentName": "AWS-RunShellScript",
+            "Parameters": {
+                "commands": [script],
+                "executionTimeout": [str(timeout)],
+            },
+            "TimeoutSeconds": timeout,
+        }
+        if comment:
+            params["Comment"] = comment
+        resp = self.ssm_client.send_command(**params)
+        cmd_id = resp["Command"]["CommandId"]
+        result = self.poll_invocation(cmd_id, instance_id, timeout_s=timeout)
+        if result.status != "Success":
+            raise RuntimeError(
+                f"SSM command failed ({result.status}):\n"
+                f"stdout={result.stdout[-2000:]}\nstderr={result.stderr[-2000:]}"
+            )
+        return result
+
+    def poll_invocation(
+        self,
+        command_id: str,
+        instance_id: str,
+        *,
+        timeout_s: int,
+    ) -> SsmResult:
+        """Poll a single invocation until terminal or timeout."""
+        deadline = time.monotonic() + timeout_s + self.poll_grace_s
+        while True:
+            try:
+                inv = self.ssm_client.get_command_invocation(
+                    CommandId=command_id,
+                    InstanceId=instance_id,
+                )
+            except ClientError as exc:
+                if "InvocationDoesNotExist" in str(exc):
+                    if time.monotonic() >= deadline:
+                        raise SsmTimeout(
+                            f"SSM command {command_id} on {instance_id} did not "
+                            f"register before deadline"
+                        ) from exc
+                    self._sleep()
+                    continue
+                raise
+            if inv.get("Status") in SSM_TERMINAL_STATUSES:
+                return SsmResult(
+                    command_id=command_id,
+                    instance_id=instance_id,
+                    status=inv["Status"],
+                    stdout=inv.get("StandardOutputContent", "") or "",
+                    stderr=inv.get("StandardErrorContent", "") or "",
+                )
+            if time.monotonic() >= deadline:
+                raise SsmTimeout(
+                    f"SSM command {command_id} on {instance_id} did not finish "
+                    f"within deadline"
+                )
+            self._sleep()
+
+    def run_bash_batch(
+        self,
+        instance_ids: list[str],
+        script: str,
+        *,
+        timeout_s: int | None = None,
+        comment: str | None = None,
+    ) -> dict[str, SsmResult]:
+        """Run ``script`` on many instances and wait for all to settle.
+
+        Uses ``list_command_invocations`` for fan-out reads; the per-instance
+        ``SsmResult`` carries the plugin output (matches existing
+        ``check_range_health.py`` behavior).
+        """
+        timeout = timeout_s if timeout_s is not None else self.default_timeout_s
+        params: dict[str, Any] = {
+            "InstanceIds": instance_ids,
+            "DocumentName": "AWS-RunShellScript",
+            "Parameters": {
+                "commands": [script],
+                "executionTimeout": [str(timeout)],
+            },
+            "TimeoutSeconds": timeout,
+            "MaxConcurrency": self.invocation_max_concurrency,
+            "MaxErrors": self.invocation_max_errors,
+        }
+        if comment:
+            params["Comment"] = comment
+        resp = self.ssm_client.send_command(**params)
+        cmd_id = resp["Command"]["CommandId"]
+
+        terminal = set(SSM_TERMINAL_STATUSES)
+        deadline = time.monotonic() + timeout + self.poll_grace_s
+        requested = set(instance_ids)
+        results: dict[str, SsmResult] = {}
+        while True:
+            results = {}
+            paginator = self.ssm_client.get_paginator("list_command_invocations")
+            for page in paginator.paginate(CommandId=cmd_id, Details=True, MaxResults=50):
+                for inv in page.get("CommandInvocations", []):
+                    plugin_out = ""
+                    plugin_err = ""
+                    for plugin in inv.get("CommandPlugins") or []:
+                        plugin_out = plugin.get("Output", "") or plugin_out
+                        plugin_err = plugin.get("StandardErrorContent", "") or plugin_err
+                    results[inv["InstanceId"]] = SsmResult(
+                        command_id=cmd_id,
+                        instance_id=inv["InstanceId"],
+                        status=inv["Status"],
+                        stdout=plugin_out,
+                        stderr=plugin_err,
+                    )
+            missing = requested - set(results)
+            pending = [iid for iid, r in results.items() if r.status not in terminal]
+            if not missing and not pending:
+                return results
+            if time.monotonic() >= deadline:
+                raise SsmTimeout(
+                    f"SSM batch {cmd_id} did not finish for "
+                    f"{len(pending) + len(missing)} instance(s) within deadline"
+                )
+            self._sleep()
+
+    def _sleep(self) -> None:
+        if self.poll_interval_s > 0:
+            time.sleep(self.poll_interval_s)
+
+
+# -----------------------------------------------------------------------------
+# Django-shell-over-SSM transport
+# -----------------------------------------------------------------------------
+
+
+_PORTAL_SHELL_WRAPPER = r"""
+set -euo pipefail
+echo "$PY_B64" | base64 -d > /tmp/{tmp_name}.py
+sudo docker cp /tmp/{tmp_name}.py portal:/tmp/{tmp_name}.py
+sudo docker exec portal bash -c '
+  set -euo pipefail
+  while IFS= read -r -d "" kv; do export "$kv"; done < /proc/1/environ
+  cd /app
+  python manage.py shell < /tmp/{tmp_name}.py
+'
+sudo docker exec portal rm -f /tmp/{tmp_name}.py || true
+rm -f /tmp/{tmp_name}.py || true
+"""
+
+_TMP_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+@dataclass
+class PortalShellTransport:
+    """Run a Python snippet inside the ``portal`` container via SSM.
+
+    The snippet is base64-encoded and piped into ``python manage.py shell``
+    so command bodies never appear in process argv on the host. The snippet
+    is expected to emit a JSON envelope between the standard markers; the
+    transport returns the parsed object.
+
+    Callers that need raw stdout (e.g. cleanup_non_keepers' line-oriented
+    ``SHELL_EVENT|`` framing) should use ``executor.run_bash`` directly with
+    a hand-written wrapper instead.
+    """
+
+    executor: SsmExecutor
+    portal_instance_id: str
+    tmp_name: str = "orch"
+
+    def __post_init__(self) -> None:
+        if not _TMP_NAME_RE.fullmatch(self.tmp_name):
+            raise ValueError(
+                f"tmp_name must match {_TMP_NAME_RE.pattern!r}; got {self.tmp_name!r}"
+            )
+
+    def run_django(
+        self,
+        python_source: str,
+        *,
+        timeout_s: int = 300,
+        comment: str | None = None,
+        json_start: str = DEFAULT_JSON_START,
+        json_end: str = DEFAULT_JSON_END,
+    ) -> Any:
+        py_b64 = base64.b64encode(python_source.encode("utf-8")).decode("ascii")
+        wrapper = _PORTAL_SHELL_WRAPPER.format(tmp_name=self.tmp_name)
+        command = f"export PY_B64='{py_b64}'\n{wrapper}"
+        result = self.executor.run_bash(
+            self.portal_instance_id,
+            command,
+            timeout_s=timeout_s,
+            comment=comment,
+        )
+        return parse_json_envelope(result.stdout, start=json_start, end=json_end)
+
+    def run_raw(
+        self,
+        python_source: str,
+        *,
+        timeout_s: int = 300,
+        comment: str | None = None,
+    ) -> SsmResult:
+        """Same transport without envelope parsing; returns the raw SsmResult.
+
+        Used by scripts (cleanup_non_keepers) that emit line-oriented event
+        records instead of a single JSON object.
+        """
+        py_b64 = base64.b64encode(python_source.encode("utf-8")).decode("ascii")
+        wrapper = _PORTAL_SHELL_WRAPPER.format(tmp_name=self.tmp_name)
+        command = f"export PY_B64='{py_b64}'\n{wrapper}"
+        return self.executor.run_bash(
+            self.portal_instance_id,
+            command,
+            timeout_s=timeout_s,
+            comment=comment,
+        )
+
+
+# Re-exports for cross-script type hints.
+__all__ = [
+    "DEFAULT_JSON_END",
+    "DEFAULT_JSON_START",
+    "DEFAULT_REGION",
+    "PORTAL_INSTANCE_TAG_NAME",
+    "PolarisAwsContext",
+    "PortalShellTransport",
+    "REDACTION",
+    "SSM_TERMINAL_STATUSES",
+    "SsmExecutor",
+    "SsmResult",
+    "SsmTimeout",
+    "find_portal_instance",
+    "mask_sensitive_output",
+    "parse_json_envelope",
+]

--- a/scripts/polaris-aws-range/orchestrate_provisioning.py
+++ b/scripts/polaris-aws-range/orchestrate_provisioning.py
@@ -2,7 +2,7 @@
 """BSides Ottawa polaris provisioning orchestrator.
 
 Trigger / monitor / trigger loop for CTF participant ranges. Picks the
-next N unprovisioned participants, fires ``cms.services.create_range``
+next N unprovisioned participants, fires ``ctf.services.range.provision_participant_range``
 for each via the portal container's Django shell, waits for all to
 reach a terminal status (``ready`` or ``failed``), then does it again.
 
@@ -27,6 +27,11 @@ Reads AWS creds from the usual boto3 chain; pass ``--profile`` for a
 named profile. Uses SSM RunCommand against one portal EC2 instance to
 execute Django shell code inside the portal docker container.
 
+The state model lives in :mod:`provisioning_state`; the batch state
+machine and Django-shell snippets live in :mod:`provisioning_batch`;
+the AWS / SSM transport lives in :mod:`common`. This entrypoint just
+wires the CLI, picks the next batch, and runs the loop.
+
 Usage::
 
     # Dry run (lists next batch, exits)
@@ -46,713 +51,128 @@ Event ID is hard-coded to the BSides Ottawa event; override with
 from __future__ import annotations
 
 import argparse
-import base64
-import json
 import sys
 import time
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
-import boto3
-from botocore.exceptions import ClientError
+from common import PolarisAwsContext, PortalShellTransport, SsmExecutor, find_portal_instance
+from provisioning_batch import (
+    fetch_unprovisioned,
+    retry_failures,
+    run_one_batch,
+)
+from provisioning_state import State, load_state, now_iso, save_state, write_status_doc
 
 DEFAULT_EVENT_ID = "fa1988b5-18fc-41d3-b3ff-ee97b0549546"  # BSides Ottawa Polaris CTF
-PORTAL_INSTANCE_TAG_NAME = "dev-portal-ec2"  # we pick any running one
-CLUSTER = "dev-portal-pulumi"
 
 STATE_DIR = Path(__file__).resolve().parent
 STATUS_MD = STATE_DIR / "provisioning_status.md"
 STATE_JSON = STATE_DIR / "provisioning_state.json"
 
 
-# -----------------------------------------------------------------------------
-# Inner Django shell scripts (run inside portal container via SSM)
-# -----------------------------------------------------------------------------
-
-# Fetch next N participants that don't have a range yet, plus a count.
-FETCH_UNPROVISIONED_TEMPLATE = r"""
-import json
-from ctf.models import CTFParticipant
-
-EVENT_ID = "__EVENT_ID__"
-LIMIT = __LIMIT__
-EMAIL_REGEX = r"__EMAIL_REGEX__"
-
-qs = CTFParticipant.objects.filter(
-    event_id=EVENT_ID,
-    range_instance_id__isnull=True,
-).select_related("user")
-if EMAIL_REGEX:
-    qs = qs.filter(email__regex=EMAIL_REGEX)
-qs = qs.order_by("email")
-
-total_unprovisioned = qs.count()
-batch = list(qs[:LIMIT])
-
-out = {
-    "total_unprovisioned": total_unprovisioned,
-    "batch": [
-        {
-            "participant_id": str(p.id),
-            "email": p.email,
-            "name": p.name,
-            "user_id": p.user_id,
-        }
-        for p in batch
-    ],
-}
-print("__JSON_START__")
-print(json.dumps(out))
-print("__JSON_END__")
-"""
-
-
-# Trigger provisioning for a specific list of participant IDs. Returns
-# {participant_id: {"range_instance_id": "...", "status": "provisioning"}|{"error": "..."}}
-TRIGGER_TEMPLATE = r"""
-import json
-from ctf.services.range import provision_participant_range
-
-PARTICIPANT_IDS = __PIDS__
-
-out = {}
-for pid in PARTICIPANT_IDS:
-    try:
-        result = provision_participant_range(pid)
-        out[pid] = {"range_instance_id": result.get("range_instance_id"), "status": result.get("status")}
-    except Exception as e:
-        out[pid] = {"error": f"{type(e).__name__}: {e}"}
-
-print("__JSON_START__")
-print(json.dumps(out))
-print("__JSON_END__")
-"""
-
-
-# Poll Range status for a list of range instance IDs.
-STATUS_TEMPLATE = r"""
-import json
-from engine.models import Range
-
-RANGE_IDS = __RIDS__
-
-out = {}
-for rid in RANGE_IDS:
-    try:
-        r = Range.objects.get(pk=rid)
-        out[str(rid)] = {"status": r.status, "name": r.name or ""}
-    except Range.DoesNotExist:
-        out[str(rid)] = {"status": "missing"}
-    except Exception as e:
-        out[str(rid)] = {"error": f"{type(e).__name__}: {e}"}
-
-print("__JSON_START__")
-print(json.dumps(out))
-print("__JSON_END__")
-"""
-
-
-# -----------------------------------------------------------------------------
-# SSM bridge
-# -----------------------------------------------------------------------------
-
-SSM_WRAPPER = r"""
-set -euo pipefail
-echo "$PY_B64" | base64 -d > /tmp/orch.py
-sudo docker cp /tmp/orch.py portal:/tmp/orch.py
-sudo docker exec portal bash -c '
-  set -euo pipefail
-  while IFS= read -r -d "" kv; do export "$kv"; done < /proc/1/environ
-  cd /app
-  python manage.py shell < /tmp/orch.py
-'
-"""
-
-
-def run_django_shell(ssm_client, instance_id: str, python_script: str, timeout_s: int = 300) -> dict[str, Any]:
-    """Run a Django-shell snippet inside the portal container.
-
-    Parses a JSON block delimited by ``__JSON_START__`` / ``__JSON_END__``
-    from stdout. Returns the parsed object or raises RuntimeError.
-    """
-    py_b64 = base64.b64encode(python_script.encode("utf-8")).decode("ascii")
-    commands = [
-        f"export PY_B64='{py_b64}'",
-        SSM_WRAPPER,
-    ]
-    resp = ssm_client.send_command(
-        InstanceIds=[instance_id],
-        DocumentName="AWS-RunShellScript",
-        Parameters={"commands": ["\n".join(commands)], "executionTimeout": [str(timeout_s)]},
-        TimeoutSeconds=timeout_s,
-    )
-    cmd_id = resp["Command"]["CommandId"]
-
-    deadline = time.monotonic() + timeout_s + 30
-    while time.monotonic() < deadline:
-        time.sleep(3)
-        try:
-            r = ssm_client.get_command_invocation(CommandId=cmd_id, InstanceId=instance_id)
-        except ClientError as e:
-            if "InvocationDoesNotExist" in str(e):
-                continue
-            raise
-        status = r["Status"]
-        if status in ("Success", "Failed", "TimedOut", "Cancelled"):
-            stdout = r.get("StandardOutputContent", "")
-            stderr = r.get("StandardErrorContent", "")
-            if status != "Success":
-                raise RuntimeError(
-                    f"SSM command failed ({status}):\nstdout={stdout[-2000:]}\nstderr={stderr[-2000:]}"
-                )
-            # Parse JSON block
-            start = stdout.find("__JSON_START__")
-            end = stdout.find("__JSON_END__")
-            if start == -1 or end == -1:
-                raise RuntimeError(f"JSON markers missing in stdout: {stdout[-2000:]}")
-            block = stdout[start + len("__JSON_START__") : end].strip()
-            try:
-                return json.loads(block)
-            except json.JSONDecodeError as e:
-                raise RuntimeError(f"bad JSON in payload: {e}: {block[:500]}") from e
-    raise RuntimeError(f"SSM command {cmd_id} did not finish within deadline")
-
-
-# -----------------------------------------------------------------------------
-# Status doc & state persistence
-# -----------------------------------------------------------------------------
-
-
-def now_iso() -> str:
-    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
-
-
-@dataclass
-class ParticipantOutcome:
-    participant_id: str
-    email: str
-    name: str
-    range_instance_id: str | None = None
-    status: str = "pending"  # pending|triggered|ready|failed|trigger_error
-    error: str | None = None
-    batch_num: int = 0
-    started_at: str = ""
-    finished_at: str = ""
-
-
-@dataclass
-class State:
-    started_at: str = ""
-    finished_at: str = ""
-    total_participants: int = 0
-    batches_completed: int = 0
-    outcomes: dict[str, ParticipantOutcome] = field(default_factory=dict)
-    halted: bool = False
-    halt_reason: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "started_at": self.started_at,
-            "finished_at": self.finished_at,
-            "total_participants": self.total_participants,
-            "batches_completed": self.batches_completed,
-            "halted": self.halted,
-            "halt_reason": self.halt_reason,
-            "outcomes": {pid: vars(o) for pid, o in self.outcomes.items()},
-        }
-
-    @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> "State":
-        s = cls(
-            started_at=d.get("started_at", ""),
-            finished_at=d.get("finished_at", ""),
-            total_participants=d.get("total_participants", 0),
-            batches_completed=d.get("batches_completed", 0),
-            halted=d.get("halted", False),
-            halt_reason=d.get("halt_reason", ""),
-        )
-        for pid, raw in (d.get("outcomes") or {}).items():
-            s.outcomes[pid] = ParticipantOutcome(**raw)
-        return s
-
-
-def save_state(state: State) -> None:
-    STATE_JSON.write_text(json.dumps(state.to_dict(), indent=2))
-
-
-def load_state() -> State:
-    if STATE_JSON.exists():
-        try:
-            return State.from_dict(json.loads(STATE_JSON.read_text()))
-        except Exception:
-            pass
-    return State(started_at=now_iso())
-
-
-def write_status_doc(state: State, current_batch_log: list[str]) -> None:
-    lines: list[str] = []
-    lines.append("# Polaris provisioning status")
-    lines.append("")
-    lines.append(f"- started: {state.started_at}")
-    if state.finished_at:
-        lines.append(f"- finished: {state.finished_at}")
-    lines.append(f"- batches completed: {state.batches_completed}")
-    lines.append(f"- participants tracked: {len(state.outcomes)}")
-    if state.halted:
-        lines.append(f"- **HALTED**: {state.halt_reason}")
-    by_status: dict[str, int] = {}
-    for o in state.outcomes.values():
-        by_status[o.status] = by_status.get(o.status, 0) + 1
-    if by_status:
-        lines.append("")
-        lines.append("## Outcome tally")
-        for k, v in sorted(by_status.items()):
-            lines.append(f"- {k}: {v}")
-    # Failures table
-    failures = [o for o in state.outcomes.values() if o.status in ("failed", "trigger_error")]
-    if failures:
-        lines.append("")
-        lines.append("## Failures")
-        lines.append("| batch | email | status | error |")
-        lines.append("|---|---|---|---|")
-        pipe = "\\|"
-        for o in sorted(failures, key=lambda x: (x.batch_num, x.email)):
-            err_cell = (o.error or "")[:200].replace("|", pipe)
-            lines.append(f"| {o.batch_num} | {o.email} | {o.status} | {err_cell} |")
-    if current_batch_log:
-        lines.append("")
-        lines.append("## Current / last batch log")
-        lines.extend("- " + x for x in current_batch_log)
-    STATUS_MD.write_text("\n".join(lines) + "\n")
-
-
-# -----------------------------------------------------------------------------
-# Orchestration
-# -----------------------------------------------------------------------------
-
-
-def find_portal_instance(ec2_client) -> str:
-    """Pick any running instance tagged Name=dev-portal-ec2."""
-    resp = ec2_client.describe_instances(
-        Filters=[
-            {"Name": "tag:Name", "Values": [PORTAL_INSTANCE_TAG_NAME]},
-            {"Name": "instance-state-name", "Values": ["running"]},
-        ]
-    )
-    for reservation in resp["Reservations"]:
-        for inst in reservation["Instances"]:
-            return inst["InstanceId"]
-    raise RuntimeError(f"no running instance tagged Name={PORTAL_INSTANCE_TAG_NAME}")
-
-
-def fetch_unprovisioned(ssm, instance_id: str, event_id: str, limit: int, email_regex: str) -> dict[str, Any]:
-    script = (
-        FETCH_UNPROVISIONED_TEMPLATE.replace("__EVENT_ID__", event_id)
-        .replace("__LIMIT__", str(limit))
-        .replace("__EMAIL_REGEX__", email_regex)
-    )
-    return run_django_shell(ssm, instance_id, script, timeout_s=120)
-
-
-def trigger_batch(ssm, instance_id: str, participant_ids: list[str]) -> dict[str, dict]:
-    script = TRIGGER_TEMPLATE.replace("__PIDS__", json.dumps(participant_ids))
-    return run_django_shell(ssm, instance_id, script, timeout_s=300)
-
-
-def check_range_status(ssm, instance_id: str, range_ids: list[str]) -> dict[str, dict]:
-    if not range_ids:
-        return {}
-    script = STATUS_TEMPLATE.replace("__RIDS__", json.dumps(range_ids))
-    return run_django_shell(ssm, instance_id, script, timeout_s=120)
-
-
-def log_line(msgs: list[str], line: str) -> None:
-    ts = now_iso()
-    formatted = f"{ts} {line}"
-    print(formatted, flush=True)
-    msgs.append(formatted)
-
-
-def wait_for_ec2_launch(
-    ec2_client, range_ids: list[str], log: list[str], timeout_s: int = 300, poll_interval_s: int = 20
-) -> dict[str, int]:
-    """Wait until every range has at least 2 running/pending EC2 instances.
-
-    Returns {range_id: instance_count}. If timeout hits with some ranges
-    short, returns what it has.
-    """
-    if not range_ids:
-        return {}
-    deadline = time.monotonic() + timeout_s
-    counts: dict[str, int] = {}
-    while time.monotonic() < deadline:
-        counts = {rid: 0 for rid in range_ids}
-        resp = ec2_client.describe_instances(
-            Filters=[
-                {"Name": "tag:shifter:range_id", "Values": range_ids},
-                {"Name": "instance-state-name", "Values": ["pending", "running"]},
-            ]
-        )
-        for r in resp["Reservations"]:
-            for inst in r["Instances"]:
-                for tag in inst.get("Tags") or []:
-                    if tag["Key"] == "shifter:range_id":
-                        counts[tag["Value"]] = counts.get(tag["Value"], 0) + 1
-        short = [rid for rid, n in counts.items() if n < 2]
-        log_line(log, f"    EC2 gate: {sum(1 for n in counts.values() if n >= 2)}/{len(range_ids)} ranges have >=2 instances")
-        if not short:
-            return counts
-        time.sleep(poll_interval_s)
-    log_line(log, f"    EC2 gate TIMEOUT: still short {len(short)} range(s): {short}")
-    return counts
-
-
-def _register_initial_outcomes(state: State, batch: list[dict], batch_num: int) -> None:
-    """Record per-participant `triggered` outcomes before the trigger call."""
-    started = now_iso()
-    for p in batch:
-        pid = p["participant_id"]
-        state.outcomes[pid] = ParticipantOutcome(
-            participant_id=pid,
-            email=p["email"],
-            name=p["name"],
-            status="triggered",
-            batch_num=batch_num,
-            started_at=started,
-        )
-
-
-def _record_trigger_results(state: State, batch: list[dict], trig: dict, current: list[str]) -> list[str]:
-    """Stamp trigger outcomes onto state; return the list of successful range ids."""
-    range_ids: list[str] = []
-    for p in batch:
-        pid = p["participant_id"]
-        tres = trig.get(pid, {})
-        if "error" in tres:
-            state.outcomes[pid].status = "trigger_error"
-            state.outcomes[pid].error = tres["error"]
-            state.outcomes[pid].finished_at = now_iso()
-            log_line(current, f"  [TRIGGER FAIL] {p['email']}: {tres['error']}")
-            continue
-        rid = tres.get("range_instance_id")
-        if rid is None:
-            state.outcomes[pid].status = "trigger_error"
-            state.outcomes[pid].error = "no range_instance_id returned"
-            state.outcomes[pid].finished_at = now_iso()
-            log_line(current, f"  [TRIGGER FAIL] {p['email']}: no range_id")
-            continue
-        state.outcomes[pid].range_instance_id = str(rid)
-        range_ids.append(str(rid))
-        log_line(current, f"  [TRIGGERED] {p['email']}: range={rid}")
-    return range_ids
-
-
-def _finalize_batch_outcomes(
-    state: State, batch: list[dict], terminal: dict[str, str]
-) -> tuple[int, int]:
-    """Translate per-range terminal statuses into outcome counts (successes, failures)."""
-    successes = failures = 0
-    for p in batch:
-        pid = p["participant_id"]
-        o = state.outcomes[pid]
-        if o.status == "trigger_error":
-            failures += 1
-            continue
-        rid = o.range_instance_id
-        if rid is None:
-            continue
-        s = terminal.get(rid, "unknown")
-        o.finished_at = now_iso()
-        if s == "ready":
-            o.status = "ready"
-            successes += 1
-        else:
-            o.status = "failed"
-            o.error = f"terminal range status={s}"
-            failures += 1
-    return successes, failures
-
-
-def _run_wave_ec2_mode(
-    state: State,
-    batch: list[dict],
-    range_ids: list[str],
-    args: argparse.Namespace,
-    ec2,
-    current: list[str],
-    batch_num: int,
-) -> tuple[int, int]:
-    """Wave mode: trigger, wait for EC2 launch, return so the next wave can trigger."""
-    log_line(
-        current,
-        f"wave mode: waiting up to {args.wave_gate_timeout}s for {len(range_ids)} ranges to launch EC2",
-    )
-    wait_for_ec2_launch(
-        ec2,
-        range_ids,
-        current,
-        timeout_s=args.wave_gate_timeout,
-        poll_interval_s=args.wave_gate_poll,
-    )
-    successes = failures = 0
-    for p in batch:
-        o = state.outcomes[p["participant_id"]]
-        if o.status == "trigger_error":
-            failures += 1
-            continue
-        o.status = "triggered"
-        o.finished_at = now_iso()
-        successes += 1
-    save_state(state)
-    write_status_doc(state, current)
-    log_line(
-        current, f"wave {batch_num} EC2-gated: triggered={successes} trigger_errors={failures}"
-    )
-    return successes, failures
-
-
-def _run_sleep_only_mode(
-    state: State,
-    batch: list[dict],
-    args: argparse.Namespace,
-    current: list[str],
-    batch_num: int,
-) -> tuple[int, int]:
-    """Sleep-only mode: trust observed provisioning time, skip DB polling."""
-    wait_s = args.sleep_only * 60
-    log_line(current, f"sleep-only mode: waiting {args.sleep_only} min before next batch")
-    time.sleep(wait_s)
-    successes = failures = 0
-    for p in batch:
-        o = state.outcomes[p["participant_id"]]
-        if o.status == "trigger_error":
-            failures += 1
-            continue
-        o.status = "ready"
-        o.finished_at = now_iso()
-        successes += 1
-    save_state(state)
-    write_status_doc(state, current)
-    log_line(
-        current, f"batch {batch_num} assumed-ready: successes={successes} failures={failures}"
-    )
-    return successes, failures
-
-
-def _wait_for_terminal(
-    ssm, instance_id: str, range_ids: list[str], args: argparse.Namespace, current: list[str]
-) -> dict[str, str]:
-    """Poll until every range reaches a terminal state or batch_timeout elapses."""
-    log_line(current, f"waiting for {len(range_ids)} range(s) to reach terminal state...")
-    deadline = time.monotonic() + args.batch_timeout * 60
-    terminal: dict[str, str] = {}
-    pending = list(range_ids)
-    while pending and time.monotonic() < deadline:
-        time.sleep(args.poll_interval)
-        statuses = check_range_status(ssm, instance_id, pending)
-        still_pending: list[str] = []
-        for rid in pending:
-            s = statuses.get(rid, {}).get("status", "?")
-            if s in ("ready", "failed", "destroyed", "missing"):
-                terminal[rid] = s
-                log_line(current, f"  [{s.upper():8}] range={rid}")
-            else:
-                still_pending.append(rid)
-        pending = still_pending
-        if pending:
-            log_line(current, f"  still pending: {len(pending)}")
-    for rid in pending:
-        terminal[rid] = "timeout"
-    return terminal
-
-
-def run_one_batch(
-    ssm, ec2, instance_id: str, state: State, batch_num: int, args: argparse.Namespace
-) -> tuple[int, int]:
-    """Trigger the next batch, wait for terminal state, record outcomes.
-
-    Returns (successes, failures) for this batch.
-    """
-    current: list[str] = []
-    log_line(current, f"=== batch {batch_num}: fetch up to {args.batch_size} unprovisioned ===")
-
-    fetched = fetch_unprovisioned(
-        ssm, instance_id, args.event_id, args.batch_size, args.email_regex
-    )
-    batch = fetched["batch"]
-    log_line(
-        current,
-        f"unprovisioned remaining: {fetched['total_unprovisioned']}; batch size: {len(batch)}",
-    )
-    if not batch:
-        return (0, 0)
-
-    _register_initial_outcomes(state, batch, batch_num)
-    save_state(state)
-    write_status_doc(state, current)
-
-    pids = [p["participant_id"] for p in batch]
-    log_line(current, f"triggering provision for pids: {pids}")
-    trig = trigger_batch(ssm, instance_id, pids)
-
-    range_ids = _record_trigger_results(state, batch, trig, current)
-    save_state(state)
-    write_status_doc(state, current)
-
-    if not range_ids:
-        log_line(current, "no ranges triggered successfully; skipping wait")
-        return (
-            0,
-            sum(1 for p in batch if state.outcomes[p["participant_id"]].status == "trigger_error"),
-        )
-
-    if args.wave_ec2_gate:
-        return _run_wave_ec2_mode(state, batch, range_ids, args, ec2, current, batch_num)
-
-    if args.sleep_only > 0:
-        return _run_sleep_only_mode(state, batch, args, current, batch_num)
-
-    terminal = _wait_for_terminal(ssm, instance_id, range_ids, args, current)
-    successes, failures = _finalize_batch_outcomes(state, batch, terminal)
-    save_state(state)
-    write_status_doc(state, current)
-    log_line(current, f"batch {batch_num} done: successes={successes} failures={failures}")
-    return successes, failures
-
-
-def _trigger_retry_and_collect_range_ids(
-    state: State, retry_pids: list[str], ssm, instance_id: str
-) -> list[str]:
-    """Re-trigger provision for `retry_pids`; mutate state and return ranges to wait on."""
-    trig = trigger_batch(ssm, instance_id, retry_pids)
-    range_ids: list[str] = []
-    for pid in retry_pids:
-        t = trig.get(pid, {})
-        if "error" in t:
-            state.outcomes[pid].status = "trigger_error"
-            state.outcomes[pid].error = t["error"]
-            state.outcomes[pid].finished_at = now_iso()
-            continue
-        rid = t.get("range_instance_id")
-        if rid:
-            state.outcomes[pid].range_instance_id = str(rid)
-            range_ids.append(str(rid))
-    return range_ids
-
-
-def _finalize_retry_outcomes(
-    state: State, retry_pids: list[str], terminal: dict[str, str]
-) -> None:
-    """Map terminal range statuses back onto the retry participants."""
-    for pid in retry_pids:
-        o = state.outcomes[pid]
-        if o.status == "trigger_error":
-            continue
-        rid = o.range_instance_id
-        s = terminal.get(rid, "unknown")
-        o.finished_at = now_iso()
-        if s == "ready":
-            o.status = "ready"
-        else:
-            o.status = "failed"
-            o.error = f"retry terminal status={s}"
-
-
-def retry_failures(
-    ssm, ec2, instance_id: str, state: State, args: argparse.Namespace
-) -> None:
-    """One retry pass for participants stuck at failed / trigger_error."""
-    failed = [o for o in state.outcomes.values() if o.status in ("failed", "trigger_error")]
-    if not failed:
-        return
-
-    current: list[str] = []
-    log_line(current, f"=== retry pass: {len(failed)} participant(s) ===")
-
-    # Before retry, the DB may already have range_instance_id set on some
-    # participants (partial provision). Skip those by re-querying.
-    fetched = fetch_unprovisioned(
-        ssm, instance_id, args.event_id, limit=len(failed) + 5, email_regex=args.email_regex
-    )
-    still_unprovisioned = {p["participant_id"] for p in fetched["batch"]}
-    retry_pids = [
-        o.participant_id for o in failed if o.participant_id in still_unprovisioned
-    ]
-    log_line(current, f"retry pids (after DB re-check): {retry_pids}")
-
-    if not retry_pids:
-        log_line(current, "no retries needed; failures already recovered")
-        write_status_doc(state, current)
-        return
-
-    for pid in retry_pids:
-        state.outcomes[pid].status = "retrying"
-        state.outcomes[pid].error = None
-    save_state(state)
-    write_status_doc(state, current)
-
-    range_ids = _trigger_retry_and_collect_range_ids(state, retry_pids, ssm, instance_id)
-    save_state(state)
-    write_status_doc(state, current)
-
-    if range_ids:
-        log_line(current, f"waiting on {len(range_ids)} retry range(s)...")
-        terminal = _wait_for_terminal(ssm, instance_id, range_ids, args, current)
-        _finalize_retry_outcomes(state, retry_pids, terminal)
-
-    save_state(state)
-    write_status_doc(state, current)
-
-
 def parse_args() -> argparse.Namespace:
-    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     p.add_argument("--profile", help="AWS profile (Account A / portal). Default: boto3 chain.")
     p.add_argument("--region", default="us-east-2")
     p.add_argument("--event-id", default=DEFAULT_EVENT_ID)
     p.add_argument("--batch-size", type=int, default=10)
-    p.add_argument("--batch-fail-threshold", type=int, default=4, help="Halt if single batch has this many failures.")
-    p.add_argument("--total-fail-threshold", type=int, default=10, help="Halt if cumulative failures reach this.")
-    p.add_argument("--batch-timeout", type=int, default=60, help="Per-batch max wait for terminal state (minutes).")
-    p.add_argument("--poll-interval", type=int, default=60, help="Seconds between Range.status polls.")
+    p.add_argument(
+        "--batch-fail-threshold",
+        type=int,
+        default=4,
+        help="Halt if single batch has this many failures.",
+    )
+    p.add_argument(
+        "--total-fail-threshold",
+        type=int,
+        default=10,
+        help="Halt if cumulative failures reach this.",
+    )
+    p.add_argument(
+        "--batch-timeout",
+        type=int,
+        default=60,
+        help="Per-batch max wait for terminal state (minutes).",
+    )
+    p.add_argument(
+        "--poll-interval", type=int, default=60, help="Seconds between Range.status polls."
+    )
     p.add_argument(
         "--sleep-only",
         type=int,
         default=0,
-        help="If >0, skip Range.status polling and simply sleep this many minutes after triggering each batch before moving on. More reliable when Range.status updates lag behind actual provisioning completion. Verification happens at the end via a separate tool.",
+        help=(
+            "If >0, skip Range.status polling and simply sleep this many minutes after triggering "
+            "each batch before moving on. More reliable when Range.status updates lag behind actual "
+            "provisioning completion. Verification happens at the end via a separate tool."
+        ),
     )
     p.add_argument(
         "--wave-ec2-gate",
         action="store_true",
-        help="After triggering a wave, move to the next wave as soon as each range has EC2 instances launched (pending/running). Pipelines waves so many can provision concurrently. Overrides --sleep-only.",
+        help=(
+            "After triggering a wave, move to the next wave as soon as each range has EC2 instances "
+            "launched (pending/running). Pipelines waves so many can provision concurrently. "
+            "Overrides --sleep-only."
+        ),
     )
-    p.add_argument("--wave-gate-timeout", type=int, default=300, help="Seconds to wait for EC2 launch per wave.")
-    p.add_argument("--wave-gate-poll", type=int, default=20, help="Seconds between EC2 gate polls.")
-    p.add_argument("--final-wait", type=int, default=25, help="Minutes to sleep after triggering the last wave before finishing.")
-    p.add_argument("--max-batches", type=int, default=20, help="Hard cap on batches (safety).")
+    p.add_argument(
+        "--wave-gate-timeout",
+        type=int,
+        default=300,
+        help="Seconds to wait for EC2 launch per wave.",
+    )
+    p.add_argument(
+        "--wave-gate-poll", type=int, default=20, help="Seconds between EC2 gate polls."
+    )
+    p.add_argument(
+        "--final-wait",
+        type=int,
+        default=25,
+        help="Minutes to sleep after triggering the last wave before finishing.",
+    )
+    p.add_argument(
+        "--max-batches", type=int, default=20, help="Hard cap on batches (safety)."
+    )
     p.add_argument(
         "--email-regex",
         default=r"^meetup\+\d+@bsidesottawa\.ca$",
         help="Only consider CTF participants whose email matches this regex. Empty = no filter.",
     )
-    p.add_argument("--dry-run", action="store_true", help="Show what the first batch would be and exit.")
-    p.add_argument("--yes", action="store_true", help="Skip the pre-flight confirmation prompt.")
+    p.add_argument(
+        "--dry-run", action="store_true", help="Show what the first batch would be and exit."
+    )
+    p.add_argument(
+        "--yes", action="store_true", help="Skip the pre-flight confirmation prompt."
+    )
     return p.parse_args()
 
 
 def _run_batch_loop(
-    ssm, ec2, instance_id: str, state: State, args: argparse.Namespace
+    transport: PortalShellTransport,
+    ec2,
+    state: State,
+    args: argparse.Namespace,
 ) -> int:
     """Run batches until the queue empties, a threshold trips, or max_batches hits."""
     total_failures = sum(
         1 for o in state.outcomes.values() if o.status in ("failed", "trigger_error")
     )
     for batch_num in range(state.batches_completed + 1, args.max_batches + 1):
-        succ, fail = run_one_batch(ssm, ec2, instance_id, state, batch_num, args)
+        succ, fail = run_one_batch(
+            transport,
+            ec2,
+            state,
+            batch_num,
+            args,
+            state_path=STATE_JSON,
+            status_md_path=STATUS_MD,
+        )
         state.batches_completed = batch_num
         total_failures += fail
-        save_state(state)
+        save_state(state, STATE_JSON)
 
         if succ == 0 and fail == 0:
             break
@@ -774,18 +194,18 @@ def _run_batch_loop(
 
 def main() -> int:
     args = parse_args()
-    session = boto3.Session(profile_name=args.profile, region_name=args.region)
-    ec2 = session.client("ec2")
-    ssm = session.client("ssm")
+    ctx = PolarisAwsContext(profile=args.profile, region=args.region)
+    ec2 = ctx.ec2()
+    executor = SsmExecutor(ctx.ssm())
 
     instance_id = find_portal_instance(ec2)
     print(f"portal instance: {instance_id}")
+    transport = PortalShellTransport(executor=executor, portal_instance_id=instance_id, tmp_name="orch")
 
-    first = fetch_unprovisioned(
-        ssm, instance_id, args.event_id, args.batch_size, args.email_regex
-    )
+    first = fetch_unprovisioned(transport, args.event_id, args.batch_size, args.email_regex)
     print(
-        f"unprovisioned: {first['total_unprovisioned']} total; next batch of {len(first['batch'])}:"
+        f"unprovisioned: {first['total_unprovisioned']} total; "
+        f"next batch of {len(first['batch'])}:"
     )
     for p in first["batch"]:
         print(f"  {p['email']}  (participant_id={p['participant_id']}, user_id={p['user_id']})")
@@ -805,25 +225,31 @@ def main() -> int:
             print("aborted.")
             return 1
 
-    state = load_state()
+    state = load_state(STATE_JSON)
     if not state.started_at:
         state.started_at = now_iso()
     state.total_participants = first["total_unprovisioned"] + sum(
         1 for o in state.outcomes.values() if o.status == "ready"
     )
-    save_state(state)
+    save_state(state, STATE_JSON)
 
-    _run_batch_loop(ssm, ec2, instance_id, state, args)
+    _run_batch_loop(transport, ec2, state, args)
 
     if args.wave_ec2_gate and args.final_wait > 0 and not state.halted:
         print(f"final wait: {args.final_wait} min to let last wave finish provisioning...")
         time.sleep(args.final_wait * 60)
 
-    retry_failures(ssm, ec2, instance_id, state, args)
+    retry_failures(
+        transport,
+        state,
+        args,
+        state_path=STATE_JSON,
+        status_md_path=STATUS_MD,
+    )
 
     state.finished_at = now_iso()
-    save_state(state)
-    write_status_doc(state, [])
+    save_state(state, STATE_JSON)
+    write_status_doc(state, [], status_md_path=STATUS_MD)
     print(f"DONE. halted={state.halted} reason={state.halt_reason!r}")
     print(f"state: {STATE_JSON}")
     print(f"status: {STATUS_MD}")

--- a/scripts/polaris-aws-range/provisioning_batch.py
+++ b/scripts/polaris-aws-range/provisioning_batch.py
@@ -1,0 +1,574 @@
+"""Polaris provisioning batch state machine (issue #691).
+
+Extracted from ``orchestrate_provisioning.py`` so ``run_one_batch`` and
+its supporting helpers can be edited in isolation from the CLI entrypoint.
+
+The portal-side Django-shell snippets (``FETCH_UNPROVISIONED_TEMPLATE``,
+``TRIGGER_TEMPLATE``, ``STATUS_TEMPLATE``) live here too because they
+travel with the orchestration logic that knows how to interpret their
+output. They run through :mod:`common.PortalShellTransport` so the SSM
+wrapper, base64 indirection, and JSON envelope parsing are not
+re-implemented in this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from common import PortalShellTransport
+from provisioning_state import (
+    ParticipantOutcome,
+    State,
+    now_iso,
+    save_state,
+    write_status_doc,
+)
+
+
+# -----------------------------------------------------------------------------
+# Inner Django shell scripts (run inside portal container via SSM)
+# -----------------------------------------------------------------------------
+
+# Fetch next N participants that don't have a range yet, plus a count.
+FETCH_UNPROVISIONED_TEMPLATE = r"""
+import json
+from ctf.models import CTFParticipant
+
+EVENT_ID = "__EVENT_ID__"
+LIMIT = __LIMIT__
+EMAIL_REGEX = r"__EMAIL_REGEX__"
+
+qs = CTFParticipant.objects.filter(
+    event_id=EVENT_ID,
+    range_instance_id__isnull=True,
+).select_related("user")
+if EMAIL_REGEX:
+    qs = qs.filter(email__regex=EMAIL_REGEX)
+qs = qs.order_by("email")
+
+total_unprovisioned = qs.count()
+batch = list(qs[:LIMIT])
+
+out = {
+    "total_unprovisioned": total_unprovisioned,
+    "batch": [
+        {
+            "participant_id": str(p.id),
+            "email": p.email,
+            "name": p.name,
+            "user_id": p.user_id,
+        }
+        for p in batch
+    ],
+}
+print("__JSON_START__")
+print(json.dumps(out))
+print("__JSON_END__")
+"""
+
+
+# Trigger provisioning for a specific list of participant IDs. Returns
+# {participant_id: {"range_instance_id": "...", "status": "provisioning"}|{"error": "..."}}
+TRIGGER_TEMPLATE = r"""
+import json
+from ctf.services.range import provision_participant_range
+
+PARTICIPANT_IDS = __PIDS__
+
+out = {}
+for pid in PARTICIPANT_IDS:
+    try:
+        result = provision_participant_range(pid)
+        out[pid] = {"range_instance_id": result.get("range_instance_id"), "status": result.get("status")}
+    except Exception as e:
+        out[pid] = {"error": f"{type(e).__name__}: {e}"}
+
+print("__JSON_START__")
+print(json.dumps(out))
+print("__JSON_END__")
+"""
+
+
+# Poll Range status for a list of range instance IDs.
+STATUS_TEMPLATE = r"""
+import json
+from engine.models import Range
+
+RANGE_IDS = __RIDS__
+
+out = {}
+for rid in RANGE_IDS:
+    try:
+        r = Range.objects.get(pk=rid)
+        out[str(rid)] = {"status": r.status, "name": r.name or ""}
+    except Range.DoesNotExist:
+        out[str(rid)] = {"status": "missing"}
+    except Exception as e:
+        out[str(rid)] = {"error": f"{type(e).__name__}: {e}"}
+
+print("__JSON_START__")
+print(json.dumps(out))
+print("__JSON_END__")
+"""
+
+
+# -----------------------------------------------------------------------------
+# Portal Django-shell wrappers
+# -----------------------------------------------------------------------------
+
+
+def fetch_unprovisioned(
+    transport: PortalShellTransport, event_id: str, limit: int, email_regex: str
+) -> dict[str, Any]:
+    script = (
+        FETCH_UNPROVISIONED_TEMPLATE.replace("__EVENT_ID__", event_id)
+        .replace("__LIMIT__", str(limit))
+        .replace("__EMAIL_REGEX__", email_regex)
+    )
+    return transport.run_django(script, timeout_s=120)
+
+
+def trigger_batch(
+    transport: PortalShellTransport, participant_ids: list[str]
+) -> dict[str, dict]:
+    script = TRIGGER_TEMPLATE.replace("__PIDS__", json.dumps(participant_ids))
+    return transport.run_django(script, timeout_s=300)
+
+
+def check_range_status(
+    transport: PortalShellTransport, range_ids: list[str]
+) -> dict[str, dict]:
+    if not range_ids:
+        return {}
+    script = STATUS_TEMPLATE.replace("__RIDS__", json.dumps(range_ids))
+    return transport.run_django(script, timeout_s=120)
+
+
+# -----------------------------------------------------------------------------
+# Status logging
+# -----------------------------------------------------------------------------
+
+
+def log_line(msgs: list[str], line: str) -> None:
+    ts = now_iso()
+    formatted = f"{ts} {line}"
+    print(formatted, flush=True)
+    msgs.append(formatted)
+
+
+# -----------------------------------------------------------------------------
+# EC2 launch gate
+# -----------------------------------------------------------------------------
+
+
+def wait_for_ec2_launch(
+    ec2_client,
+    range_ids: list[str],
+    log: list[str],
+    timeout_s: int = 300,
+    poll_interval_s: int = 20,
+) -> dict[str, int]:
+    """Wait until every range has at least 2 running/pending EC2 instances.
+
+    Returns ``{range_id: instance_count}``. If timeout hits with some ranges
+    short, returns what it has.
+    """
+    if not range_ids:
+        return {}
+    deadline = time.monotonic() + timeout_s
+    counts: dict[str, int] = {}
+    short: list[str] = []
+    while time.monotonic() < deadline:
+        counts = {rid: 0 for rid in range_ids}
+        resp = ec2_client.describe_instances(
+            Filters=[
+                {"Name": "tag:shifter:range_id", "Values": range_ids},
+                {"Name": "instance-state-name", "Values": ["pending", "running"]},
+            ]
+        )
+        for r in resp["Reservations"]:
+            for inst in r["Instances"]:
+                for tag in inst.get("Tags") or []:
+                    if tag["Key"] == "shifter:range_id":
+                        counts[tag["Value"]] = counts.get(tag["Value"], 0) + 1
+        short = [rid for rid, n in counts.items() if n < 2]
+        log_line(
+            log,
+            f"    EC2 gate: {sum(1 for n in counts.values() if n >= 2)}/{len(range_ids)} ranges have >=2 instances",
+        )
+        if not short:
+            return counts
+        time.sleep(poll_interval_s)
+    log_line(log, f"    EC2 gate TIMEOUT: still short {len(short)} range(s): {short}")
+    return counts
+
+
+# -----------------------------------------------------------------------------
+# Per-batch state transitions
+# -----------------------------------------------------------------------------
+
+
+def _register_initial_outcomes(state: State, batch: list[dict], batch_num: int) -> None:
+    """Record per-participant ``triggered`` outcomes before the trigger call."""
+    started = now_iso()
+    for p in batch:
+        pid = p["participant_id"]
+        state.outcomes[pid] = ParticipantOutcome(
+            participant_id=pid,
+            email=p["email"],
+            name=p["name"],
+            status="triggered",
+            batch_num=batch_num,
+            started_at=started,
+        )
+
+
+def _record_trigger_results(
+    state: State, batch: list[dict], trig: dict, current: list[str]
+) -> list[str]:
+    """Stamp trigger outcomes onto state; return the list of successful range ids."""
+    range_ids: list[str] = []
+    for p in batch:
+        pid = p["participant_id"]
+        tres = trig.get(pid, {})
+        if "error" in tres:
+            state.outcomes[pid].status = "trigger_error"
+            state.outcomes[pid].error = tres["error"]
+            state.outcomes[pid].finished_at = now_iso()
+            log_line(current, f"  [TRIGGER FAIL] {p['email']}: {tres['error']}")
+            continue
+        rid = tres.get("range_instance_id")
+        if rid is None:
+            state.outcomes[pid].status = "trigger_error"
+            state.outcomes[pid].error = "no range_instance_id returned"
+            state.outcomes[pid].finished_at = now_iso()
+            log_line(current, f"  [TRIGGER FAIL] {p['email']}: no range_id")
+            continue
+        state.outcomes[pid].range_instance_id = str(rid)
+        range_ids.append(str(rid))
+        log_line(current, f"  [TRIGGERED] {p['email']}: range={rid}")
+    return range_ids
+
+
+def _finalize_batch_outcomes(
+    state: State, batch: list[dict], terminal: dict[str, str]
+) -> tuple[int, int]:
+    """Translate per-range terminal statuses into outcome counts (successes, failures)."""
+    successes = failures = 0
+    for p in batch:
+        pid = p["participant_id"]
+        o = state.outcomes[pid]
+        if o.status == "trigger_error":
+            failures += 1
+            continue
+        rid = o.range_instance_id
+        if rid is None:
+            continue
+        s = terminal.get(rid, "unknown")
+        o.finished_at = now_iso()
+        if s == "ready":
+            o.status = "ready"
+            successes += 1
+        else:
+            o.status = "failed"
+            o.error = f"terminal range status={s}"
+            failures += 1
+    return successes, failures
+
+
+# -----------------------------------------------------------------------------
+# Wave-mode helpers
+# -----------------------------------------------------------------------------
+
+
+def _run_wave_ec2_mode(
+    state: State,
+    batch: list[dict],
+    range_ids: list[str],
+    args: argparse.Namespace,
+    ec2,
+    current: list[str],
+    batch_num: int,
+    *,
+    state_path: Path,
+    status_md_path: Path,
+) -> tuple[int, int]:
+    """Wave mode: trigger, wait for EC2 launch, return so the next wave can trigger."""
+    log_line(
+        current,
+        f"wave mode: waiting up to {args.wave_gate_timeout}s for {len(range_ids)} ranges to launch EC2",
+    )
+    wait_for_ec2_launch(
+        ec2,
+        range_ids,
+        current,
+        timeout_s=args.wave_gate_timeout,
+        poll_interval_s=args.wave_gate_poll,
+    )
+    successes = failures = 0
+    for p in batch:
+        o = state.outcomes[p["participant_id"]]
+        if o.status == "trigger_error":
+            failures += 1
+            continue
+        o.status = "triggered"
+        o.finished_at = now_iso()
+        successes += 1
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+    log_line(
+        current, f"wave {batch_num} EC2-gated: triggered={successes} trigger_errors={failures}"
+    )
+    return successes, failures
+
+
+def _run_sleep_only_mode(
+    state: State,
+    batch: list[dict],
+    args: argparse.Namespace,
+    current: list[str],
+    batch_num: int,
+    *,
+    state_path: Path,
+    status_md_path: Path,
+) -> tuple[int, int]:
+    """Sleep-only mode: trust observed provisioning time, skip DB polling."""
+    wait_s = args.sleep_only * 60
+    log_line(current, f"sleep-only mode: waiting {args.sleep_only} min before next batch")
+    time.sleep(wait_s)
+    successes = failures = 0
+    for p in batch:
+        o = state.outcomes[p["participant_id"]]
+        if o.status == "trigger_error":
+            failures += 1
+            continue
+        o.status = "ready"
+        o.finished_at = now_iso()
+        successes += 1
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+    log_line(
+        current, f"batch {batch_num} assumed-ready: successes={successes} failures={failures}"
+    )
+    return successes, failures
+
+
+def _wait_for_terminal(
+    transport: PortalShellTransport,
+    range_ids: list[str],
+    args: argparse.Namespace,
+    current: list[str],
+) -> dict[str, str]:
+    """Poll until every range reaches a terminal state or batch_timeout elapses."""
+    log_line(current, f"waiting for {len(range_ids)} range(s) to reach terminal state...")
+    deadline = time.monotonic() + args.batch_timeout * 60
+    terminal: dict[str, str] = {}
+    pending = list(range_ids)
+    while pending and time.monotonic() < deadline:
+        time.sleep(args.poll_interval)
+        statuses = check_range_status(transport, pending)
+        still_pending: list[str] = []
+        for rid in pending:
+            s = statuses.get(rid, {}).get("status", "?")
+            if s in ("ready", "failed", "destroyed", "missing"):
+                terminal[rid] = s
+                log_line(current, f"  [{s.upper():8}] range={rid}")
+            else:
+                still_pending.append(rid)
+        pending = still_pending
+        if pending:
+            log_line(current, f"  still pending: {len(pending)}")
+    for rid in pending:
+        terminal[rid] = "timeout"
+    return terminal
+
+
+# -----------------------------------------------------------------------------
+# Public batch entrypoints
+# -----------------------------------------------------------------------------
+
+
+def run_one_batch(
+    transport: PortalShellTransport,
+    ec2,
+    state: State,
+    batch_num: int,
+    args: argparse.Namespace,
+    *,
+    state_path: Path,
+    status_md_path: Path,
+) -> tuple[int, int]:
+    """Trigger the next batch, wait for terminal state, record outcomes.
+
+    Returns ``(successes, failures)`` for this batch.
+    """
+    current: list[str] = []
+    log_line(current, f"=== batch {batch_num}: fetch up to {args.batch_size} unprovisioned ===")
+
+    fetched = fetch_unprovisioned(transport, args.event_id, args.batch_size, args.email_regex)
+    batch = fetched["batch"]
+    log_line(
+        current,
+        f"unprovisioned remaining: {fetched['total_unprovisioned']}; batch size: {len(batch)}",
+    )
+    if not batch:
+        return (0, 0)
+
+    _register_initial_outcomes(state, batch, batch_num)
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+
+    pids = [p["participant_id"] for p in batch]
+    log_line(current, f"triggering provision for pids: {pids}")
+    trig = trigger_batch(transport, pids)
+
+    range_ids = _record_trigger_results(state, batch, trig, current)
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+
+    if not range_ids:
+        log_line(current, "no ranges triggered successfully; skipping wait")
+        return (
+            0,
+            sum(1 for p in batch if state.outcomes[p["participant_id"]].status == "trigger_error"),
+        )
+
+    if args.wave_ec2_gate:
+        return _run_wave_ec2_mode(
+            state,
+            batch,
+            range_ids,
+            args,
+            ec2,
+            current,
+            batch_num,
+            state_path=state_path,
+            status_md_path=status_md_path,
+        )
+
+    if args.sleep_only > 0:
+        return _run_sleep_only_mode(
+            state,
+            batch,
+            args,
+            current,
+            batch_num,
+            state_path=state_path,
+            status_md_path=status_md_path,
+        )
+
+    terminal = _wait_for_terminal(transport, range_ids, args, current)
+    successes, failures = _finalize_batch_outcomes(state, batch, terminal)
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+    log_line(current, f"batch {batch_num} done: successes={successes} failures={failures}")
+    return successes, failures
+
+
+def _trigger_retry_and_collect_range_ids(
+    state: State,
+    retry_pids: list[str],
+    transport: PortalShellTransport,
+) -> list[str]:
+    """Re-trigger provision for ``retry_pids``; mutate state and return ranges to wait on."""
+    trig = trigger_batch(transport, retry_pids)
+    range_ids: list[str] = []
+    for pid in retry_pids:
+        t = trig.get(pid, {})
+        if "error" in t:
+            state.outcomes[pid].status = "trigger_error"
+            state.outcomes[pid].error = t["error"]
+            state.outcomes[pid].finished_at = now_iso()
+            continue
+        rid = t.get("range_instance_id")
+        if rid:
+            state.outcomes[pid].range_instance_id = str(rid)
+            range_ids.append(str(rid))
+    return range_ids
+
+
+def _finalize_retry_outcomes(
+    state: State, retry_pids: list[str], terminal: dict[str, str]
+) -> None:
+    """Map terminal range statuses back onto the retry participants."""
+    for pid in retry_pids:
+        o = state.outcomes[pid]
+        if o.status == "trigger_error":
+            continue
+        rid = o.range_instance_id
+        s = terminal.get(rid, "unknown")
+        o.finished_at = now_iso()
+        if s == "ready":
+            o.status = "ready"
+        else:
+            o.status = "failed"
+            o.error = f"retry terminal status={s}"
+
+
+def retry_failures(
+    transport: PortalShellTransport,
+    state: State,
+    args: argparse.Namespace,
+    *,
+    state_path: Path,
+    status_md_path: Path,
+) -> None:
+    """One retry pass for participants stuck at failed / trigger_error."""
+    failed = [o for o in state.outcomes.values() if o.status in ("failed", "trigger_error")]
+    if not failed:
+        return
+
+    current: list[str] = []
+    log_line(current, f"=== retry pass: {len(failed)} participant(s) ===")
+
+    # Before retry, the DB may already have range_instance_id set on some
+    # participants (partial provision). Skip those by re-querying.
+    fetched = fetch_unprovisioned(
+        transport, args.event_id, limit=len(failed) + 5, email_regex=args.email_regex
+    )
+    still_unprovisioned = {p["participant_id"] for p in fetched["batch"]}
+    retry_pids = [
+        o.participant_id for o in failed if o.participant_id in still_unprovisioned
+    ]
+    log_line(current, f"retry pids (after DB re-check): {retry_pids}")
+
+    if not retry_pids:
+        log_line(current, "no retries needed; failures already recovered")
+        write_status_doc(state, current, status_md_path=status_md_path)
+        return
+
+    for pid in retry_pids:
+        state.outcomes[pid].status = "retrying"
+        state.outcomes[pid].error = None
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+
+    range_ids = _trigger_retry_and_collect_range_ids(state, retry_pids, transport)
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+
+    if range_ids:
+        log_line(current, f"waiting on {len(range_ids)} retry range(s)...")
+        terminal = _wait_for_terminal(transport, range_ids, args, current)
+        _finalize_retry_outcomes(state, retry_pids, terminal)
+
+    save_state(state, state_path)
+    write_status_doc(state, current, status_md_path=status_md_path)
+
+
+__all__ = [
+    "FETCH_UNPROVISIONED_TEMPLATE",
+    "STATUS_TEMPLATE",
+    "TRIGGER_TEMPLATE",
+    "check_range_status",
+    "fetch_unprovisioned",
+    "log_line",
+    "retry_failures",
+    "run_one_batch",
+    "trigger_batch",
+    "wait_for_ec2_launch",
+]

--- a/scripts/polaris-aws-range/provisioning_state.py
+++ b/scripts/polaris-aws-range/provisioning_state.py
@@ -1,0 +1,157 @@
+"""Polaris provisioning state data model and IO (issue #691).
+
+Extracted from ``orchestrate_provisioning.py`` so the orchestrator
+entrypoint stays a thin CLI wrapper and the persisted-state contract has a
+single owner.
+
+The state lives in two artifacts:
+
+- ``provisioning_state.json`` — machine-readable; resumable across runs.
+- ``provisioning_status.md`` — human-readable running log written every
+  time an outcome flips.
+
+Both paths are caller-provided so callers can keep their current
+script-local defaults without this module hard-coding them.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def now_iso() -> str:
+    """ISO-8601 UTC timestamp matching the existing operator-script format."""
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+@dataclass
+class ParticipantOutcome:
+    """Per-participant tracking record for one provisioning batch."""
+
+    participant_id: str
+    email: str
+    name: str
+    range_instance_id: str | None = None
+    status: str = "pending"  # pending|triggered|ready|failed|trigger_error|retrying
+    error: str | None = None
+    batch_num: int = 0
+    started_at: str = ""
+    finished_at: str = ""
+
+
+@dataclass
+class State:
+    """Aggregate provisioning state across all batches."""
+
+    started_at: str = ""
+    finished_at: str = ""
+    total_participants: int = 0
+    batches_completed: int = 0
+    outcomes: dict[str, ParticipantOutcome] = field(default_factory=dict)
+    halted: bool = False
+    halt_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "total_participants": self.total_participants,
+            "batches_completed": self.batches_completed,
+            "halted": self.halted,
+            "halt_reason": self.halt_reason,
+            "outcomes": {pid: vars(o) for pid, o in self.outcomes.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "State":
+        s = cls(
+            started_at=d.get("started_at", ""),
+            finished_at=d.get("finished_at", ""),
+            total_participants=d.get("total_participants", 0),
+            batches_completed=d.get("batches_completed", 0),
+            halted=d.get("halted", False),
+            halt_reason=d.get("halt_reason", ""),
+        )
+        for pid, raw in (d.get("outcomes") or {}).items():
+            s.outcomes[pid] = ParticipantOutcome(**raw)
+        return s
+
+
+def save_state(state: State, path: Path) -> None:
+    path.write_text(json.dumps(state.to_dict(), indent=2))
+
+
+def load_state(path: Path) -> State:
+    if path.exists():
+        try:
+            return State.from_dict(json.loads(path.read_text()))
+        except Exception:
+            # Corrupt or partially-written state — treat as fresh so the
+            # caller's run can recover. The DB is authoritative for what's
+            # already provisioned; the json is diagnostic.
+            pass
+    return State(started_at=now_iso())
+
+
+def write_status_doc(
+    state: State,
+    current_batch_log: list[str],
+    *,
+    status_md_path: Path,
+) -> None:
+    """Render a markdown summary of ``state`` to ``status_md_path``.
+
+    Failure rows escape ``|`` characters so the markdown table renders even
+    when an exception message contains pipes.
+    """
+    lines: list[str] = []
+    lines.append("# Polaris provisioning status")
+    lines.append("")
+    lines.append(f"- started: {state.started_at}")
+    if state.finished_at:
+        lines.append(f"- finished: {state.finished_at}")
+    lines.append(f"- batches completed: {state.batches_completed}")
+    lines.append(f"- participants tracked: {len(state.outcomes)}")
+    if state.halted:
+        lines.append(f"- **HALTED**: {state.halt_reason}")
+
+    by_status: dict[str, int] = {}
+    for o in state.outcomes.values():
+        by_status[o.status] = by_status.get(o.status, 0) + 1
+    if by_status:
+        lines.append("")
+        lines.append("## Outcome tally")
+        for k, v in sorted(by_status.items()):
+            lines.append(f"- {k}: {v}")
+
+    failures = [o for o in state.outcomes.values() if o.status in ("failed", "trigger_error")]
+    if failures:
+        lines.append("")
+        lines.append("## Failures")
+        lines.append("| batch | email | status | error |")
+        lines.append("|---|---|---|---|")
+        pipe = r"\|"
+        for o in sorted(failures, key=lambda x: (x.batch_num, x.email)):
+            err_cell = (o.error or "")[:200].replace("|", pipe)
+            lines.append(f"| {o.batch_num} | {o.email} | {o.status} | {err_cell} |")
+
+    if current_batch_log:
+        lines.append("")
+        lines.append("## Current / last batch log")
+        lines.extend("- " + x for x in current_batch_log)
+
+    status_md_path.write_text("\n".join(lines) + "\n")
+
+
+__all__ = [
+    "ParticipantOutcome",
+    "State",
+    "load_state",
+    "now_iso",
+    "save_state",
+    "write_status_doc",
+]

--- a/scripts/polaris-aws-range/range_health.py
+++ b/scripts/polaris-aws-range/range_health.py
@@ -1,0 +1,317 @@
+"""Polaris range health-check data model + IO (issue #691).
+
+Extracted from ``check_range_health.py`` so the script becomes a thin CLI
+over (a) ``common.SsmExecutor`` for the SSM fan-out and (b) this module
+for target discovery, the per-host pipe-delimited record parser, the
+issue-detection model, and the markdown report writer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+from botocore.exceptions import ClientError
+
+EXPECTED_CONTAINER_COUNT = 22
+FLAG_CRITICAL_CONTAINERS = ("a5-scada", "a9-splice", "a0-website", "a14-kali")
+KALI_ENV_KEYS = (
+    "CLAUDE_CODE_USE_BEDROCK",
+    "AWS_REGION",
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
+)
+
+POLARIS_AMI_SSM_PARAM = "/shifter/ami/polaris-vm"
+
+# Bash run on each polaris-vm. Emits key=value|key=value|... record to stdout.
+# Boolean-ish fields use 1/0; string fields are space-free tokens. The pipe
+# format keeps the parser trivial and avoids any string-quoting failure
+# modes that have bitten richer envelopes in the past.
+HEALTH_PROBE_SCRIPT = r"""#!/bin/bash
+set -u
+
+out=""
+add() { out="${out}${out:+|}${1}=${2}"; }
+
+# host identity
+add host "$(hostname)"
+inst_id=$(curl -s --max-time 3 -H "X-aws-ec2-metadata-token: $(curl -s --max-time 3 -X PUT -H 'X-aws-ec2-metadata-token-ttl-seconds: 60' http://169.254.169.254/latest/api/token)" http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null || echo "?")
+add instance_id "$inst_id"
+
+# docker container count
+running=$(sudo docker ps -q | wc -l | tr -d ' ')
+add container_count "$running"
+exited=$(sudo docker ps -a --filter status=exited --filter status=dead --format '{{.Names}}' | paste -sd, - )
+exited=${exited:-none}
+add exited_containers "$exited"
+
+# a14-kali container running
+kali_state=$(sudo docker inspect -f '{{.State.Status}}' a14-kali 2>/dev/null || echo missing)
+add a14_state "$kali_state"
+
+# a14-kali on splice-link?
+if [[ "$kali_state" == "running" ]]; then
+  on_splice=$(sudo docker inspect a14-kali --format '{{json .NetworkSettings.Networks}}' 2>/dev/null | grep -q 'splice-link' && echo 1 || echo 0)
+else
+  on_splice=0
+fi
+add a14_on_splice "$on_splice"
+
+# a14-kali profile.d file
+if [[ "$kali_state" == "running" ]]; then
+  profile_ok=$(sudo docker exec a14-kali test -r /etc/profile.d/claude-bedrock.sh && echo 1 || echo 0)
+else
+  profile_ok=0
+fi
+add bedrock_profile "$profile_ok"
+
+# presence of each required env key (no values, just 1/0)
+if [[ "$profile_ok" == "1" ]]; then
+  for key in CLAUDE_CODE_USE_BEDROCK AWS_REGION ANTHROPIC_MODEL ANTHROPIC_SMALL_FAST_MODEL; do
+    present=$(sudo docker exec a14-kali grep -q "^export ${key}=" /etc/profile.d/claude-bedrock.sh && echo 1 || echo 0)
+    add "env_${key}" "$present"
+  done
+  # static keys are only set for Account B shards — don't require them
+  has_ak=$(sudo docker exec a14-kali grep -q '^export AWS_ACCESS_KEY_ID=' /etc/profile.d/claude-bedrock.sh && echo 1 || echo 0)
+  add env_AWS_ACCESS_KEY_ID "$has_ak"
+else
+  for key in CLAUDE_CODE_USE_BEDROCK AWS_REGION ANTHROPIC_MODEL ANTHROPIC_SMALL_FAST_MODEL AWS_ACCESS_KEY_ID; do
+    add "env_${key}" 0
+  done
+fi
+
+# /etc/hosts entry
+if [[ "$kali_state" == "running" ]]; then
+  hosts_ok=$(sudo docker exec a14-kali grep -q 'bedrock-runtime.us-east-2.amazonaws.com' /etc/hosts && echo 1 || echo 0)
+else
+  hosts_ok=0
+fi
+add hosts_override "$hosts_ok"
+
+# splice watcher systemd
+sv_state=$(systemctl is-active polaris-splice-watcher.service 2>/dev/null || echo missing)
+add splice_watcher "$sv_state"
+
+# flag-critical containers
+for name in a5-scada a9-splice a0-website; do
+  state=$(sudo docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo missing)
+  add "${name//-/_}_state" "$state"
+done
+
+echo "__RECORD__${out}__END__"
+"""
+
+
+@dataclass(frozen=True)
+class Target:
+    """Identifying info for one polaris-vm EC2 instance."""
+
+    instance_id: str
+    vpc_id: str
+    name: str
+    range_id: str
+    user_id: str
+
+
+@dataclass
+class RangeReport:
+    """Per-instance health report assembled from a parsed bash record."""
+
+    instance_id: str
+    range_id: str
+    user_id: str
+    fields: dict[str, str]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues()
+
+    def issues(self) -> list[str]:
+        probs: list[str] = []
+        probs.extend(self._container_count_issue())
+        probs.extend(self._exited_containers_issue())
+        probs.extend(self._a14_kali_issues())
+        probs.extend(self._bedrock_env_issues())
+        probs.extend(self._splice_watcher_issue())
+        probs.extend(self._other_container_state_issues())
+        return probs
+
+    def _container_count_issue(self) -> list[str]:
+        cc = self.fields.get("container_count", "?")
+        if cc != str(EXPECTED_CONTAINER_COUNT):
+            return [f"container_count={cc}/{EXPECTED_CONTAINER_COUNT}"]
+        return []
+
+    def _exited_containers_issue(self) -> list[str]:
+        ex = self.fields.get("exited_containers", "")
+        if ex and ex != "none":
+            return [f"exited=[{ex}]"]
+        return []
+
+    def _a14_kali_issues(self) -> list[str]:
+        probs: list[str] = []
+        if self.fields.get("a14_state") != "running":
+            probs.append(f"a14-kali={self.fields.get('a14_state')}")
+        if self.fields.get("a14_on_splice") == "1":
+            probs.append("a14 still on splice-link (watcher didn't disconnect)")
+        return probs
+
+    def _bedrock_env_issues(self) -> list[str]:
+        probs: list[str] = []
+        if self.fields.get("bedrock_profile") != "1":
+            probs.append("missing /etc/profile.d/claude-bedrock.sh")
+        for k in KALI_ENV_KEYS:
+            if self.fields.get(f"env_{k}") != "1":
+                probs.append(f"missing env {k}")
+        if self.fields.get("hosts_override") != "1":
+            probs.append("missing /etc/hosts bedrock-runtime entry")
+        return probs
+
+    def _splice_watcher_issue(self) -> list[str]:
+        sw = self.fields.get("splice_watcher")
+        if sw != "active":
+            return [f"splice-watcher={sw}"]
+        return []
+
+    def _other_container_state_issues(self) -> list[str]:
+        probs: list[str] = []
+        for name in ("a5_scada_state", "a9_splice_state", "a0_website_state"):
+            if self.fields.get(name) != "running":
+                probs.append(f"{name.replace('_state', '')}={self.fields.get(name)}")
+        return probs
+
+
+def parse_record(stdout: str) -> dict[str, str]:
+    """Parse the ``__RECORD__k=v|k=v__END__`` envelope written by the bash probe."""
+    start = stdout.find("__RECORD__")
+    end = stdout.find("__END__")
+    if start == -1 or end == -1:
+        return {}
+    body = stdout[start + len("__RECORD__") : end]
+    out: dict[str, str] = {}
+    for part in body.split("|"):
+        if "=" in part:
+            k, v = part.split("=", 1)
+            out[k] = v
+    return out
+
+
+def resolve_polaris_ami_id(ssm_client, *, parameter_name: str = POLARIS_AMI_SSM_PARAM) -> str:
+    try:
+        resp = ssm_client.get_parameter(Name=parameter_name)
+    except ClientError as e:
+        raise SystemExit(f"failed to read SSM {parameter_name}: {e}") from e
+    return resp["Parameter"]["Value"]
+
+
+def discover_targets(ec2_client, ami_id: str, vpc_id: str | None) -> list[Target]:
+    filters = [
+        {"Name": "image-id", "Values": [ami_id]},
+        {"Name": "instance-state-name", "Values": ["running"]},
+    ]
+    if vpc_id:
+        filters.append({"Name": "vpc-id", "Values": [vpc_id]})
+    targets: list[Target] = []
+    paginator = ec2_client.get_paginator("describe_instances")
+    for page in paginator.paginate(Filters=filters):
+        for reservation in page["Reservations"]:
+            for inst in reservation["Instances"]:
+                tags = {t["Key"]: t["Value"] for t in (inst.get("Tags") or [])}
+                targets.append(
+                    Target(
+                        instance_id=inst["InstanceId"],
+                        vpc_id=inst["VpcId"],
+                        name=tags.get("Name", ""),
+                        range_id=tags.get("shifter:range_id", ""),
+                        user_id=tags.get("shifter:user_id", ""),
+                    )
+                )
+    return targets
+
+
+def batched(seq: list[str], size: int) -> Iterable[list[str]]:
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
+def write_report(
+    targets: list[Target],
+    reports: list[RangeReport],
+    out_path: Path,
+    verbose: bool,
+) -> None:
+    ok = [r for r in reports if r.ok]
+    bad = [r for r in reports if not r.ok]
+
+    lines: list[str] = []
+    lines.append("# Polaris range health report")
+    lines.append("")
+    now_utc = datetime.now(tz=timezone.utc).replace(microsecond=0)
+    now_edt = now_utc - timedelta(hours=4)
+    lines.append(f"Generated: {now_utc.isoformat()} / {now_edt.strftime('%H:%M EDT')}")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"- Discovered polaris-vm ranges: {len(targets)}")
+    lines.append(f"- Checked: {len(reports)}")
+    lines.append(f"- Healthy: **{len(ok)}**")
+    lines.append(f"- With issues: **{len(bad)}**")
+    lines.append(f"- Unreachable (SSM failure): {len(targets) - len(reports)}")
+    lines.append("")
+
+    if bad:
+        lines.append("## Issues")
+        lines.append("")
+        lines.append("| range | user | instance | problems |")
+        lines.append("|---|---|---|---|")
+        for r in sorted(
+            bad,
+            key=lambda x: (int(x.range_id) if x.range_id.isdigit() else 999, x.instance_id),
+        ):
+            probs = "; ".join(r.issues())
+            lines.append(f"| {r.range_id} | {r.user_id} | {r.instance_id} | {probs} |")
+        lines.append("")
+    else:
+        lines.append("## Issues")
+        lines.append("")
+        lines.append("None. 🟢")
+        lines.append("")
+
+    if verbose:
+        lines.append("## All ranges")
+        lines.append("")
+        lines.append("| range | user | instance | ok | containers | a14 | splice-watcher | shard model |")
+        lines.append("|---|---|---|---|---|---|---|---|")
+        for r in sorted(
+            reports,
+            key=lambda x: (int(x.range_id) if x.range_id.isdigit() else 999, x.instance_id),
+        ):
+            ok_m = "🟢" if r.ok else "🔴"
+            cc = r.fields.get("container_count", "?")
+            a14 = r.fields.get("a14_state", "?")
+            sw = r.fields.get("splice_watcher", "?")
+            lines.append(
+                f"| {r.range_id} | {r.user_id} | {r.instance_id} | {ok_m} | {cc}/22 | {a14} | {sw} | - |"
+            )
+        lines.append("")
+
+    out_path.write_text("\n".join(lines) + "\n")
+
+
+__all__ = [
+    "EXPECTED_CONTAINER_COUNT",
+    "FLAG_CRITICAL_CONTAINERS",
+    "HEALTH_PROBE_SCRIPT",
+    "KALI_ENV_KEYS",
+    "POLARIS_AMI_SSM_PARAM",
+    "RangeReport",
+    "Target",
+    "batched",
+    "discover_targets",
+    "parse_record",
+    "resolve_polaris_ami_id",
+    "write_report",
+]

--- a/scripts/polaris-aws-range/test_common.py
+++ b/scripts/polaris-aws-range/test_common.py
@@ -1,0 +1,408 @@
+"""Tests for the shared Polaris AWS operator helpers (issue #691).
+
+Run from this directory:
+    python3 -m unittest test_common -v
+
+The scripts import sibling modules by bare name, so the directory must be on
+sys.path; running with ``-m unittest`` from here satisfies that.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from botocore.exceptions import ClientError
+
+from common import (
+    PORTAL_INSTANCE_TAG_NAME,
+    PolarisAwsContext,
+    PortalShellTransport,
+    SsmExecutor,
+    SsmResult,
+    SsmTimeout,
+    find_portal_instance,
+    mask_sensitive_output,
+    parse_json_envelope,
+)
+
+
+# -----------------------------------------------------------------------------
+# parse_json_envelope
+# -----------------------------------------------------------------------------
+
+
+class ParseJsonEnvelopeTests(unittest.TestCase):
+    def test_returns_parsed_object_between_default_markers(self) -> None:
+        stdout = 'noise\n__JSON_START__{"a": 1, "b": [2, 3]}__JSON_END__\nmore noise'
+
+        self.assertEqual(parse_json_envelope(stdout), {"a": 1, "b": [2, 3]})
+
+    def test_tolerates_whitespace_inside_envelope(self) -> None:
+        stdout = "x\n__JSON_START__\n   {\"k\": \"v\"}   \n__JSON_END__\n"
+
+        self.assertEqual(parse_json_envelope(stdout), {"k": "v"})
+
+    def test_raises_when_markers_missing(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "JSON markers missing"):
+            parse_json_envelope("no markers here")
+
+    def test_raises_when_only_one_marker_present(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "JSON markers missing"):
+            parse_json_envelope("__JSON_START__{}")
+
+    def test_raises_on_malformed_json(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "bad JSON"):
+            parse_json_envelope("__JSON_START__{not json}__JSON_END__")
+
+    def test_supports_custom_markers(self) -> None:
+        stdout = "__RECORD__[1,2,3]__END__"
+
+        self.assertEqual(
+            parse_json_envelope(stdout, start="__RECORD__", end="__END__"),
+            [1, 2, 3],
+        )
+
+
+# -----------------------------------------------------------------------------
+# mask_sensitive_output
+# -----------------------------------------------------------------------------
+
+
+class MaskSensitiveOutputTests(unittest.TestCase):
+    def test_redacts_known_secret(self) -> None:
+        masked = mask_sensitive_output("token=super-secret abc", ["super-secret"])
+
+        self.assertEqual(masked, "token=***REDACTED*** abc")
+
+    def test_redacts_multiple_secrets(self) -> None:
+        masked = mask_sensitive_output(
+            "AWS_SECRET=abc CTFD_TOKEN=def",
+            ["abc", "def"],
+        )
+
+        self.assertEqual(masked, "AWS_SECRET=***REDACTED*** CTFD_TOKEN=***REDACTED***")
+
+    def test_no_secrets_returns_input_unchanged(self) -> None:
+        self.assertEqual(mask_sensitive_output("hello world", []), "hello world")
+
+    def test_empty_secret_is_ignored(self) -> None:
+        # An empty string would match everywhere; never substitute it.
+        self.assertEqual(
+            mask_sensitive_output("hello", ["", "world"]),
+            "hello",
+        )
+
+    def test_handles_none_in_iterable(self) -> None:
+        self.assertEqual(
+            mask_sensitive_output("hello secret", [None, "secret"]),  # type: ignore[list-item]
+            "hello ***REDACTED***",
+        )
+
+
+# -----------------------------------------------------------------------------
+# find_portal_instance
+# -----------------------------------------------------------------------------
+
+
+class FindPortalInstanceTests(unittest.TestCase):
+    def test_returns_first_running_instance_id(self) -> None:
+        ec2 = MagicMock()
+        ec2.describe_instances.return_value = {
+            "Reservations": [
+                {"Instances": [{"InstanceId": "i-aaa"}, {"InstanceId": "i-bbb"}]},
+            ],
+        }
+
+        self.assertEqual(find_portal_instance(ec2), "i-aaa")
+        ec2.describe_instances.assert_called_once()
+        kwargs = ec2.describe_instances.call_args.kwargs
+        # Confirms the filter pins on Name tag + running state.
+        filters = {f["Name"]: f["Values"] for f in kwargs["Filters"]}
+        self.assertEqual(filters["tag:Name"], [PORTAL_INSTANCE_TAG_NAME])
+        self.assertEqual(filters["instance-state-name"], ["running"])
+
+    def test_raises_when_no_instances(self) -> None:
+        ec2 = MagicMock()
+        ec2.describe_instances.return_value = {"Reservations": []}
+
+        with self.assertRaisesRegex(RuntimeError, "no running instance"):
+            find_portal_instance(ec2)
+
+    def test_supports_custom_tag(self) -> None:
+        ec2 = MagicMock()
+        ec2.describe_instances.return_value = {
+            "Reservations": [{"Instances": [{"InstanceId": "i-xyz"}]}],
+        }
+
+        self.assertEqual(find_portal_instance(ec2, name_tag="my-portal"), "i-xyz")
+        filters = {f["Name"]: f["Values"] for f in ec2.describe_instances.call_args.kwargs["Filters"]}
+        self.assertEqual(filters["tag:Name"], ["my-portal"])
+
+
+# -----------------------------------------------------------------------------
+# SsmExecutor
+# -----------------------------------------------------------------------------
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": code}}, "GetCommandInvocation")
+
+
+class SsmExecutorTests(unittest.TestCase):
+    def test_run_bash_round_trip_success(self) -> None:
+        ssm = MagicMock()
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
+        ssm.get_command_invocation.return_value = {
+            "Status": "Success",
+            "StandardOutputContent": "ok-out",
+            "StandardErrorContent": "",
+        }
+        executor = SsmExecutor(ssm, poll_interval_s=0)
+
+        result = executor.run_bash("i-1", "echo hi", timeout_s=30)
+
+        self.assertIsInstance(result, SsmResult)
+        self.assertEqual(result.command_id, "cmd-1")
+        self.assertEqual(result.instance_id, "i-1")
+        self.assertEqual(result.status, "Success")
+        self.assertEqual(result.stdout, "ok-out")
+        self.assertEqual(result.stderr, "")
+        ssm.send_command.assert_called_once()
+
+    def test_run_bash_raises_on_terminal_failure(self) -> None:
+        ssm = MagicMock()
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-2"}}
+        ssm.get_command_invocation.return_value = {
+            "Status": "Failed",
+            "StandardOutputContent": "out",
+            "StandardErrorContent": "err",
+        }
+        executor = SsmExecutor(ssm, poll_interval_s=0)
+
+        with self.assertRaisesRegex(RuntimeError, "SSM command failed .Failed."):
+            executor.run_bash("i-1", "false", timeout_s=10)
+
+    def test_poll_invocation_retries_on_invocation_not_yet_visible(self) -> None:
+        ssm = MagicMock()
+        ssm.get_command_invocation.side_effect = [
+            _client_error("InvocationDoesNotExist"),
+            {
+                "Status": "Success",
+                "StandardOutputContent": "done",
+                "StandardErrorContent": "",
+            },
+        ]
+        executor = SsmExecutor(ssm, poll_interval_s=0)
+
+        result = executor.poll_invocation("cmd-3", "i-2", timeout_s=10)
+
+        self.assertEqual(result.status, "Success")
+        self.assertEqual(result.stdout, "done")
+        self.assertEqual(ssm.get_command_invocation.call_count, 2)
+
+    def test_poll_invocation_re_raises_unknown_client_error(self) -> None:
+        ssm = MagicMock()
+        ssm.get_command_invocation.side_effect = _client_error("InternalServerError")
+        executor = SsmExecutor(ssm, poll_interval_s=0)
+
+        with self.assertRaises(ClientError):
+            executor.poll_invocation("cmd-4", "i-3", timeout_s=5)
+
+    def test_poll_invocation_raises_timeout_when_deadline_exceeded(self) -> None:
+        ssm = MagicMock()
+        ssm.get_command_invocation.return_value = {
+            "Status": "InProgress",
+            "StandardOutputContent": "",
+            "StandardErrorContent": "",
+        }
+        # grace=0 keeps the test fast; production callers leave the default 30s.
+        executor = SsmExecutor(ssm, poll_interval_s=0, poll_grace_s=0)
+
+        with self.assertRaises(SsmTimeout):
+            executor.poll_invocation("cmd-5", "i-4", timeout_s=0)
+
+    def test_run_bash_batch_returns_per_instance_results(self) -> None:
+        ssm = MagicMock()
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-6"}}
+        ssm.get_paginator.return_value.paginate.return_value = [
+            {
+                "CommandInvocations": [
+                    {
+                        "InstanceId": "i-1",
+                        "Status": "Success",
+                        "CommandPlugins": [
+                            {"Output": "out-1", "StandardErrorContent": ""},
+                        ],
+                    },
+                    {
+                        "InstanceId": "i-2",
+                        "Status": "Success",
+                        "CommandPlugins": [
+                            {"Output": "out-2", "StandardErrorContent": "warn"},
+                        ],
+                    },
+                ],
+            },
+        ]
+        executor = SsmExecutor(ssm, poll_interval_s=0)
+
+        results = executor.run_bash_batch(["i-1", "i-2"], "echo hi", timeout_s=30)
+
+        self.assertEqual(set(results), {"i-1", "i-2"})
+        self.assertEqual(results["i-1"].stdout, "out-1")
+        self.assertEqual(results["i-2"].stderr, "warn")
+        self.assertEqual(results["i-1"].status, "Success")
+
+    def test_run_bash_batch_keeps_polling_until_all_requested_ids_report(self) -> None:
+        # First poll only returns i-1 (Success); list_command_invocations can be
+        # eventually consistent. The batch must NOT return early — it must wait
+        # for i-2 to also appear with a terminal status.
+        ssm = MagicMock()
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-7"}}
+        ssm.get_paginator.return_value.paginate.side_effect = [
+            [
+                {
+                    "CommandInvocations": [
+                        {
+                            "InstanceId": "i-1",
+                            "Status": "Success",
+                            "CommandPlugins": [
+                                {"Output": "out-1", "StandardErrorContent": ""},
+                            ],
+                        },
+                    ],
+                },
+            ],
+            [
+                {
+                    "CommandInvocations": [
+                        {
+                            "InstanceId": "i-1",
+                            "Status": "Success",
+                            "CommandPlugins": [
+                                {"Output": "out-1", "StandardErrorContent": ""},
+                            ],
+                        },
+                        {
+                            "InstanceId": "i-2",
+                            "Status": "Success",
+                            "CommandPlugins": [
+                                {"Output": "out-2", "StandardErrorContent": ""},
+                            ],
+                        },
+                    ],
+                },
+            ],
+        ]
+        executor = SsmExecutor(ssm, poll_interval_s=0)
+
+        results = executor.run_bash_batch(["i-1", "i-2"], "echo hi", timeout_s=30)
+
+        self.assertEqual(set(results), {"i-1", "i-2"})
+        self.assertEqual(results["i-2"].stdout, "out-2")
+        self.assertEqual(ssm.get_paginator.return_value.paginate.call_count, 2)
+
+    def test_run_bash_batch_times_out_when_requested_id_never_reports(self) -> None:
+        ssm = MagicMock()
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-8"}}
+        ssm.get_paginator.return_value.paginate.return_value = [
+            {
+                "CommandInvocations": [
+                    {
+                        "InstanceId": "i-1",
+                        "Status": "Success",
+                        "CommandPlugins": [
+                            {"Output": "out-1", "StandardErrorContent": ""},
+                        ],
+                    },
+                ],
+            },
+        ]
+        executor = SsmExecutor(ssm, poll_interval_s=0, poll_grace_s=0)
+
+        with self.assertRaises(SsmTimeout):
+            executor.run_bash_batch(["i-1", "i-missing"], "echo hi", timeout_s=0)
+
+
+# -----------------------------------------------------------------------------
+# PortalShellTransport
+# -----------------------------------------------------------------------------
+
+
+class PortalShellTransportTests(unittest.TestCase):
+    def test_run_django_wraps_payload_and_returns_parsed_envelope(self) -> None:
+        ssm = MagicMock()
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-1"}}
+        ssm.get_command_invocation.return_value = {
+            "Status": "Success",
+            "StandardOutputContent": "__JSON_START__{\"hello\": \"world\"}__JSON_END__",
+            "StandardErrorContent": "",
+        }
+        transport = PortalShellTransport(SsmExecutor(ssm, poll_interval_s=0), "i-portal")
+
+        parsed = transport.run_django("print('hello')", timeout_s=30)
+
+        self.assertEqual(parsed, {"hello": "world"})
+        # Confirm the inner script went over via base64 in send_command parameters.
+        kwargs = ssm.send_command.call_args.kwargs
+        commands = kwargs["Parameters"]["commands"]
+        # one command string, includes base64 indirection sentinel.
+        self.assertEqual(len(commands), 1)
+        self.assertIn("base64 -d", commands[0])
+        self.assertIn("docker exec portal", commands[0])
+
+    def test_run_django_propagates_failure(self) -> None:
+        ssm = MagicMock()
+        ssm.send_command.return_value = {"Command": {"CommandId": "cmd-2"}}
+        ssm.get_command_invocation.return_value = {
+            "Status": "Failed",
+            "StandardOutputContent": "",
+            "StandardErrorContent": "broken",
+        }
+        transport = PortalShellTransport(SsmExecutor(ssm, poll_interval_s=0), "i-portal")
+
+        with self.assertRaises(RuntimeError):
+            transport.run_django("raise Exception", timeout_s=10)
+
+
+# -----------------------------------------------------------------------------
+# PolarisAwsContext
+# -----------------------------------------------------------------------------
+
+
+class PolarisAwsContextTests(unittest.TestCase):
+    def test_clients_are_cached_per_service(self) -> None:
+        fake_session = MagicMock()
+        fake_session.client.side_effect = lambda service: MagicMock(name=service)
+        ctx = PolarisAwsContext(profile=None, region="us-east-2", _session=fake_session)
+
+        ec2_a = ctx.ec2()
+        ec2_b = ctx.ec2()
+        ssm_a = ctx.ssm()
+        ssm_b = ctx.ssm()
+
+        self.assertIs(ec2_a, ec2_b)
+        self.assertIs(ssm_a, ssm_b)
+        # 2 distinct services, each created once.
+        self.assertEqual(fake_session.client.call_count, 2)
+
+    def test_session_factory_uses_profile_and_region(self) -> None:
+        recorded: dict[str, object] = {}
+
+        def fake_session_factory(**kwargs):
+            recorded.update(kwargs)
+            return MagicMock()
+
+        ctx = PolarisAwsContext(
+            profile="my-profile",
+            region="us-west-1",
+            _session_factory=fake_session_factory,
+        )
+        ctx.session()
+
+        self.assertEqual(recorded, {"profile_name": "my-profile", "region_name": "us-west-1"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/polaris-aws-range/test_provisioning_state.py
+++ b/scripts/polaris-aws-range/test_provisioning_state.py
@@ -1,0 +1,171 @@
+"""Tests for the extracted provisioning-state data model (issue #691).
+
+Run from this directory:
+    python3 -m unittest test_provisioning_state -v
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from provisioning_state import (
+    ParticipantOutcome,
+    State,
+    load_state,
+    now_iso,
+    save_state,
+    write_status_doc,
+)
+
+
+class StateRoundTripTests(unittest.TestCase):
+    def test_to_dict_and_from_dict_preserve_outcomes(self) -> None:
+        state = State(
+            started_at="2026-05-23T00:00:00+00:00",
+            finished_at="",
+            total_participants=2,
+            batches_completed=1,
+            halted=False,
+            halt_reason="",
+            outcomes={
+                "p1": ParticipantOutcome(
+                    participant_id="p1",
+                    email="a@example.com",
+                    name="Alice",
+                    range_instance_id="r-1",
+                    status="ready",
+                    batch_num=1,
+                    started_at="2026-05-23T00:00:01+00:00",
+                    finished_at="2026-05-23T00:05:00+00:00",
+                ),
+                "p2": ParticipantOutcome(
+                    participant_id="p2",
+                    email="b@example.com",
+                    name="Bob",
+                    status="failed",
+                    error="boom",
+                    batch_num=1,
+                ),
+            },
+        )
+
+        round_tripped = State.from_dict(state.to_dict())
+
+        self.assertEqual(round_tripped.batches_completed, 1)
+        self.assertEqual(round_tripped.outcomes["p1"].status, "ready")
+        self.assertEqual(round_tripped.outcomes["p1"].range_instance_id, "r-1")
+        self.assertEqual(round_tripped.outcomes["p2"].error, "boom")
+        self.assertEqual(round_tripped.outcomes["p2"].finished_at, "")
+
+    def test_save_state_and_load_state_round_trip_through_disk(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / "state.json"
+            state = State(started_at=now_iso(), total_participants=3)
+            state.outcomes["pX"] = ParticipantOutcome(
+                participant_id="pX",
+                email="x@example.com",
+                name="X",
+                status="triggered",
+            )
+
+            save_state(state, state_path)
+            loaded = load_state(state_path)
+
+            self.assertEqual(loaded.total_participants, 3)
+            self.assertIn("pX", loaded.outcomes)
+            self.assertEqual(loaded.outcomes["pX"].status, "triggered")
+
+    def test_load_state_returns_fresh_state_when_file_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / "absent.json"
+
+            loaded = load_state(state_path)
+
+            self.assertTrue(loaded.started_at)
+            self.assertEqual(loaded.outcomes, {})
+
+    def test_load_state_returns_fresh_state_on_corrupt_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            state_path = Path(tmp) / "corrupt.json"
+            state_path.write_text("{not json")
+
+            loaded = load_state(state_path)
+
+            self.assertTrue(loaded.started_at)
+            self.assertEqual(loaded.outcomes, {})
+
+
+class WriteStatusDocTests(unittest.TestCase):
+    def test_renders_header_tallies_and_failure_table(self) -> None:
+        state = State(
+            started_at="2026-05-23T00:00:00+00:00",
+            finished_at="2026-05-23T00:30:00+00:00",
+            batches_completed=2,
+            outcomes={
+                "p1": ParticipantOutcome(
+                    participant_id="p1", email="a@x", name="A", status="ready", batch_num=1
+                ),
+                "p2": ParticipantOutcome(
+                    participant_id="p2",
+                    email="b@x",
+                    name="B",
+                    status="failed",
+                    error="boom",
+                    batch_num=1,
+                ),
+                "p3": ParticipantOutcome(
+                    participant_id="p3",
+                    email="c@x",
+                    name="C",
+                    status="trigger_error",
+                    error="bad|pipe",
+                    batch_num=2,
+                ),
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            status_path = Path(tmp) / "status.md"
+            write_status_doc(state, current_batch_log=["did the thing"], status_md_path=status_path)
+            rendered = status_path.read_text()
+
+        self.assertIn("# Polaris provisioning status", rendered)
+        self.assertIn("- started: 2026-05-23T00:00:00+00:00", rendered)
+        self.assertIn("- finished: 2026-05-23T00:30:00+00:00", rendered)
+        self.assertIn("- batches completed: 2", rendered)
+        self.assertIn("## Outcome tally", rendered)
+        self.assertIn("## Failures", rendered)
+        # Pipes in error fields must be escaped (markdown table cell discipline).
+        self.assertIn(r"bad\|pipe", rendered)
+        self.assertIn("## Current / last batch log", rendered)
+        self.assertIn("- did the thing", rendered)
+
+    def test_renders_halted_marker_when_state_is_halted(self) -> None:
+        state = State(
+            started_at="2026-05-23T00:00:00+00:00",
+            halted=True,
+            halt_reason="threshold exceeded",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            status_path = Path(tmp) / "status.md"
+            write_status_doc(state, current_batch_log=[], status_md_path=status_path)
+            rendered = status_path.read_text()
+
+        self.assertIn("**HALTED**: threshold exceeded", rendered)
+
+    def test_save_state_writes_pretty_json(self) -> None:
+        state = State(started_at="2026-05-23T00:00:00+00:00")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "out.json"
+            save_state(state, path)
+            payload = json.loads(path.read_text())
+        self.assertEqual(payload["started_at"], "2026-05-23T00:00:00+00:00")
+        self.assertIn("outcomes", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/polaris-aws-range/test_range_health.py
+++ b/scripts/polaris-aws-range/test_range_health.py
@@ -1,0 +1,151 @@
+"""Tests for the extracted range-health model (issue #691).
+
+Run from this directory:
+    python3 -m unittest test_range_health -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from range_health import (
+    EXPECTED_CONTAINER_COUNT,
+    KALI_ENV_KEYS,
+    RangeReport,
+    Target,
+    parse_record,
+    write_report,
+)
+
+
+def _healthy_fields() -> dict[str, str]:
+    fields = {
+        "host": "polaris-vm-1",
+        "instance_id": "i-aaa",
+        "container_count": str(EXPECTED_CONTAINER_COUNT),
+        "exited_containers": "none",
+        "a14_state": "running",
+        "a14_on_splice": "0",
+        "bedrock_profile": "1",
+        "hosts_override": "1",
+        "splice_watcher": "active",
+        "a5_scada_state": "running",
+        "a9_splice_state": "running",
+        "a0_website_state": "running",
+        "env_AWS_ACCESS_KEY_ID": "0",
+    }
+    for key in KALI_ENV_KEYS:
+        fields[f"env_{key}"] = "1"
+    return fields
+
+
+class ParseRecordTests(unittest.TestCase):
+    def test_round_trips_pipe_delimited_record(self) -> None:
+        stdout = "noise\n__RECORD__host=polaris-vm-1|instance_id=i-aaa|container_count=22__END__\ntrailing"
+
+        record = parse_record(stdout)
+
+        self.assertEqual(
+            record,
+            {"host": "polaris-vm-1", "instance_id": "i-aaa", "container_count": "22"},
+        )
+
+    def test_returns_empty_when_markers_missing(self) -> None:
+        self.assertEqual(parse_record("no markers"), {})
+
+    def test_ignores_segments_without_equals(self) -> None:
+        # The bash producer is well-formed in practice; the parser tolerates
+        # malformed segments rather than crashing the whole run.
+        record = parse_record("__RECORD__valid=1|orphan|other=2__END__")
+
+        self.assertEqual(record, {"valid": "1", "other": "2"})
+
+
+class RangeReportIssueTests(unittest.TestCase):
+    def test_healthy_record_has_no_issues(self) -> None:
+        report = RangeReport(
+            instance_id="i-aaa",
+            range_id="42",
+            user_id="u-1",
+            fields=_healthy_fields(),
+        )
+
+        self.assertEqual(report.issues(), [])
+        self.assertTrue(report.ok)
+
+    def test_low_container_count_flagged(self) -> None:
+        fields = _healthy_fields()
+        fields["container_count"] = "18"
+        report = RangeReport(instance_id="i-bbb", range_id="7", user_id="u-2", fields=fields)
+
+        issues = report.issues()
+        self.assertIn(f"container_count=18/{EXPECTED_CONTAINER_COUNT}", issues)
+        self.assertFalse(report.ok)
+
+    def test_kali_off_and_still_on_splice_both_reported(self) -> None:
+        fields = _healthy_fields()
+        fields["a14_state"] = "exited"
+        fields["a14_on_splice"] = "1"
+        report = RangeReport(instance_id="i-ccc", range_id="8", user_id="u-3", fields=fields)
+
+        issues = report.issues()
+        self.assertIn("a14-kali=exited", issues)
+        self.assertIn("a14 still on splice-link (watcher didn't disconnect)", issues)
+
+    def test_missing_bedrock_env_keys_each_reported(self) -> None:
+        fields = _healthy_fields()
+        for key in KALI_ENV_KEYS:
+            fields[f"env_{key}"] = "0"
+        report = RangeReport(instance_id="i-ddd", range_id="9", user_id="u-4", fields=fields)
+
+        issues = report.issues()
+        for key in KALI_ENV_KEYS:
+            self.assertIn(f"missing env {key}", issues)
+
+    def test_splice_watcher_not_active_reported(self) -> None:
+        fields = _healthy_fields()
+        fields["splice_watcher"] = "inactive"
+        report = RangeReport(instance_id="i-eee", range_id="10", user_id="u-5", fields=fields)
+
+        self.assertIn("splice-watcher=inactive", report.issues())
+
+    def test_exited_containers_reported_when_present(self) -> None:
+        fields = _healthy_fields()
+        fields["exited_containers"] = "a0-website,a5-scada"
+        report = RangeReport(instance_id="i-fff", range_id="11", user_id="u-6", fields=fields)
+
+        self.assertIn("exited=[a0-website,a5-scada]", report.issues())
+
+
+class WriteReportTests(unittest.TestCase):
+    def test_renders_summary_and_issues_table(self) -> None:
+        healthy_fields = _healthy_fields()
+        unhealthy_fields = _healthy_fields()
+        unhealthy_fields["splice_watcher"] = "missing"
+        targets = [
+            Target(instance_id="i-aaa", vpc_id="v", name="r1", range_id="1", user_id="u-1"),
+            Target(instance_id="i-bbb", vpc_id="v", name="r2", range_id="2", user_id="u-2"),
+        ]
+        reports = [
+            RangeReport(instance_id="i-aaa", range_id="1", user_id="u-1", fields=healthy_fields),
+            RangeReport(instance_id="i-bbb", range_id="2", user_id="u-2", fields=unhealthy_fields),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "report.md"
+            write_report(targets, reports, out, verbose=True)
+            rendered = out.read_text()
+
+        self.assertIn("# Polaris range health report", rendered)
+        self.assertIn("Discovered polaris-vm ranges: 2", rendered)
+        self.assertIn("Healthy: **1**", rendered)
+        self.assertIn("With issues: **1**", rendered)
+        self.assertIn("splice-watcher=missing", rendered)
+        # verbose mode adds the per-range table.
+        self.assertIn("## All ranges", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refactor Polaris support scripts onto shared AWS/SSM and CTFd helpers, per the issue #691 acceptance criteria and the preflight note at `docs/architecture/polaris-support-decomposition-preflight-691.md`. The four operator/CTFd scripts that exceeded ~400 LOC (`orchestrate_provisioning.py` 834→260, `check_range_health.py` 431→148, `sync_polaris_ctfd.py` 513→297, `sync_polaris_ctfd_onboarding.py` 421→126) are now thin CLI entrypoints over new shared modules: `scripts/polaris-aws-range/common.py` (boto3 session caching, EC2 portal discovery, `SsmExecutor`, `PortalShellTransport`, JSON-envelope parse, redaction); `scripts/polaris-aws-range/provisioning_state.py`, `provisioning_batch.py`, `range_health.py`; `scripts/ctfd-workshop/ctfd_reconcile.py` (generic CTFd upsert/reconcile/manifest readers) and `polaris_manifest.py` (Polaris challenge ordering, validation, prereq resolution). `seed_ctfd.py` reuses the generic upsert path while keeping its single-flag keeper and no-delete-stale-hint semantics that differ deliberately from Polaris. Large scenario assets keep their current shape with explicit justification README files: the monolithic SDL is held until #620 supplies a generator+verification path, and the briefing-deck is already split per `<section class="slide">`. #620 remains the architecture parent for scenario expressiveness; this PR is concrete code decomposition only.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #691

## ADR Impact

- ADR-021

## Changes

- Add `scripts/polaris-aws-range/common.py` (`PolarisAwsContext`, `find_portal_instance`, `SsmExecutor`, `PortalShellTransport`, `parse_json_envelope`, `mask_sensitive_output`) — collapses three duplicate copies of the SSM poll loop, two of the portal-instance lookup, and two Django-shell-over-SSM wrappers.
- Extract `scripts/polaris-aws-range/provisioning_state.py` (state dataclasses + JSON/markdown IO) and `provisioning_batch.py` (`run_one_batch`, `retry_failures`, Django-shell snippets) from `orchestrate_provisioning.py`. `orchestrate_provisioning.py` is now the CLI entrypoint (834→260 LOC).
- Extract `scripts/polaris-aws-range/range_health.py` (probe script, target discovery, report writer, issue model) from `check_range_health.py`. `check_range_health.py` is now the CLI entrypoint (431→148 LOC). Catches both `ClientError` and `SsmTimeout` so a single missing instance can no longer kill the fleet report.
- Refactor `scripts/polaris-aws-range/cleanup_non_keepers.py` onto `common.PolarisAwsContext` + `PortalShellTransport.run_raw` (preserves the existing line-oriented `SHELL_EVENT|` parsing).
- Add `scripts/ctfd-workshop/ctfd_reconcile.py` (`reconcile_rows`, `find_by_key`, `upsert_page`, `upsert_challenge`, `build_challenge_payload`, `ensure_flags`, `ensure_hints`, `normalize_flag`/`normalize_hints`, `parse_page`/`load_pages`/`load_json`, `get_all_items`). `build_challenge_payload` defaults `requirements` to `{"prerequisites": []}` so an interrupted first pass can never persist unresolved manifest ids as live CTFd authorization gates.
- Add `scripts/ctfd-workshop/polaris_manifest.py` (Polaris challenge ordering, `validate_manifest`, `validate_live_challenge_names`, `verify_challenge_rows`, `resolve_prerequisites`, `sort_challenges`, `SyncError`).
- Refactor `sync_polaris_ctfd.py` (513→297 LOC) and `sync_polaris_ctfd_onboarding.py` (421→126 LOC) onto the new helpers. `seed_ctfd.py` (307→287 LOC) uses the shared upsert + `find_by_key` while keeping its single-flag keeper and no-delete-stale-hint behavior that differs deliberately from Polaris.
- Add 43 unit tests across `test_common.py`, `test_provisioning_state.py`, `test_range_health.py`. Update `test_sync_polaris_ctfd.py` (20 existing tests) to import from the new module layout — all still pass.
- Add `scenario-dev/polaris/sdl/README.md` justifying the monolithic SDL per the preflight (#620 owns the long-term declarative path; splitting now would create a generator+verification debt the preflight forbids).
- Add `scenario-dev/polaris/briefing-deck/README.md` documenting the existing `<section class="slide">` per-slide review unit + CSS variant convention as the chosen reviewability solution.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

**Local gates run by `/implement`:** 43 polaris-aws-range tests and 20 ctfd-workshop tests pass; `python3 scripts/adr_guard/adr_guard.py --all --level ci` clean; `pre-commit run --all-files` clean (every pytest suite, jest, mcp tests, layer-import checks, etc.). Codex pre-push review converged after 4 cycles (3 over-cap with explicit user authorization) — 3 real refactor-introduced bugs found and fixed mid-loop: wrong Django API in extracted shell templates, `SsmExecutor.run_bash_batch` partial-result early-return, missing `SsmTimeout` catch in `check_range_health`. Test-quality review clean on cycle 1.

**Live-AWS smoketests NOT run by CI.** `scenario-dev/polaris/tests/run-all-smoketests.sh` requires an active Polaris range and credentials; please exercise it against the staging range before merge.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-021 ← scripts/polaris-aws-range/common.py, ADR-021 ← scripts/ctfd-workshop/ctfd_reconcile.py
- TESTS: ADR-021 ← scripts/polaris-aws-range/test_common.py, ADR-021 ← scripts/polaris-aws-range/test_provisioning_state.py, ADR-021 ← scripts/polaris-aws-range/test_range_health.py, ADR-021 ← scripts/ctfd-workshop/test_sync_polaris_ctfd.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/691.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
