### PR TITLE
security(provisioner): scope ELBv2 IAM permissions on engine provisioner

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -104,6 +104,16 @@ jobs:
             platform/terraform/modules/portal/ec2/main.tf \
             platform/terraform/modules/guacamole/iam.tf
 
+      # Issue #46: ELBv2 (Gateway Load Balancer) IAM scoping on the
+      # engine provisioner ECS task role. Mirrors check-tf-iam-ec2-scope:
+      # rejects Resource=* and wildcard ELBv2 actions on the GWLB
+      # mutation statements and requires the Shifter ownership tag
+      # conditions. Pre-commit also enforces it locally.
+      - name: Run check-tf-iam-elb-scope
+        run: |
+          python3 scripts/check_tf_iam_elb_scope/check_tf_iam_elb_scope.py \
+            platform/terraform/modules/engine-provisioner/iam.tf
+
       # Pin the behavior of the check_tf_* IAM/security checkers
       # themselves. The live-file invocations above only exercise the
       # happy-path shape; the test suites cover wildcards, list
@@ -117,6 +127,7 @@ jobs:
       - name: Run check_tf_* checker tests
         run: |
           python3 -m unittest scripts.check_tf_iam_ec2_scope.test_check_tf_iam_ec2_scope
+          python3 -m unittest scripts.check_tf_iam_elb_scope.test_check_tf_iam_elb_scope
           python3 -m unittest scripts.check_tf_sg_cidrs.test_check_tf_sg_cidrs
           python3 -m unittest scripts.check_tf_kms_secrets_grant.test_check_tf_kms_secrets_grant
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,7 @@ jobs:
               # is verified, but it shouldn't trigger any deploy — the
               # `mcp` filter is the existing "Quality-only" route.
               - 'scripts/check_tf_iam_ec2_scope/**'
+              - 'scripts/check_tf_iam_elb_scope/**'
               - 'scripts/check_tf_sg_cidrs/**'
               - 'scripts/check_tf_kms_secrets_grant/**'
               # Guardrail / ADR-registry surfaces. A change to any of

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,6 +179,12 @@ repos:
         language: system
         files: ^platform/terraform/modules/engine-provisioner/iam\.tf$
 
+      - id: check-tf-iam-elb-scope
+        name: AWS ELBv2 (GWLB) IAM scoping (engine provisioner)
+        entry: python3 scripts/check_tf_iam_elb_scope/check_tf_iam_elb_scope.py
+        language: system
+        files: ^platform/terraform/modules/engine-provisioner/iam\.tf$
+
       # Custom: Secrets Manager kms:Decrypt grant check (issue #52).
       # Ensures every aws_iam_role defined in scoped files that reads
       # the portal Secrets Manager CMK has an attached
@@ -231,11 +237,12 @@ repos:
         entry: >-
           bash -c '
           python3 -m unittest scripts.check_tf_iam_ec2_scope.test_check_tf_iam_ec2_scope &&
+          python3 -m unittest scripts.check_tf_iam_elb_scope.test_check_tf_iam_elb_scope &&
           python3 -m unittest scripts.check_tf_sg_cidrs.test_check_tf_sg_cidrs &&
           python3 -m unittest scripts.check_tf_kms_secrets_grant.test_check_tf_kms_secrets_grant
           '
         language: system
-        files: ^scripts/check_tf_(iam_ec2_scope|sg_cidrs|kms_secrets_grant)/
+        files: ^scripts/check_tf_(iam_ec2_scope|iam_elb_scope|sg_cidrs|kms_secrets_grant)/
         pass_filenames: false
 
   # Kubernetes schema validation

--- a/changelog.d/46.security.md
+++ b/changelog.d/46.security.md
@@ -1,0 +1,11 @@
+Scope the engine-provisioner ECS task role's ELBv2 (Gateway Load Balancer)
+permissions. The `aws_iam_role_policy.gwlb` policy in
+`platform/terraform/modules/engine-provisioner/iam.tf` no longer grants
+mutable `elasticloadbalancing:*` actions on `Resource = "*"`; create,
+delete, modify, register/deregister-targets, and tag-mutation actions are
+restricted to Gateway Load Balancer resource ARNs
+(`loadbalancer/gwy/*`, `listener/gwy/*/*/*`, `targetgroup/*`) and gated on
+Shifter ownership request/resource tags. `Describe*` is enumerated and
+retains `Resource = "*"` per AWS service authorization requirements. A new
+`scripts/check_tf_iam_elb_scope` static checker (wired through pre-commit
+and the Quality workflow) prevents regression.

