### PR TITLE
docs: reference scenario_smoketest harness in Polaris README

### DIFF
--- a/scenario-dev/polaris/README.md
+++ b/scenario-dev/polaris/README.md
@@ -46,10 +46,12 @@ scenario-dev/polaris/
 ├── tests/                          everything test-related
 │   ├── setup.sh                    build + up + wait ready
 │   ├── reset.sh                    force-recreate sticky-state services (a5/a10/a11/a12/a13)
-│   ├── run-all-smoketests.sh       full sweep: reset + 15 asset smoketests + isolation
+│   ├── run-all-smoketests.sh       infra sweep: reset + per-asset smoketests + isolation
 │   ├── isolation-smoketest.sh      cross-cutting network boundary validation (70 checks)
 │   ├── smoketests/                 one per asset, pointed at the live range from its pivot container
 │   │   ├── A0-smoketest.sh ... A14-smoketest.(sh|py)
+│   ├── scenario_smoketest/         pre-event challenge-hint → flag verifier (Python package; see its README)
+│   ├── test_scenario_smoketest.py  unit tests for scenario_smoketest
 │   └── walkthroughs/               step-by-step happy-path participant guides, grouped by flag range
 │       ├── README.md
 │       ├── 00-range-access-docker.md
@@ -94,8 +96,19 @@ first instead of assuming the older design prose is correct.
    ssh ctf-range-builder 'bash /home/atomik/range/tests/run-all-smoketests.sh'
    ```
    Expected: `16 / 16 asset sweeps PASS`, `NORTHSTORM full range: PASS`.
+   Infrastructure-level: per-asset connectivity + cross-cutting network
+   isolation. Does not verify CTFd challenge content.
 
-3. **Reset** — before each test or between participant sessions:
+3. **Verify scenario content** — pre-event content check that every CTFd
+   challenge's hint path produces the configured flag:
+   ```
+   ssh ctf-range-builder 'cd /home/atomik/range/tests && python3 -m scenario_smoketest'
+   ```
+   Content-level (vs. step 2's infra sweep). Full usage, flags, and the
+   CTFd-token security model live in
+   [`tests/scenario_smoketest/README.md`](tests/scenario_smoketest/README.md).
+
+4. **Reset** — before each test or between participant sessions:
    ```
    ssh ctf-range-builder 'bash /home/atomik/range/tests/reset.sh'
    ```


### PR DESCRIPTION
## Summary

Surface the scenario_smoketest harness (added in PR #827) in scenario-dev/polaris/README.md so operators discover the pre-event challenge-hint → flag verifier alongside the existing infra-level run-all-smoketests.sh. The harness's own README at scenario-dev/polaris/tests/scenario_smoketest/README.md remains the canonical usage doc; this PR only wires it into the parent scenario docs for discovery and scope differentiation.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #828

## ADR Impact

- ADR-021
- ADR-029

## Changes

- Add `scenario_smoketest/` and `test_scenario_smoketest.py` entries under `tests/` in the Layout tree.
- Tighten the `run-all-smoketests.sh` description to call out its infra scope (per-asset connectivity + cross-cutting isolation) so it doesn't read as overlapping with the content-level verifier.
- Add a `Verify scenario content` step under Getting started with the `ssh ctf-range-builder 'cd /home/atomik/range/tests && python3 -m scenario_smoketest'` invocation, and link to `tests/scenario_smoketest/README.md` for full usage, flags, and the CTFd-token security model.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Pure prose diff (single file: scenario-dev/polaris/README.md). Verification is visual review of the rendered Markdown against the issue's acceptance criteria; the existing scenario-dev/polaris/tests/test_scenario_smoketest.py is unchanged and continues to validate the harness itself.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