--- a/docs/adr/exceptions.yaml
+++ b/docs/adr/exceptions.yaml
@@ -47,7 +47,7 @@
   {
     "rule_id": "ADR-004-R11",
     "owner": "@Brad-Edwards",
-    "reason": "CKV_AWS_355 / CKV_AWS_290 / CKV_AWS_289 (IAM wildcard resource / unconstrained write / unconstrained permissions management): the engine provisioner orchestrates EC2, ELBv2 (GWLB), VPC endpoints, Security Groups, Route Tables, NAT Gateways, and Internet Gateways across arbitrary ranges. Many AWS APIs require Resource = '*' by design (e.g. CreateRouteTable, CreateSubnet, ec2:CreateTags). The runtime path is constrained by tag-based StringEquals conditions (aws:RequestTag / ec2:ResourceTag) where the API supports it. Narrowing further would require tagging at create time on every API call which is not universally supported.",
+    "reason": "CKV_AWS_355 / CKV_AWS_290 / CKV_AWS_289 (IAM wildcard resource / unconstrained write / unconstrained permissions management): the engine provisioner orchestrates EC2, VPC endpoints, Security Groups, Route Tables, NAT Gateways, and Internet Gateways across arbitrary ranges. Many AWS APIs require Resource = '*' by design (e.g. CreateRouteTable, CreateSubnet, ec2:CreateTags). The runtime path is constrained by tag-based StringEquals conditions (aws:RequestTag / ec2:ResourceTag) where the API supports it. Narrowing further would require tagging at create time on every API call which is not universally supported. ELBv2 (GWLB) wildcards were narrowed in #46: the gwlb policy now scopes mutable actions to Gateway Load Balancer ARNs with ownership tag conditions and is regression-checked by scripts/check_tf_iam_elb_scope.",
     "expires_on": "2027-05-26",
     "paths": [
       "platform/terraform/modules/engine-provisioner/iam.tf"

--- a/docs/architecture/elb-iam-scope-preflight-46.md
+++ b/docs/architecture/elb-iam-scope-preflight-46.md
@@ -1,0 +1,150 @@
+# ELB IAM Scope Preflight (#46)
+
+Status: implemented (see `aws_iam_role_policy.gwlb` in
+`platform/terraform/modules/engine-provisioner/iam.tf` and the regression
+checker at `scripts/check_tf_iam_elb_scope/`).
+
+Tracking issue: GitHub #46, migrated from PaloAltoNetworks/shifter#56.
+
+This note records the repository-wide guardrails for narrowing the engine
+provisioner's ELBv2 permissions. It is retained as the binding design record
+for the static checker that pins the implementation.
+
+## Scope Boundary
+
+The issue is an IAM least-privilege repair for the engine-provisioner ECS task
+role. The implementation should stay focused on
+`platform/terraform/modules/engine-provisioner/iam.tf` unless a validation or
+documentation update is needed to keep the guardrails honest.
+
+Do not change runtime provisioning behavior, task-definition environment
+variables, secret hydration, database contracts, SNS events, or cloud-provider
+abstractions to satisfy this issue.
+
+## Architecture Decisions
+
+- Split ELBv2 read/list APIs from mutable management APIs. Keep
+  `Resource = "*"` only where the AWS ELBv2 service authorization table does not
+  support resource-level permissions for the action.
+- Prefer enumerated `Describe...` actions over `Describe*` unless Terraform
+  provider behavior proves an additional describe action is required.
+- Scope mutable ELBv2 permissions to the resource types the provisioner actually
+  manages. For the current `gwlb` policy surface, that means Gateway Load
+  Balancer ARNs, target group ARNs, and Gateway Load Balancer listener ARNs.
+  Do not copy Application Load Balancer `app` listener-rule patterns into the
+  GWLB statement unless the runtime creates those resources.
+- Use existing module locals for region/account interpolation:
+  `local.region` and `local.account_id`. Do not introduce duplicate
+  caller-identity or region data sources.
+- Derive resource-name patterns from the existing naming contract. The issue's
+  suggested `shifter-*` pattern is not automatically authoritative here:
+  portal module names use `var.name_prefix` values like `dev-portal`, while
+  runtime NGFW Terraform uses `ngfw-user-{user_id}`. Confirm the managed ELBv2
+  names before selecting an ARN pattern.
+- Add tag conditions where ELBv2 supports them. Creation-time actions should
+  require the Shifter ownership request tags; existing-resource mutations should
+  require Shifter ownership resource tags.
+- Preserve the existing Terraform style in this module: inline
+  `jsonencode(...)` policies, `Sid` names that describe the action family, and
+  short comments only where AWS requires a wildcard or dependent action.
+
+## Canonical Incumbents
+
+| Concern | Canonical incumbent | Guardrail for #46 |
+| --- | --- | --- |
+| Engine-provisioner IAM ownership | `platform/terraform/modules/engine-provisioner/iam.tf` | Keep the ELBv2 repair in the existing `aws_iam_role_policy.gwlb` boundary unless the role split itself changes. |
+| Region/account interpolation | `platform/terraform/modules/engine-provisioner/main.tf` `local.region` and `local.account_id` | Reuse these locals for ARN construction. |
+| Runtime ownership tags | `shifter/engine/provisioner/components/tags.py`, `shifter/engine/provisioner/terraform/modules/ngfw/main.tf`, and `shifter/engine/provisioner/terraform/modules/range/main.tf` | IAM tag conditions should align to `shifter:system = shifter`, `shifter:environment = var.environment`, and `ManagedBy = terraform`. |
+| Existing IAM hardening pattern | `scripts/check_tf_iam_ec2_scope/check_tf_iam_ec2_scope.py` | If regression coverage is added, follow the focused repo-native static-check style instead of adding a second policy framework. |
+| Terraform security gate | `platform/terraform/.checkov.yaml`, `docs/adr/exceptions.yaml`, ADR-004-R11 | Narrowing ELBv2 wildcards should not be hidden by the broad Checkov skip; update the ADR exception text if it stops accurately describing accepted risk. |
+| Local and CI Terraform gates | `.pre-commit-config.yaml`, `.github/workflows/_quality.yml`, `.tflint.hcl` | Keep local and CI validation aligned; do not add a check in only one place. |
+
+## Cross-Cutting Layers
+
+- IAM auth surface: the design touches the engine-provisioner ECS task role.
+  Read/list actions may remain wildcard when AWS requires it. Mutable actions
+  should be scoped to ELBv2 resource ARNs and Shifter ownership tags.
+- AWS policy-resource shape: Gateway Load Balancer ARNs use `gwy`, not `app`.
+  Relevant ELBv2 patterns are
+  `loadbalancer/gwy/<name>/<id>`, `listener/gwy/<lb-name>/<lb-id>/<listener-id>`,
+  and `targetgroup/<name>/<id>`. Listener rules are `app`/`net` resources and
+  are not part of the GWLB surface unless a separate ALB/NLB use case is added.
+- Tagging authorization: tagged creates need both the create action and
+  `elasticloadbalancing:AddTags`. Creation-time `AddTags` should be constrained
+  with `elasticloadbalancing:CreateAction`; later tag mutations should be
+  resource-scoped and resource-tag-gated.
+- Secret-handling surface: unchanged. This fix should not add secrets, secret
+  values, secret references, KMS grants, tfvars values, or task-definition
+  plaintext environment variables.
+- Env-binding shape: unchanged unless the implementation proves that ELBv2 name
+  patterns must be configured. If a pattern seam is needed, keep it as a typed
+  Terraform module input or centralized local, not an ECS environment variable.
+- OS/process exposure: Terraform may render ARNs in plans and IAM policy JSON;
+  no credentials or secret values should be introduced on command lines, in
+  process argv, or in generated env files.
+- Error/log envelope: runtime error handling is out of scope. If a permission
+  mistake later surfaces through provisioner AWS calls, preserve the existing
+  `CommandResult`/logger pattern and do not leak credentials or full provider
+  payloads in logs.
+- Config and validation gates: Terraform changes must pass `terraform fmt`,
+  `terraform validate`, TFLint, Checkov's canonical config, and ADR guard.
+  Architecture guardrail changes must update ADR docs in the same change.
+
+## Extensibility Boundary
+
+The seam is the managed ELBv2 resource-name pattern and resource-type list.
+Keep it centralized in one local value or one typed module input if the current
+names cannot be expressed from existing variables. A future ALB/NLB variation
+should require adding explicit `app` or `net` resource patterns, not broadening
+the GWLB statement back to `Resource = "*"`.
+
+## Gotchas And Anti-Patterns
+
+- Do not hard-code `shifter-*` unless the managed ELBv2 resources actually use
+  that prefix in every environment.
+- Do not use Application Load Balancer ARN paths (`app`) for Gateway Load
+  Balancer resources (`gwy`).
+- Do not add unused ELBv2 actions from the issue suggestion, such as listener
+  rule or security-group mutations, unless the provisioner currently performs
+  those operations.
+- Do not rely on `Resource` ARNs alone for ownership. Pair them with Shifter
+  request/resource tag conditions where AWS supports the condition keys.
+- Do not make Checkov skips broader, turn Checkov soft-fail on, or treat the
+  existing ADR-004-R11 exception as permission to leave newly scopeable ELBv2
+  writes on wildcard resources.
+- Do not split IAM into a new module, policy generator, schema, or exception
+  hierarchy for this narrow repair.
+- Do not rename resource tags or runtime names in the same change. That turns a
+  least-privilege repair into a runtime migration.
+
+## Non-Goals
+
+- No redesign of the engine provisioner, NGFW provisioning, VPC endpoint
+  handling, runtime Terraform modules, cloud-provider adapters, or Django data
+  model.
+- No new Ground Control requirement, public API, DTO, validation schema,
+  persistence path, logging framework, or secret-management behavior.
+- No cleanup or recreation of existing load balancers, target groups, listeners,
+  VPC endpoints, or route tables.
+- No broad Terraform/Checkov policy overhaul beyond keeping documentation and
+  local/CI enforcement consistent with the scoped IAM change.
+
+## Validation Expectations
+
+At minimum, the implementation should run:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+cd platform/terraform && tflint --recursive --config ../../.tflint.hcl
+```
+
+Also run `terraform fmt`/`terraform validate` for the touched Terraform root or
+module. If a new IAM static checker is added, run its unit tests and wire the
+checker through both pre-commit and CI.
+
+## References
+
+- AWS Service Authorization Reference:
+  <https://docs.aws.amazon.com/service-authorization/latest/reference/list_awselasticloadbalancingv2.html>
+- AWS ELB tagging during creation:
+  <https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/tagging-resources-during-creation.html>

--- a/platform/terraform/modules/engine-provisioner/iam.tf
+++ b/platform/terraform/modules/engine-provisioner/iam.tf
@@ -496,32 +496,103 @@ resource "aws_iam_role_policy" "gwlb" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "GWLBOperations"
+        # ELBv2 Describe APIs require Resource = "*" per the AWS service
+        # authorization reference. Actions are enumerated so the wildcard
+        # statement cannot grow silently to additional read APIs.
+        Sid    = "GWLBDescribe"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeTags"
+        ]
+        Resource = "*"
+      },
+      {
+        # GWLB resource creation. Scoped to Gateway Load Balancer
+        # resource types and gated on Shifter ownership request tags so
+        # this statement cannot create ALB/NLB resources or untagged
+        # resources.
+        Sid    = "GWLBCreate"
         Effect = "Allow"
         Action = [
           "elasticloadbalancing:CreateLoadBalancer",
-          "elasticloadbalancing:DeleteLoadBalancer",
           "elasticloadbalancing:CreateTargetGroup",
+          "elasticloadbalancing:CreateListener"
+        ]
+        Resource = [
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "aws:RequestTag/shifter:system"      = "shifter"
+            "aws:RequestTag/shifter:environment" = var.environment
+            "aws:RequestTag/ManagedBy"           = "terraform"
+          }
+        }
+      },
+      {
+        # Existing-resource mutations. Restricted to Shifter-owned GWLB
+        # resources via ELBv2 resource tags so the runtime cannot delete
+        # or reconfigure load balancers it does not own.
+        Sid    = "GWLBMutateOwned"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:DeleteLoadBalancer",
           "elasticloadbalancing:DeleteTargetGroup",
-          "elasticloadbalancing:CreateListener",
           "elasticloadbalancing:DeleteListener",
           "elasticloadbalancing:RegisterTargets",
           "elasticloadbalancing:DeregisterTargets",
           "elasticloadbalancing:ModifyLoadBalancerAttributes",
           "elasticloadbalancing:ModifyTargetGroup",
           "elasticloadbalancing:ModifyTargetGroupAttributes",
-          "elasticloadbalancing:AddTags",
           "elasticloadbalancing:RemoveTags"
         ]
-        Resource = "*"
+        Resource = [
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "elasticloadbalancing:ResourceTag/shifter:system"      = "shifter"
+            "elasticloadbalancing:ResourceTag/shifter:environment" = var.environment
+            "elasticloadbalancing:ResourceTag/ManagedBy"           = "terraform"
+          }
+        }
       },
       {
-        Sid    = "GWLBDescribe"
+        # Tagging at create time. Bound to the GWLB create APIs and the
+        # Shifter ownership request tags so this statement cannot tag
+        # arbitrary ELBv2 resources or strip ownership tags later.
+        Sid    = "GWLBTagOnCreate"
         Effect = "Allow"
         Action = [
-          "elasticloadbalancing:Describe*"
+          "elasticloadbalancing:AddTags"
         ]
-        Resource = "*"
+        Resource = [
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+        ]
+        Condition = {
+          StringEquals = {
+            "elasticloadbalancing:CreateAction" = [
+              "CreateLoadBalancer",
+              "CreateTargetGroup",
+              "CreateListener"
+            ]
+            "aws:RequestTag/shifter:system"      = "shifter"
+            "aws:RequestTag/shifter:environment" = var.environment
+            "aws:RequestTag/ManagedBy"           = "terraform"
+          }
+        }
       }
     ]
   })

--- a/scripts/check_tf_iam_elb_scope/check_tf_iam_elb_scope.py
+++ b/scripts/check_tf_iam_elb_scope/check_tf_iam_elb_scope.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Lint ELBv2 (Gateway Load Balancer) IAM statements in Terraform files.
+
+The engine provisioner legitimately needs to create and manage Gateway Load
+Balancer infrastructure for NGFW traffic steering, but mutable ELBv2 APIs
+must not remain on wildcard statements that can target every load balancer,
+target group, or listener in the account.
+
+Three action families are pinned independently:
+
+- Existing-resource mutations (Delete / Modify / Register / Deregister /
+  RemoveTags) must be scoped to GWLB ARNs and require Shifter ownership
+  resource tags.
+- Resource creation (Create*LoadBalancer / Create*TargetGroup / CreateListener)
+  must be scoped to GWLB ARNs and require Shifter ownership request tags.
+- Tag-on-create (AddTags) must be scoped to GWLB ARNs and require both an
+  elasticloadbalancing:CreateAction condition and Shifter ownership request
+  tags.
+
+Describe APIs must stay in their own wildcard statement (AWS service
+authorization requires Resource = "*" for the ELBv2 read APIs).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+MUTABLE_EXISTING_ELB_ACTIONS: set[str] = {
+    "elasticloadbalancing:DeleteLoadBalancer",
+    "elasticloadbalancing:DeleteTargetGroup",
+    "elasticloadbalancing:DeleteListener",
+    "elasticloadbalancing:ModifyLoadBalancerAttributes",
+    "elasticloadbalancing:ModifyTargetGroup",
+    "elasticloadbalancing:ModifyTargetGroupAttributes",
+    "elasticloadbalancing:RegisterTargets",
+    "elasticloadbalancing:DeregisterTargets",
+    "elasticloadbalancing:RemoveTags",
+}
+CREATE_ELB_ACTIONS: set[str] = {
+    "elasticloadbalancing:CreateLoadBalancer",
+    "elasticloadbalancing:CreateTargetGroup",
+    "elasticloadbalancing:CreateListener",
+}
+TAG_ON_CREATE_ELB_ACTIONS: set[str] = {
+    "elasticloadbalancing:AddTags",
+}
+ALL_MUTABLE_ELB_ACTIONS: set[str] = (
+    MUTABLE_EXISTING_ELB_ACTIONS | CREATE_ELB_ACTIONS | TAG_ON_CREATE_ELB_ACTIONS
+)
+
+REQUIRED_RESOURCE_SNIPPETS: tuple[str, ...] = (
+    "loadbalancer/gwy/",
+    "listener/gwy/",
+    "targetgroup/",
+)
+EXISTING_RESOURCE_TAG_KEYS: tuple[str, ...] = (
+    "elasticloadbalancing:ResourceTag/shifter:system",
+    "elasticloadbalancing:ResourceTag/shifter:environment",
+    "elasticloadbalancing:ResourceTag/ManagedBy",
+)
+REQUEST_TAG_KEYS: tuple[str, ...] = (
+    "aws:RequestTag/shifter:system",
+    "aws:RequestTag/shifter:environment",
+    "aws:RequestTag/ManagedBy",
+)
+CREATE_ACTION_CONDITION_KEY: str = "elasticloadbalancing:CreateAction"
+
+_RESOURCE_RE = re.compile(r'^\s*resource\s+"aws_iam_role_policy"\s+"([^"]+)"\s*\{')
+_ACTION_RE = re.compile(r'"(elasticloadbalancing:[^"]+)"')
+
+
+@dataclass
+class Violation:
+    file: Path
+    line: int
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}: {self.reason}"
+
+
+def _brace_delta(line: str) -> int:
+    return line.count("{") - line.count("}")
+
+
+def _extract_statement_blocks(lines: list[str]) -> list[tuple[int, str]]:
+    blocks: list[tuple[int, str]] = []
+    idx = 0
+    while idx < len(lines):
+        line = lines[idx]
+        if not re.match(r"^\s*\{\s*$", line):
+            idx += 1
+            continue
+
+        start_idx = idx
+        depth = _brace_delta(line)
+        idx += 1
+        while idx < len(lines) and depth > 0:
+            depth += _brace_delta(lines[idx])
+            idx += 1
+
+        block = "\n".join(lines[start_idx:idx])
+        if '"elasticloadbalancing:' in block:
+            blocks.append((start_idx + 1, block))
+    return blocks
+
+
+def _extract_policy_body(lines: list[str], resource_name: str) -> tuple[int, list[str]] | None:
+    in_resource = False
+    resource_depth = 0
+    resource_start = 0
+
+    for idx, line in enumerate(lines):
+        if not in_resource:
+            match = _RESOURCE_RE.match(line)
+            if match and match.group(1) == resource_name:
+                in_resource = True
+                resource_depth = _brace_delta(line)
+                resource_start = idx
+            continue
+
+        resource_depth += _brace_delta(line)
+        if resource_depth <= 0:
+            return resource_start + 1, lines[resource_start : idx + 1]
+
+    return None
+
+
+def _actions(block: str) -> set[str]:
+    return set(_ACTION_RE.findall(block))
+
+
+def _action_matches(actions: set[str], family: set[str]) -> list[str]:
+    matches: set[str] = set()
+    for action in actions:
+        for member in family:
+            if action == member or fnmatchcase(member, action):
+                matches.add(action)
+    return sorted(matches)
+
+
+def _wildcard_action_violations(
+    path: Path, line: int, mutable_actions: list[str]
+) -> list[Violation]:
+    wildcard_actions = [action for action in mutable_actions if "*" in action]
+    if not wildcard_actions:
+        return []
+    return [
+        Violation(
+            path,
+            line,
+            "mutable ELBv2 actions must be enumerated, "
+            f"not granted through wildcard action patterns ({', '.join(wildcard_actions)})",
+        )
+    ]
+
+
+def _statement_scope_violations(
+    path: Path, line: int, block: str, mutable_actions: list[str]
+) -> list[Violation]:
+    violations: list[Violation] = []
+    if 'Resource = "*"' in block:
+        violations.append(
+            Violation(
+                path,
+                line,
+                "mutable ELBv2 actions must not use Resource=* "
+                f"({', '.join(mutable_actions)})",
+            )
+        )
+    if not all(snippet in block for snippet in REQUIRED_RESOURCE_SNIPPETS):
+        violations.append(
+            Violation(
+                path,
+                line,
+                "mutable ELBv2 actions must be scoped to GWLB ELBv2 ARNs "
+                "(loadbalancer/gwy/, listener/gwy/, targetgroup/)",
+            )
+        )
+    return violations
+
+
+def _required_keys_violations(
+    path: Path,
+    line: int,
+    block: str,
+    keys: tuple[str, ...],
+    reason_template: str,
+) -> list[Violation]:
+    return [
+        Violation(path, line, reason_template.format(key=key))
+        for key in keys
+        if key not in block
+    ]
+
+
+def _statement_mixing_violations(path: Path, line: int, block: str) -> list[Violation]:
+    if "elasticloadbalancing:Describe" not in block:
+        return []
+    return [
+        Violation(
+            path,
+            line,
+            "Describe APIs must stay separate from mutable ELBv2 actions",
+        )
+    ]
+
+
+def _check_statement(path: Path, line: int, block: str) -> list[Violation]:
+    actions = _actions(block)
+    mutable_actions = _action_matches(actions, ALL_MUTABLE_ELB_ACTIONS)
+    if not mutable_actions:
+        return []
+
+    violations: list[Violation] = []
+    violations.extend(_wildcard_action_violations(path, line, mutable_actions))
+    violations.extend(_statement_scope_violations(path, line, block, mutable_actions))
+    violations.extend(_statement_mixing_violations(path, line, block))
+
+    has_existing = bool(_action_matches(actions, MUTABLE_EXISTING_ELB_ACTIONS))
+    has_create = bool(_action_matches(actions, CREATE_ELB_ACTIONS))
+    has_tag_on_create = bool(_action_matches(actions, TAG_ON_CREATE_ELB_ACTIONS))
+
+    if has_existing:
+        violations.extend(
+            _required_keys_violations(
+                path,
+                line,
+                block,
+                EXISTING_RESOURCE_TAG_KEYS,
+                "mutable ELBv2 actions on existing resources must require {key}",
+            )
+        )
+    if has_create:
+        violations.extend(
+            _required_keys_violations(
+                path,
+                line,
+                block,
+                REQUEST_TAG_KEYS,
+                "ELBv2 create actions must require {key}",
+            )
+        )
+    if has_tag_on_create:
+        violations.extend(
+            _required_keys_violations(
+                path,
+                line,
+                block,
+                REQUEST_TAG_KEYS,
+                "ELBv2 AddTags must require {key}",
+            )
+        )
+        if CREATE_ACTION_CONDITION_KEY not in block:
+            violations.append(
+                Violation(
+                    path,
+                    line,
+                    "ELBv2 AddTags must require "
+                    f"{CREATE_ACTION_CONDITION_KEY} (creation-time-only tagging)",
+                )
+            )
+
+    return violations
+
+
+def check_file(path: Path, resource_name: str = "gwlb") -> list[Violation]:
+    lines = path.read_text().splitlines()
+    policy = _extract_policy_body(lines, resource_name)
+    if policy is None:
+        return []
+
+    policy_start_line, policy_lines = policy
+    violations: list[Violation] = []
+    for relative_line, block in _extract_statement_blocks(policy_lines):
+        line = policy_start_line + relative_line - 1
+        violations.extend(_check_statement(path, line, block))
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(
+            "usage: check_tf_iam_elb_scope.py FILE.tf [FILE.tf ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    violations: list[Violation] = []
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.exists():
+            print(f"{path}: file not found", file=sys.stderr)
+            return 2
+        if path.suffix == ".tf":
+            violations.extend(check_file(path))
+
+    if violations:
+        print(
+            "ELBv2 IAM scope violations "
+            f"({len(violations)} total):",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/check_tf_iam_elb_scope/test_check_tf_iam_elb_scope.py
+++ b/scripts/check_tf_iam_elb_scope/test_check_tf_iam_elb_scope.py
@@ -1,0 +1,418 @@
+"""Tests for check_tf_iam_elb_scope.py.
+
+Run from the repo root:
+    python3 -m unittest scripts.check_tf_iam_elb_scope.test_check_tf_iam_elb_scope -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from .check_tf_iam_elb_scope import check_file
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "iam.tf"
+    path.write_text(textwrap.dedent(body).lstrip())
+    return path
+
+
+class CheckTfIamElbScopeTest(unittest.TestCase):
+    def test_wildcard_mutation_statement_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Action = [
+                          "elasticloadbalancing:CreateLoadBalancer",
+                          "elasticloadbalancing:DeleteLoadBalancer",
+                          "elasticloadbalancing:ModifyTargetGroupAttributes",
+                          "elasticloadbalancing:Describe*"
+                        ]
+                        Resource = "*"
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(
+            any("must not use Resource=*" in reason for reason in reasons),
+            reasons,
+        )
+        self.assertTrue(
+            any("must be scoped to GWLB ELBv2 ARNs" in reason for reason in reasons),
+            reasons,
+        )
+        self.assertTrue(
+            any(
+                "elasticloadbalancing:ResourceTag/shifter:system" in reason
+                for reason in reasons
+            ),
+            reasons,
+        )
+        self.assertTrue(
+            any("Describe APIs must stay separate" in reason for reason in reasons),
+            reasons,
+        )
+
+    def test_wildcard_action_pattern_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Action = [
+                          "elasticloadbalancing:*"
+                        ]
+                        Resource = "*"
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(
+            any("wildcard action patterns" in reason for reason in reasons),
+            reasons,
+        )
+        self.assertTrue(
+            any("must not use Resource=*" in reason for reason in reasons),
+            reasons,
+        )
+
+    def test_create_statement_missing_request_tags_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Sid = "GWLBCreate"
+                        Action = [
+                          "elasticloadbalancing:CreateLoadBalancer",
+                          "elasticloadbalancing:CreateTargetGroup",
+                          "elasticloadbalancing:CreateListener"
+                        ]
+                        Resource = [
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+                        ]
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(
+            any(
+                "ELBv2 create actions must require aws:RequestTag/shifter:system"
+                in reason
+                for reason in reasons
+            ),
+            reasons,
+        )
+        self.assertTrue(
+            any(
+                "ELBv2 create actions must require aws:RequestTag/ManagedBy"
+                in reason
+                for reason in reasons
+            ),
+            reasons,
+        )
+
+    def test_create_statement_on_wildcard_resource_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Sid = "GWLBCreateWildcard"
+                        Action = [
+                          "elasticloadbalancing:CreateLoadBalancer",
+                          "elasticloadbalancing:CreateTargetGroup",
+                          "elasticloadbalancing:CreateListener"
+                        ]
+                        Resource = "*"
+                        Condition = {
+                          StringEquals = {
+                            "aws:RequestTag/shifter:system"      = "shifter"
+                            "aws:RequestTag/shifter:environment" = var.environment
+                            "aws:RequestTag/ManagedBy"           = "terraform"
+                          }
+                        }
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(
+            any("must not use Resource=*" in reason for reason in reasons),
+            reasons,
+        )
+
+    def test_addtags_missing_create_action_condition_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Sid = "GWLBTagOnCreate"
+                        Action = [
+                          "elasticloadbalancing:AddTags"
+                        ]
+                        Resource = [
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+                        ]
+                        Condition = {
+                          StringEquals = {
+                            "aws:RequestTag/shifter:system"      = "shifter"
+                            "aws:RequestTag/shifter:environment" = var.environment
+                            "aws:RequestTag/ManagedBy"           = "terraform"
+                          }
+                        }
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(
+            any(
+                "AddTags must require elasticloadbalancing:CreateAction" in reason
+                for reason in reasons
+            ),
+            reasons,
+        )
+
+    def test_addtags_missing_request_tag_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Sid = "GWLBTagOnCreateMissingTag"
+                        Action = [
+                          "elasticloadbalancing:AddTags"
+                        ]
+                        Resource = [
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+                        ]
+                        Condition = {
+                          StringEquals = {
+                            "elasticloadbalancing:CreateAction" = [
+                              "CreateLoadBalancer"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(
+            any(
+                "AddTags must require aws:RequestTag/shifter:system" in reason
+                for reason in reasons
+            ),
+            reasons,
+        )
+
+    def test_scoped_statements_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Sid = "GWLBDescribe"
+                        Action = [
+                          "elasticloadbalancing:DescribeLoadBalancers",
+                          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                          "elasticloadbalancing:DescribeTargetGroups",
+                          "elasticloadbalancing:DescribeTargetGroupAttributes",
+                          "elasticloadbalancing:DescribeTargetHealth",
+                          "elasticloadbalancing:DescribeListeners",
+                          "elasticloadbalancing:DescribeTags"
+                        ]
+                        Resource = "*"
+                      },
+                      {
+                        Sid = "GWLBCreate"
+                        Action = [
+                          "elasticloadbalancing:CreateLoadBalancer",
+                          "elasticloadbalancing:CreateTargetGroup",
+                          "elasticloadbalancing:CreateListener"
+                        ]
+                        Resource = [
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+                        ]
+                        Condition = {
+                          StringEquals = {
+                            "aws:RequestTag/shifter:system"      = "shifter"
+                            "aws:RequestTag/shifter:environment" = var.environment
+                            "aws:RequestTag/ManagedBy"           = "terraform"
+                          }
+                        }
+                      },
+                      {
+                        Sid = "GWLBMutateOwned"
+                        Action = [
+                          "elasticloadbalancing:DeleteLoadBalancer",
+                          "elasticloadbalancing:DeleteTargetGroup",
+                          "elasticloadbalancing:DeleteListener",
+                          "elasticloadbalancing:RegisterTargets",
+                          "elasticloadbalancing:DeregisterTargets",
+                          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                          "elasticloadbalancing:ModifyTargetGroup",
+                          "elasticloadbalancing:ModifyTargetGroupAttributes",
+                          "elasticloadbalancing:RemoveTags"
+                        ]
+                        Resource = [
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+                        ]
+                        Condition = {
+                          StringEquals = {
+                            "elasticloadbalancing:ResourceTag/shifter:system"      = "shifter"
+                            "elasticloadbalancing:ResourceTag/shifter:environment" = var.environment
+                            "elasticloadbalancing:ResourceTag/ManagedBy"           = "terraform"
+                          }
+                        }
+                      },
+                      {
+                        Sid = "GWLBTagOnCreate"
+                        Action = [
+                          "elasticloadbalancing:AddTags"
+                        ]
+                        Resource = [
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/gwy/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:listener/gwy/*/*/*",
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:targetgroup/*"
+                        ]
+                        Condition = {
+                          StringEquals = {
+                            "elasticloadbalancing:CreateAction" = [
+                              "CreateLoadBalancer",
+                              "CreateTargetGroup",
+                              "CreateListener"
+                            ]
+                            "aws:RequestTag/shifter:system"      = "shifter"
+                            "aws:RequestTag/shifter:environment" = var.environment
+                            "aws:RequestTag/ManagedBy"           = "terraform"
+                          }
+                        }
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            self.assertEqual(check_file(tf), [])
+
+    def test_missing_gwy_resource_path_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_iam_role_policy" "gwlb" {
+                  policy = jsonencode({
+                    Statement = [
+                      {
+                        Sid = "ELBMutateButWrongResourceType"
+                        Action = [
+                          "elasticloadbalancing:DeleteLoadBalancer",
+                          "elasticloadbalancing:ModifyTargetGroupAttributes"
+                        ]
+                        Resource = [
+                          "arn:aws:elasticloadbalancing:${local.region}:${local.account_id}:loadbalancer/app/*"
+                        ]
+                        Condition = {
+                          StringEquals = {
+                            "elasticloadbalancing:ResourceTag/shifter:system"      = "shifter"
+                            "elasticloadbalancing:ResourceTag/shifter:environment" = var.environment
+                            "elasticloadbalancing:ResourceTag/ManagedBy"           = "terraform"
+                          }
+                        }
+                      }
+                    ]
+                  })
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertTrue(
+            any("must be scoped to GWLB ELBv2 ARNs" in reason for reason in reasons),
+            reasons,
+        )
+
+    def test_current_engine_provisioner_policy_scopes_mutable_elb_actions(self) -> None:
+        path = Path("platform/terraform/modules/engine-provisioner/iam.tf")
+
+        # Without this assertion, renaming or removing the gwlb policy block
+        # would make check_file return [] (resource not found) and this test
+        # would pass vacuously, defeating the regression coverage.
+        self.assertIn(
+            'resource "aws_iam_role_policy" "gwlb"',
+            path.read_text(),
+            "iam.tf must contain aws_iam_role_policy.gwlb for this check to be meaningful",
+        )
+        self.assertEqual(check_file(path), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The engine-provisioner ECS task role's GWLB IAM policy granted mutable elasticloadbalancing:* actions on Resource = "*", letting the runtime touch any load balancer in the account. Split the policy into Describe (enumerated, Resource = "*" per AWS authorization model), Create (scoped to Gateway Load Balancer ARNs with aws:RequestTag ownership), existing-resource mutations (same ARNs with elasticloadbalancing:ResourceTag ownership), and AddTags (gated on elasticloadbalancing:CreateAction plus request tags). Add a scripts/check_tf_iam_elb_scope guardrail mirroring the existing EC2 IAM checker — pre-commit and the Quality workflow now reject regressions across all three mutation classes.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #46

## ADR Impact

- ADR-021

## Changes

- platform/terraform/modules/engine-provisioner/iam.tf: refactor aws_iam_role_policy.gwlb into four resource-scoped, tag-conditioned statements (GWLBDescribe, GWLBCreate, GWLBMutateOwned, GWLBTagOnCreate).
- scripts/check_tf_iam_elb_scope/: new static checker covering existing-resource mutations, resource creation, and tag-on-create families; 9 unit tests pin the shape including a live-policy integration test guarded by an explicit resource-block assertion.
- .pre-commit-config.yaml, .github/workflows/_quality.yml, .github/workflows/deploy.yml: wire the new checker through pre-commit, the Quality workflow's terraform-lint job, the checker-tests batch, and the Quality-only deploy path filter.
- docs/adr/exceptions.yaml: drop ELBv2 from the ADR-004-R11 'Resource = * by AWS design' justification for engine-provisioner/iam.tf and point at the new static check.
- docs/architecture/elb-iam-scope-preflight-46.md: flip preflight design note from pre-implementation to implemented status.
- changelog.d/46.security.md: security fragment summarizing the scope narrowing and regression guard.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Unit: `python3 -m unittest scripts.check_tf_iam_elb_scope.test_check_tf_iam_elb_scope` (9 tests). Local validation: `python3 scripts/adr_guard/adr_guard.py --all --level ci`, `pre-commit run --all-files`, `terraform fmt -check && terraform init -backend=false && terraform validate` on `platform/terraform/modules/engine-provisioner`, `tflint --recursive --config ../../.tflint.hcl` from `platform/terraform/`.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/46.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed