### PR TITLE
security(portal): add east-west inspection boundary to portal VPC

### DIFF
--- a/changelog.d/122.security.md
+++ b/changelog.d/122.security.md
@@ -1,0 +1,11 @@
+Add a portal-VPC east-west inspection boundary on AWS. An AWS Network
+Firewall sits between the public ALB tier and the private services
+tier, with route-backed steering through a dedicated firewall subnet
+and a baseline stateful rule group that ALERTs on protocols that have
+no legitimate east-west use (SSH/RDP/ICMP). FLOW + ALERT logs go to a
+CMK-encrypted CloudWatch log group and feed the existing
+`log-aggregation` pipeline; `enable_portal_inspection = true`
+fails closed when `enable_log_aggregation = false`. Portal RDS and
+Redis ingress tighten from a broad VPC-CIDR allowlist to SG-to-SG
+references from the portal EC2 / Django security group. Gated by the
+new `enable_portal_inspection` environment variable.

--- a/docs/adr/exceptions.yaml
+++ b/docs/adr/exceptions.yaml
@@ -185,6 +185,7 @@
     "expires_on": "2027-05-26",
     "paths": [
       "platform/terraform/modules/portal/alb/main.tf",
+      "platform/terraform/modules/portal/vpc/inspection.tf",
       "platform/terraform/modules/range/vpc/firewall.tf"
     ]
   },

--- a/docs/architecture/portal-vpc-inspection-preflight-122.md
+++ b/docs/architecture/portal-vpc-inspection-preflight-122.md
@@ -1,0 +1,181 @@
+# Portal VPC Inspection Preflight (#122)
+
+Status: pre-implementation guidance
+
+Date: 2026-05-29
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/122>
+
+## Scope Boundary
+
+This is a requirement-free preflight. GitHub issue #122 is the shipping
+contract: add an inline inspection and microsegmentation boundary for the AWS
+portal VPC so traffic between the public ALB tier and internal portal services
+is logged and inspectable before production handoff.
+
+Do not implement the issue in this note. The implementation that follows must
+design against the existing AWS portal Terraform, telemetry, secret, and CI
+guardrails rather than adding parallel infrastructure concepts.
+
+## Architecture Decisions
+
+- Use AWS Network Firewall as the default portal inspection mechanism for this
+  issue. It is the repo's existing managed AWS inspection primitive, already
+  modeled in `platform/terraform/modules/range/vpc/firewall.tf`, and it avoids
+  adding a VM-Series/PAN-OS bootstrap, licensing, Secrets Manager, and operator
+  management surface to the portal boundary.
+- The portal firewall is a portal-owned boundary. Reuse range-side Network
+  Firewall patterns for Terraform shape, logging, KMS, and route-table hygiene,
+  but do not reuse range concepts such as Kali, victim, XDR egress allowlists,
+  NGFW bypass, or range VPC route outputs.
+- Inspection must be route-backed. Create a dedicated portal firewall subnet
+  tier and route the protected flows through firewall endpoints with symmetric
+  return paths. Do not claim inspection for traffic that stays in one subnet,
+  bypasses route tables, or cannot be proven to return through the same
+  stateful inspection path.
+- Keep WAF at the public ALB, but treat it as north-south HTTP protection only.
+  WAF, ALB access logs, VPC Flow Logs, and RDS logs are telemetry layers; they
+  are not substitutes for the inline east-west inspection boundary.
+- Logging and alerting must feed the existing `log-aggregation` module and
+  shared alerting conventions. New firewall log groups should be emitted as
+  module outputs and included in the environment root's `source_log_group_names`
+  so CloudWatch -> Firehose -> S3/SQS stays the single telemetry pipeline.
+- The current committed portal tfvars set `enable_alb_access_logs`,
+  `enable_vpc_flow_logs`, `enable_rds_log_exports`, and `enable_waf_logging` to
+  true while `enable_log_aggregation` is false. The implementation must make
+  production telemetry fail closed: either enable aggregation for production or
+  add Terraform validation so per-source logging cannot silently degrade to
+  empty destinations.
+- Tighten microsegmentation with security-group-to-security-group rules where
+  the repo already has the pattern. Guacamole RDS and engine provisioner RDS
+  access already use SG references; portal RDS and Redis should not keep broad
+  `allowed_cidr_blocks = [module.vpc.vpc_cidr]` as the final posture if the
+  work claims microsegmentation.
+- LibreChat is named in the issue, but this repo currently has no canonical
+  LibreChat Terraform module. If the implementation adds one, model it as a
+  named portal internal service with its own security group, log group, subnet
+  placement, secrets contract, and inspection attachment. Do not introduce a
+  generic "internal service" schema only to hide a single concrete service.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #122 |
+| --- | --- | --- |
+| AWS portal root | `platform/terraform/environments/{dev,prod}/portal/main.tf` and `variables.tf` | Wire the inspection module through both env roots consistently; keep env-specific values in tfvars or `local.auto.tfvars`. |
+| Portal network ownership | `platform/terraform/modules/portal/vpc/` | Add portal subnet/route-table outputs at the VPC boundary; do not put portal routing in app modules. |
+| Public edge | `platform/terraform/modules/portal/alb/` | Preserve HTTPS listener, `/admin` fixed-response block, WAF association, access-log contract, and target-group ownership. |
+| Django compute | `platform/terraform/modules/portal/ec2/` | Preserve private-only EC2/ASG, IMDSv2, CloudWatch awslogs, SSM bootstrap, and secret-ARN handoff. |
+| Data plane | `platform/terraform/modules/portal/rds/`, `portal/redis/`, `modules/guacamole/` | Reuse existing RDS/Redis/Guacamole resource boundaries and SG-reference patterns; do not duplicate database/cache modules. |
+| Existing inspection pattern | `platform/terraform/modules/range/vpc/firewall.tf` | Reuse AWS Network Firewall resource/logging/KMS patterns only; keep portal rules portal-specific. |
+| Telemetry pipeline | `platform/terraform/modules/log-aggregation/` | Add firewall logs through existing CloudWatch subscription/Firehose/S3/SQS outputs, not a second bucket or SIEM exporter. |
+| KMS for logs and secrets | module-local CloudWatch CMKs, `kms_cw_logs.tf`, portal Secrets Manager CMK | New log groups need CMK-backed retention; new secret readers must satisfy ADR-004-R10. |
+| Runtime secret hydration | `platform/terraform/modules/portal/ssm/`, `portal/ec2/user_data.sh`, `shifter/shifter_platform/entrypoint.sh`, `entrypoint-lib.sh` | SSM stores non-secret references; secret values come from Secrets Manager at container start and must not ride in Terraform vars or process argv. |
+| Terraform guardrails | `.tflint.hcl`, `platform/terraform/.checkov.yaml`, `docs/adr/exceptions.yaml` | Blocking Checkov/TFLint posture applies; new skips require ADR-004-R11 exceptions with owner and expiry. |
+| Architecture checks | `.gc/plan-rules.md`, `scripts/adr_guard/adr_guard.py`, `.github/workflows/deploy.yml` path filters | Terraform and docs changes must keep CI routing and ADR guard coverage intact. |
+| Product docs | `shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/networking.md` | Update the live networking/threat-model docs when the boundary lands; deprecated docs are not the source of truth. |
+
+## Cross-Cutting Layers The Design Must Pass
+
+- Auth surface: keep Cognito/OIDC as the AWS portal authentication boundary and
+  keep the ALB `/admin` deny rule intact. The inspection layer must not create
+  a new public admin path, bypass listener, private debug endpoint, or alternate
+  auth flow.
+- Secret-handling surface: AWS Network Firewall should require no new runtime
+  secret. If a later third-party appliance or LibreChat service needs a token,
+  store the value in Secrets Manager under the portal CMK, pass only secret
+  ARNs through SSM/terraform outputs, and extend the KMS grant checker scope
+  when a new role reads portal-CMK secrets.
+- Env-binding shape: required Terraform inputs belong in the portal env roots
+  and module `variables.tf` with explicit types and validation. Deployment
+  values continue to flow through `TF_VARS_<ENV>_PORTAL` or gitignored
+  `local.auto.tfvars`, not committed real operator values.
+- Terraform validation: CIDRs, subnet selections, feature toggles, and logging
+  dependencies must fail at `terraform validate`/plan time. In particular,
+  `enable_*_logging = true` with no aggregation destination must not be a
+  successful production shape.
+- Routing/security policy: use dedicated firewall subnets and exact route-table
+  entries for protected subnet CIDRs. Preserve symmetric routing for stateful
+  inspection, especially across AZs, ALB target placement, RDS failover, and
+  Guacamole ECS tasks. Keep SGs as least-privilege enforcement even when the
+  firewall is present.
+- OS/process exposure: do not put secret values, firewall rule payloads that
+  contain credentials, or appliance bootstrap authcodes into user-data command
+  lines, Docker `-e` values, process argv, or cloud-init logs. Non-secret ARNs,
+  log group names, subnet IDs, and SG IDs may remain configuration.
+- Observability/logging: new Network Firewall FLOW and ALERT logs must use
+  CloudWatch log groups with retention and KMS, and must be subscribed through
+  `log-aggregation` when aggregation is enabled. Alerting should use the
+  existing SNS/alarm pattern rather than a bespoke notification path.
+- Error envelope: this is infrastructure work. Expected failures should surface
+  through Terraform validation, plan/apply failures, Checkov/TFLint, and ADR
+  guard. Do not add Django exception classes or user-facing error envelopes
+  unless the implementation genuinely adds an application runtime surface.
+
+## Extensibility Seam
+
+The durable seam is a portal-owned inspection attachment contract: named subnet
+tiers, route-table outputs, security-group inputs, and firewall log-group
+outputs. A future internal service such as LibreChat should join that contract
+by contributing its service subnet/security group/log group to the portal env
+root, without editing the telemetry pipeline or adding a second inspection
+abstraction.
+
+Keep the enablement knob environment-owned, such as `enable_portal_inspection`.
+Per-service rule variation belongs as narrowly typed Terraform inputs on the
+portal inspection/VPC boundary, not as a root application schema, Django model,
+or duplicated YAML policy language.
+
+## Gotchas And Anti-Patterns
+
+- Do not conflate security groups with inspection. SGs decide reachability;
+  they do not provide payload visibility, alert logs, or a routeable inspection
+  boundary.
+- Do not conflate VPC Flow Logs with inline inspection. Flow logs are required
+  telemetry, but they cannot block or perform stateful rule evaluation.
+- Do not route protected services and their clients into the same subnet and
+  then claim east-west inspection. Same-subnet traffic is the common bypass
+  class for route-table-based firewalls.
+- Do not ignore asymmetric routing. Stateful inspection can fail or silently
+  miss return traffic if cross-AZ routes, ALB target selection, RDS failover,
+  or ECS task placement send each direction through different endpoints.
+- Do not claim portal-to-range peering traffic is covered by the new portal
+  firewall unless the implementation explicitly routes and validates it. The
+  issue is portal VPC defense-in-depth, independent of range-side controls.
+- Do not copy range firewall allowlist rules into the portal. Portal service
+  traffic is not Kali/victim egress and should not inherit XDR egress language,
+  PANW allowlists, or NGFW licensing bypasses.
+- Do not add a parallel log bucket, SQS queue, SIEM connector, KMS key policy
+  pattern, exception format, or workflow path filter if the existing
+  log-aggregation and ADR machinery covers it.
+- Do not add Checkov inline skips without matching `docs/adr/exceptions.yaml`
+  entries. The repo's Terraform Checkov gate is blocking by design.
+- Do not make production depend on example.com committed tfvars. Real values
+  still come from GitHub secrets or gitignored local overrides.
+
+## Non-Goals
+
+- No application feature work, Django DTO/schema work, database migrations, or
+  new business-service abstractions.
+- No change to Cognito/OIDC auth, CTF participant auth, Django admin policy, or
+  risk-register audit schema.
+- No GCP implementation, Kubernetes NetworkPolicy change, or Helm chart change
+  unless the issue scope is explicitly expanded.
+- No range-side redesign, range egress policy change, or reuse of persistent
+  per-user VM-Series NGFW infrastructure for the portal.
+- No new secret hierarchy, exception hierarchy, validation framework, logging
+  framework, or workflow engine.
+
+## Validation Expectations
+
+For the implementation change, run the repo-required architecture checks for
+all touched surfaces. At minimum for AWS portal Terraform plus docs:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+cd platform/terraform && tflint --recursive --config ../../.tflint.hcl
+```
+
+Also run `terraform fmt`, `terraform validate`, and Checkov through the
+repo-standard hooks/CI path for any touched Terraform roots or modules. Run
+`actionlint` if workflow path filters change, and update ADR exceptions/docs in
+the same PR if any new guardrail waiver is introduced.

--- a/platform/terraform/environments/dev/portal/main.tf
+++ b/platform/terraform/environments/dev/portal/main.tf
@@ -232,6 +232,11 @@ module "vpc" {
   # Phase 5: VPC Flow Logs
   enable_flow_logs   = var.enable_vpc_flow_logs
   log_retention_days = var.log_retention_days
+
+  # Portal east-west inspection (#122)
+  enable_portal_inspection    = var.enable_portal_inspection
+  enable_log_aggregation      = var.enable_log_aggregation
+  firewall_log_retention_days = var.firewall_log_retention_days
 }
 
 # ------------------------------------------------------------------------------
@@ -241,11 +246,11 @@ module "vpc" {
 module "rds" {
   source = "../../../modules/portal/rds"
 
-  name_prefix         = local.name_prefix
-  secrets_kms_key_arn = aws_kms_key.secrets_manager.arn
-  vpc_id              = module.vpc.vpc_id
-  subnet_ids          = module.vpc.private_subnet_ids
-  allowed_cidr_blocks = [module.vpc.vpc_cidr]
+  name_prefix                = local.name_prefix
+  secrets_kms_key_arn        = aws_kms_key.secrets_manager.arn
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnet_ids
+  allowed_security_group_ids = [module.ec2.security_group_id]
 
   db_name               = var.db_name
   db_username           = var.db_username
@@ -298,13 +303,13 @@ module "alb" {
 module "redis" {
   source = "../../../modules/portal/redis"
 
-  name_prefix         = local.name_prefix
-  vpc_id              = module.vpc.vpc_id
-  subnet_ids          = module.vpc.private_subnet_ids
-  allowed_cidr_blocks = [module.vpc.vpc_cidr]
-  node_type           = var.redis_node_type
-  engine_version      = var.redis_engine_version
-  enable_replication  = var.redis_enable_replication
+  name_prefix                = local.name_prefix
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnet_ids
+  allowed_security_group_ids = [module.ec2.security_group_id]
+  node_type                  = var.redis_node_type
+  engine_version             = var.redis_engine_version
+  enable_replication         = var.redis_enable_replication
 
   # CloudWatch Alarms
   enable_alarms = var.alarm_email != ""
@@ -603,9 +608,11 @@ resource "aws_vpc_peering_connection" "portal_to_range" {
   })
 }
 
-# Route from Portal private subnets to Range VPC via peering
+# Route from Portal private subnets to Range VPC via peering (per-AZ).
 resource "aws_route" "portal_to_range" {
-  route_table_id            = module.vpc.private_route_table_id
+  count = length(module.vpc.private_route_table_ids)
+
+  route_table_id            = module.vpc.private_route_table_ids[count.index]
   destination_cidr_block    = data.terraform_remote_state.range.outputs.vpc_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.portal_to_range.id
 }
@@ -823,6 +830,8 @@ module "log_aggregation" {
     module.engine_provisioner.log_group_names,
     # Guacamole logs
     module.guacamole.log_group_names,
+    # Portal east-west inspection (#122)
+    var.enable_portal_inspection ? [module.vpc.firewall_log_group_name] : [],
   ) : []
 
   tags = var.tags

--- a/platform/terraform/environments/dev/portal/outputs.tf
+++ b/platform/terraform/environments/dev/portal/outputs.tf
@@ -29,9 +29,9 @@ output "availability_zones" {
   value       = module.vpc.availability_zones
 }
 
-output "private_route_table_id" {
-  description = "ID of the private route table (for NAT gateway access)"
-  value       = module.vpc.private_route_table_id
+output "private_route_table_ids" {
+  description = "IDs of the per-AZ private route tables, ordered by availability_zones."
+  value       = module.vpc.private_route_table_ids
 }
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/environments/dev/portal/terraform.tfvars
+++ b/platform/terraform/environments/dev/portal/terraform.tfvars
@@ -140,8 +140,9 @@ log_level = "DEBUG"
 # Log Aggregation
 # ------------------------------------------------------------------------------
 
-# Disabled for initial deployment - enable when ready for XDR integration
-enable_log_aggregation = false
+# Enabled so portal Network Firewall FLOW / ALERT logs reach the existing
+# CloudWatch -> Firehose -> S3 / SQS pipeline (#122 fail-closed contract).
+enable_log_aggregation = true
 
 # ------------------------------------------------------------------------------
 # Phase 5: Additional Log Sources
@@ -151,6 +152,13 @@ enable_alb_access_logs = true
 enable_vpc_flow_logs   = true
 enable_rds_log_exports = true
 enable_waf_logging     = true
+
+# ------------------------------------------------------------------------------
+# Portal east-west inspection (#122)
+# ------------------------------------------------------------------------------
+
+enable_portal_inspection    = true
+firewall_log_retention_days = 365
 
 # ------------------------------------------------------------------------------
 # Engine Provisioner

--- a/platform/terraform/environments/dev/portal/variables.tf
+++ b/platform/terraform/environments/dev/portal/variables.tf
@@ -353,6 +353,20 @@ variable "enable_waf_logging" {
 }
 
 # ------------------------------------------------------------------------------
+# Portal east-west inspection (#122)
+# ------------------------------------------------------------------------------
+
+variable "enable_portal_inspection" {
+  description = "Insert an AWS Network Firewall east-west inspection boundary between the portal public (ALB) tier and the private services tier. Requires enable_log_aggregation = true."
+  type        = bool
+}
+
+variable "firewall_log_retention_days" {
+  description = "CloudWatch retention in days for portal Network Firewall FLOW / ALERT logs."
+  type        = number
+}
+
+# ------------------------------------------------------------------------------
 # Engine Provisioner
 # ------------------------------------------------------------------------------
 

--- a/platform/terraform/environments/prod/portal/main.tf
+++ b/platform/terraform/environments/prod/portal/main.tf
@@ -232,6 +232,11 @@ module "vpc" {
   # Phase 5: VPC Flow Logs
   enable_flow_logs   = var.enable_vpc_flow_logs
   log_retention_days = var.log_retention_days
+
+  # Portal east-west inspection (#122)
+  enable_portal_inspection    = var.enable_portal_inspection
+  enable_log_aggregation      = var.enable_log_aggregation
+  firewall_log_retention_days = var.firewall_log_retention_days
 }
 
 # ------------------------------------------------------------------------------
@@ -241,11 +246,11 @@ module "vpc" {
 module "rds" {
   source = "../../../modules/portal/rds"
 
-  name_prefix         = local.name_prefix
-  secrets_kms_key_arn = aws_kms_key.secrets_manager.arn
-  vpc_id              = module.vpc.vpc_id
-  subnet_ids          = module.vpc.private_subnet_ids
-  allowed_cidr_blocks = [module.vpc.vpc_cidr]
+  name_prefix                = local.name_prefix
+  secrets_kms_key_arn        = aws_kms_key.secrets_manager.arn
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnet_ids
+  allowed_security_group_ids = [module.ec2.security_group_id]
 
   db_name               = var.db_name
   db_username           = var.db_username
@@ -298,13 +303,13 @@ module "alb" {
 module "redis" {
   source = "../../../modules/portal/redis"
 
-  name_prefix         = local.name_prefix
-  vpc_id              = module.vpc.vpc_id
-  subnet_ids          = module.vpc.private_subnet_ids
-  allowed_cidr_blocks = [module.vpc.vpc_cidr]
-  node_type           = var.redis_node_type
-  engine_version      = var.redis_engine_version
-  enable_replication  = var.redis_enable_replication
+  name_prefix                = local.name_prefix
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnet_ids
+  allowed_security_group_ids = [module.ec2.security_group_id]
+  node_type                  = var.redis_node_type
+  engine_version             = var.redis_engine_version
+  enable_replication         = var.redis_enable_replication
 
   # CloudWatch Alarms
   enable_alarms = var.alarm_email != ""
@@ -566,9 +571,11 @@ resource "aws_vpc_peering_connection" "portal_to_range" {
   })
 }
 
-# Route from Portal private subnets to Range VPC via peering
+# Route from Portal private subnets to Range VPC via peering (per-AZ).
 resource "aws_route" "portal_to_range" {
-  route_table_id            = module.vpc.private_route_table_id
+  count = length(module.vpc.private_route_table_ids)
+
+  route_table_id            = module.vpc.private_route_table_ids[count.index]
   destination_cidr_block    = data.terraform_remote_state.range.outputs.vpc_cidr
   vpc_peering_connection_id = aws_vpc_peering_connection.portal_to_range.id
 }
@@ -790,6 +797,8 @@ module "log_aggregation" {
     module.engine_provisioner.log_group_names,
     # Guacamole logs
     module.guacamole.log_group_names,
+    # Portal east-west inspection (#122)
+    var.enable_portal_inspection ? [module.vpc.firewall_log_group_name] : [],
   ) : []
 
   # Monitoring

--- a/platform/terraform/environments/prod/portal/outputs.tf
+++ b/platform/terraform/environments/prod/portal/outputs.tf
@@ -29,9 +29,9 @@ output "availability_zones" {
   value       = module.vpc.availability_zones
 }
 
-output "private_route_table_id" {
-  description = "ID of the private route table (for NAT gateway access)"
-  value       = module.vpc.private_route_table_id
+output "private_route_table_ids" {
+  description = "IDs of the per-AZ private route tables, ordered by availability_zones."
+  value       = module.vpc.private_route_table_ids
 }
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/environments/prod/portal/terraform.tfvars
+++ b/platform/terraform/environments/prod/portal/terraform.tfvars
@@ -118,7 +118,9 @@ log_level = "INFO"
 # ------------------------------------------------------------------------------
 
 # Disabled for initial deployment - enable when ready for XDR integration
-enable_log_aggregation = false
+# Enabled so portal Network Firewall FLOW / ALERT logs reach the existing
+# CloudWatch -> Firehose -> S3 / SQS pipeline (#122 fail-closed contract).
+enable_log_aggregation = true
 
 # ------------------------------------------------------------------------------
 # Phase 5: Additional Log Sources
@@ -128,6 +130,13 @@ enable_alb_access_logs = true
 enable_vpc_flow_logs   = true
 enable_rds_log_exports = true
 enable_waf_logging     = true
+
+# ------------------------------------------------------------------------------
+# Portal east-west inspection (#122)
+# ------------------------------------------------------------------------------
+
+enable_portal_inspection    = true
+firewall_log_retention_days = 365
 
 # ------------------------------------------------------------------------------
 # Engine Provisioner

--- a/platform/terraform/environments/prod/portal/variables.tf
+++ b/platform/terraform/environments/prod/portal/variables.tf
@@ -281,6 +281,20 @@ variable "enable_waf_logging" {
 }
 
 # ------------------------------------------------------------------------------
+# Portal east-west inspection (#122)
+# ------------------------------------------------------------------------------
+
+variable "enable_portal_inspection" {
+  description = "Insert an AWS Network Firewall east-west inspection boundary between the portal public (ALB) tier and the private services tier. Requires enable_log_aggregation = true."
+  type        = bool
+}
+
+variable "firewall_log_retention_days" {
+  description = "CloudWatch retention in days for portal Network Firewall FLOW / ALERT logs."
+  type        = number
+}
+
+# ------------------------------------------------------------------------------
 # Engine Provisioner
 # ------------------------------------------------------------------------------
 

--- a/platform/terraform/modules/portal/alb/main.tf
+++ b/platform/terraform/modules/portal/alb/main.tf
@@ -364,7 +364,12 @@ resource "aws_wafv2_web_acl_association" "this" {
 # ------------------------------------------------------------------------------
 
 resource "aws_wafv2_web_acl_logging_configuration" "this" {
-  count = var.enable_waf && var.enable_waf_logging && var.waf_log_destination_arn != "" ? 1 : 0
+  # The previous guard `var.waf_log_destination_arn != ""` becomes
+  # apply-time when the caller wires the ARN from a Firehose output, so
+  # plan can't determine the count. Rely on the boolean toggle: callers
+  # must set `enable_waf_logging = false` (and may pass any value for
+  # waf_log_destination_arn) when WAF logging is off.
+  count = var.enable_waf && var.enable_waf_logging ? 1 : 0
 
   log_destination_configs = [var.waf_log_destination_arn]
   resource_arn            = aws_wafv2_web_acl.this[0].arn

--- a/platform/terraform/modules/portal/rds/main.tf
+++ b/platform/terraform/modules/portal/rds/main.tf
@@ -36,13 +36,27 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_security_group_rule" "ingress_postgres" {
+  count = length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+
   type              = "ingress"
   from_port         = 5432
   to_port           = 5432
   protocol          = "tcp"
   cidr_blocks       = var.allowed_cidr_blocks
   security_group_id = aws_security_group.this.id
-  description       = "PostgreSQL access"
+  description       = "PostgreSQL access (CIDR-based)"
+}
+
+resource "aws_security_group_rule" "ingress_postgres_sg" {
+  count = length(var.allowed_security_group_ids)
+
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = var.allowed_security_group_ids[count.index]
+  security_group_id        = aws_security_group.this.id
+  description              = "PostgreSQL access (SG-based)"
 }
 
 resource "aws_security_group_rule" "egress_all" {
@@ -151,6 +165,13 @@ resource "aws_db_instance" "this" {
   # Whether class/storage/parameter changes apply during the deploy or wait
   # for the maintenance window. Set true in dev, false in prod.
   apply_immediately = var.apply_immediately
+
+  lifecycle {
+    precondition {
+      condition     = length(var.allowed_security_group_ids) > 0 || length(var.allowed_cidr_blocks) > 0
+      error_message = "portal/rds: at least one of allowed_security_group_ids or allowed_cidr_blocks must be non-empty so the RDS security group has an ingress source."
+    }
+  }
 
   tags = merge(var.tags, {
     Name   = "${var.name_prefix}-db"

--- a/platform/terraform/modules/portal/rds/variables.tf
+++ b/platform/terraform/modules/portal/rds/variables.tf
@@ -16,8 +16,15 @@ variable "subnet_ids" {
 }
 
 variable "allowed_cidr_blocks" {
-  description = "CIDR blocks allowed to access the database"
+  description = "CIDR blocks allowed to access the database. Prefer allowed_security_group_ids; CIDRs are kept for callers that genuinely cannot pass an SG."
   type        = list(string)
+  default     = []
+}
+
+variable "allowed_security_group_ids" {
+  description = "Security group IDs allowed to access the database. Preferred over allowed_cidr_blocks for microsegmentation. At least one of allowed_cidr_blocks or allowed_security_group_ids must be non-empty (enforced by a precondition on the RDS instance)."
+  type        = list(string)
+  default     = []
 }
 
 variable "db_name" {

--- a/platform/terraform/modules/portal/redis/main.tf
+++ b/platform/terraform/modules/portal/redis/main.tf
@@ -35,13 +35,27 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_security_group_rule" "ingress_redis" {
+  count = length(var.allowed_cidr_blocks) > 0 ? 1 : 0
+
   type              = "ingress"
   from_port         = 6379
   to_port           = 6379
   protocol          = "tcp"
   cidr_blocks       = var.allowed_cidr_blocks
   security_group_id = aws_security_group.this.id
-  description       = "Redis access"
+  description       = "Redis access (CIDR-based)"
+}
+
+resource "aws_security_group_rule" "ingress_redis_sg" {
+  count = length(var.allowed_security_group_ids)
+
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  source_security_group_id = var.allowed_security_group_ids[count.index]
+  security_group_id        = aws_security_group.this.id
+  description              = "Redis access (SG-based)"
 }
 
 resource "aws_security_group_rule" "egress_all" {
@@ -77,13 +91,21 @@ resource "aws_elasticache_cluster" "single_node" {
   # Maintenance window (UTC) - Sunday 3-4 AM
   maintenance_window = "sun:03:00-sun:04:00"
 
-  # Snapshot retention disabled for single-node (not supported)
-  snapshot_retention_limit = 0
+  # Daily snapshot (CKV_AWS_134). Mirrors the replication-group window.
+  snapshot_retention_limit = 1
+  snapshot_window          = "01:00-02:00"
 
   tags = merge(var.tags, {
     Name   = "${var.name_prefix}-redis"
     Module = "redis"
   })
+
+  lifecycle {
+    precondition {
+      condition     = length(var.allowed_security_group_ids) > 0 || length(var.allowed_cidr_blocks) > 0
+      error_message = "portal/redis: at least one of allowed_security_group_ids or allowed_cidr_blocks must be non-empty so the Redis security group has an ingress source."
+    }
+  }
 }
 
 # ------------------------------------------------------------------------------
@@ -123,6 +145,13 @@ resource "aws_elasticache_replication_group" "ha" {
     Name   = "${var.name_prefix}-redis"
     Module = "redis"
   })
+
+  lifecycle {
+    precondition {
+      condition     = length(var.allowed_security_group_ids) > 0 || length(var.allowed_cidr_blocks) > 0
+      error_message = "portal/redis: at least one of allowed_security_group_ids or allowed_cidr_blocks must be non-empty so the Redis security group has an ingress source."
+    }
+  }
 }
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/portal/redis/variables.tf
+++ b/platform/terraform/modules/portal/redis/variables.tf
@@ -16,8 +16,15 @@ variable "subnet_ids" {
 }
 
 variable "allowed_cidr_blocks" {
-  description = "CIDR blocks allowed to access Redis"
+  description = "CIDR blocks allowed to access Redis. Prefer allowed_security_group_ids; CIDRs are kept for callers that genuinely cannot pass an SG."
   type        = list(string)
+  default     = []
+}
+
+variable "allowed_security_group_ids" {
+  description = "Security group IDs allowed to access Redis. Preferred over allowed_cidr_blocks for microsegmentation. At least one of allowed_cidr_blocks or allowed_security_group_ids must be non-empty (enforced by a precondition on the Redis instance)."
+  type        = list(string)
+  default     = []
 }
 
 variable "node_type" {

--- a/platform/terraform/modules/portal/vpc/inspection.tf
+++ b/platform/terraform/modules/portal/vpc/inspection.tf
@@ -1,0 +1,340 @@
+# Portal east-west inspection boundary (#122).
+#
+# Inserts an AWS Network Firewall between the portal public tier (ALB) and
+# the private services tier (Django EC2, RDS, Redis, Guacamole ECS) so
+# internal traffic between the two is route-backed, logged, and inspectable.
+#
+# v1 scope:
+#   - Per-AZ firewall subnets, per-AZ Network Firewall endpoints, and
+#     per-AZ public/private/firewall route tables, so the firewall is
+#     not a single zonal failure dependency on the portal ingress path.
+#   - Complete public<->private route matrix: every public RT routes
+#     every private subnet CIDR through its same-AZ firewall endpoint
+#     (and the symmetric private->public matrix), so cross-AZ flows
+#     created by ALB cross-zone load balancing and by the single shared
+#     NAT do not fall back to implicit local routing and bypass
+#     inspection.
+#   - Stateful default = pass; a baseline rule group ALERTs on protocols
+#     that have no legitimate east-west use in the portal (SSH/RDP/ICMP).
+#   - FLOW + ALERT logs go to a CMK-encrypted CloudWatch log group; the env
+#     root subscribes that log group through the existing log-aggregation
+#     pipeline.
+#
+# Stateful symmetry trade-off:
+#   ALB cross-zone load balancing is always on for ALB (the platform
+#   cannot turn it off), and the portal runs a single shared NAT. So
+#   public<->private and private<->Internet flows can legitimately cross
+#   AZs in either direction. With per-AZ firewall endpoints, cross-AZ
+#   flows are inspected by different endpoints on the forward and return
+#   legs (asymmetric stateful). This is compatible with the visibility-
+#   first v1 policy (pass + alert + FLOW) because rules fire per packet
+#   on whichever endpoint observes it and FLOW logs from both endpoints
+#   reconstruct the flow. A stateful drop-by-default posture would
+#   require a centralized inspection topology (single endpoint via
+#   Transit Gateway, GWLB with consistent hashing, or single-AZ portal
+#   appliance) — all deferred beyond this issue.
+#
+# Out of scope (explicit deferrals):
+#   - Stateful-symmetric inspection for cross-AZ flows (see trade-off
+#     above).
+#   - Inspection of portal<->range peering traffic.
+
+locals {
+  # Default firewall subnets to /28 blocks at the top of the VPC /16 so
+  # they do not collide with the public/private /20 tiers at the bottom.
+  # firewall_subnet_cidr (singular) on var is the v0 single-AZ override;
+  # the per-AZ default below is preferred. If both are set, the per-AZ
+  # default still wins for indexes > 0 (the override only covers index 0
+  # for backwards-compat).
+  firewall_subnet_cidrs = [
+    for i in range(var.az_count) :
+    var.firewall_subnet_cidr != "" && i == 0
+    ? var.firewall_subnet_cidr
+    : cidrsubnet(var.vpc_cidr, 12, 4080 + i)
+  ]
+}
+
+# ------------------------------------------------------------------------------
+# Per-AZ firewall subnets + route tables
+# ------------------------------------------------------------------------------
+
+resource "aws_subnet" "firewall" {
+  count = var.enable_portal_inspection ? var.az_count : 0
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = local.firewall_subnet_cidrs[count.index]
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = false
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-firewall-subnet-${local.azs[count.index]}"
+    Tier = "firewall"
+  })
+}
+
+resource "aws_route_table" "firewall" {
+  count = var.enable_portal_inspection ? var.az_count : 0
+
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-firewall-rt-${local.azs[count.index]}"
+  })
+}
+
+resource "aws_route_table_association" "firewall" {
+  count = var.enable_portal_inspection ? var.az_count : 0
+
+  subnet_id      = aws_subnet.firewall[count.index].id
+  route_table_id = aws_route_table.firewall[count.index].id
+}
+
+# ------------------------------------------------------------------------------
+# Stateful rule group: portal-anomalies (ALERT-only baseline)
+# ------------------------------------------------------------------------------
+# Suricata-style ALERTs on protocols with no legitimate east-west use in the
+# portal. Visibility-first: nothing is dropped here, so a misconfiguration
+# does not break a deploy. FLOW logs from the firewall capture the rest.
+
+resource "aws_networkfirewall_rule_group" "portal_anomalies" {
+  count = var.enable_portal_inspection ? 1 : 0
+
+  encryption_configuration {
+    type   = "CUSTOMER_KMS"
+    key_id = aws_kms_key.cloudwatch_logs.arn
+  }
+
+  capacity = 100
+  name     = "${var.name_prefix}-portal-anomalies"
+  type     = "STATEFUL"
+
+  rule_group {
+    rule_variables {
+      ip_sets {
+        key = "HOME_NET"
+        ip_set {
+          definition = [var.vpc_cidr]
+        }
+      }
+    }
+
+    rules_source {
+      rules_string = <<-EOT
+        alert tcp $HOME_NET any -> $HOME_NET 22 (msg:"Portal east-west SSH (unexpected)"; flow:to_server,established; sid:1100001; rev:1;)
+        alert tcp $HOME_NET any -> $HOME_NET 3389 (msg:"Portal east-west RDP (unexpected)"; flow:to_server,established; sid:1100002; rev:1;)
+        alert icmp $HOME_NET any -> $HOME_NET any (msg:"Portal east-west ICMP (unexpected)"; sid:1100003; rev:1;)
+      EOT
+    }
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-portal-anomalies"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Firewall policy
+# ------------------------------------------------------------------------------
+
+resource "aws_networkfirewall_firewall_policy" "portal" {
+  count = var.enable_portal_inspection ? 1 : 0
+
+  encryption_configuration {
+    type   = "CUSTOMER_KMS"
+    key_id = aws_kms_key.cloudwatch_logs.arn
+  }
+
+  name = "${var.name_prefix}-portal-firewall-policy"
+
+  firewall_policy {
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+
+    stateful_rule_group_reference {
+      resource_arn = aws_networkfirewall_rule_group.portal_anomalies[0].arn
+    }
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-portal-firewall-policy"
+  })
+}
+
+# ------------------------------------------------------------------------------
+# Firewall instance (multi-AZ via subnet_mapping)
+# ------------------------------------------------------------------------------
+# CKV2_AWS_63 (firewall logging cross-resource): logging is wired via the
+# separate aws_networkfirewall_logging_configuration below. Reuses the same
+# ADR-004-R11 exception class as the range firewall.
+
+resource "aws_networkfirewall_firewall" "portal" {
+  # checkov:skip=CKV2_AWS_63:Logging defined in aws_networkfirewall_logging_configuration.portal below.
+  count = var.enable_portal_inspection ? 1 : 0
+
+  encryption_configuration {
+    type   = "CUSTOMER_KMS"
+    key_id = aws_kms_key.cloudwatch_logs.arn
+  }
+
+  name                = "${var.name_prefix}-portal-firewall"
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.portal[0].arn
+  vpc_id              = aws_vpc.this.id
+  delete_protection   = true
+
+  dynamic "subnet_mapping" {
+    for_each = aws_subnet.firewall
+    content {
+      subnet_id = subnet_mapping.value.id
+    }
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-portal-firewall"
+  })
+
+  lifecycle {
+    precondition {
+      condition     = !var.enable_portal_inspection || var.enable_log_aggregation
+      error_message = "enable_portal_inspection requires enable_log_aggregation = true so firewall FLOW / ALERT logs reach the existing log-aggregation pipeline. Either enable aggregation or disable portal inspection."
+    }
+  }
+}
+
+# ------------------------------------------------------------------------------
+# CloudWatch logging (FLOW + ALERT)
+# ------------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "firewall" {
+  count = var.enable_portal_inspection ? 1 : 0
+
+  name              = "/aws/network-firewall/${var.name_prefix}-portal"
+  retention_in_days = var.firewall_log_retention_days
+  kms_key_id        = aws_kms_key.cloudwatch_logs.arn
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name_prefix}-portal-firewall-logs"
+  })
+}
+
+resource "aws_networkfirewall_logging_configuration" "portal" {
+  count = var.enable_portal_inspection ? 1 : 0
+
+  firewall_arn = aws_networkfirewall_firewall.portal[0].arn
+
+  logging_configuration {
+    log_destination_config {
+      log_destination = {
+        logGroup = aws_cloudwatch_log_group.firewall[0].name
+      }
+      log_destination_type = "CloudWatchLogs"
+      log_type             = "ALERT"
+    }
+
+    log_destination_config {
+      log_destination = {
+        logGroup = aws_cloudwatch_log_group.firewall[0].name
+      }
+      log_destination_type = "CloudWatchLogs"
+      log_type             = "FLOW"
+    }
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Complete-matrix east-west and egress routing
+# ------------------------------------------------------------------------------
+# Every public route table installs a more-specific route to EVERY private
+# subnet CIDR via that public RT's same-AZ firewall endpoint, and every
+# private route table installs the symmetric route to every public subnet
+# CIDR via that private RT's same-AZ firewall endpoint. With ALB's
+# always-on cross-zone load balancing and a single shared NAT, public and
+# private traffic can legitimately cross AZs in either direction;
+# routing only the same-index pair through the firewall would let those
+# cross-AZ flows fall back to the implicit local VPC route and bypass
+# inspection entirely. The complete matrix closes that bypass: every
+# public<->private flow traverses some firewall endpoint in each direction
+# and gets logged + rule-evaluated.
+#
+# Stateful trade-off (acknowledged):
+#   For cross-AZ flows the forward and return legs traverse different
+#   per-AZ firewall endpoints (each AZ's RT steers through its own
+#   endpoint). The flow is therefore inspected asymmetrically: each
+#   endpoint sees one direction. This is compatible with the v1 policy
+#   (visibility-first: stateful default pass + ALERT-only rules + FLOW
+#   logs) because the rule set fires per-packet on whichever endpoint
+#   observes the packet, and FLOW logs from both endpoints together
+#   reconstruct the flow. It would not be compatible with a stateful
+#   drop-by-default policy that requires session symmetry; that posture
+#   would require a centralized inspection topology (single endpoint via
+#   Transit Gateway, GWLB with consistent hashing, or single-AZ portal
+#   appliance), all of which are larger architecture changes deferred
+#   beyond this issue.
+#
+# Egress shape:
+#   - Private egress out:  AZ-private -> AZ-firewall endpoint -> shared
+#     NAT -> IGW (private RT default 0/0 -> AZ-firewall endpoint; firewall
+#     RT default 0/0 -> the shared NAT gateway).
+#   - NAT return in:  IGW -> NAT (in public_subnet[0]) -> public RT for
+#     NAT's AZ -> firewall endpoint for THAT AZ -> destination private
+#     subnet. For private destinations in other AZs the return is
+#     therefore inspected by the NAT-AZ endpoint while the outbound
+#     leg was inspected by the source-AZ endpoint. The direct
+#     private->NAT default in main.tf is disabled when
+#     enable_portal_inspection = true so the path is uniformly
+#     private -> firewall -> NAT outbound.
+
+locals {
+  # Build a map of availability_zone -> firewall endpoint id from the
+  # firewall's sync_states. Each sync_states entry corresponds to one
+  # subnet_mapping entry, keyed by its AZ, with the endpoint id under
+  # attachment.endpoint_id.
+  firewall_endpoint_ids_by_az = var.enable_portal_inspection ? {
+    for s in tolist(aws_networkfirewall_firewall.portal[0].firewall_status[0].sync_states) :
+    s.availability_zone => tolist(s.attachment)[0].endpoint_id
+  } : {}
+
+  # Cartesian product of route-table index (which AZ's RT) x destination
+  # subnet index (which AZ's subnet CIDR). Each pair becomes one route on
+  # the route-table-AZ's same-AZ firewall endpoint pointed at the
+  # destination AZ's subnet CIDR — including the same-index pair, which
+  # remains the dominant in-AZ flow.
+  az_pairs = setproduct(range(var.az_count), range(var.az_count))
+}
+
+resource "aws_route" "public_to_private_via_firewall" {
+  count = var.enable_portal_inspection ? length(local.az_pairs) : 0
+
+  route_table_id         = aws_route_table.public[local.az_pairs[count.index][0]].id
+  destination_cidr_block = aws_subnet.private[local.az_pairs[count.index][1]].cidr_block
+  vpc_endpoint_id        = local.firewall_endpoint_ids_by_az[local.azs[local.az_pairs[count.index][0]]]
+}
+
+resource "aws_route" "private_to_public_via_firewall" {
+  count = var.enable_portal_inspection ? length(local.az_pairs) : 0
+
+  route_table_id         = aws_route_table.private[local.az_pairs[count.index][0]].id
+  destination_cidr_block = aws_subnet.public[local.az_pairs[count.index][1]].cidr_block
+  vpc_endpoint_id        = local.firewall_endpoint_ids_by_az[local.azs[local.az_pairs[count.index][0]]]
+}
+
+# Per-AZ private egress default: send 0.0.0.0/0 from the private tier
+# through the same-AZ firewall endpoint instead of straight to NAT. Pairs
+# with the firewall RT default below so the path is private -> firewall
+# -> NAT -> IGW.
+resource "aws_route" "private_default_via_firewall" {
+  count = var.enable_portal_inspection && var.enable_nat_gateway ? var.az_count : 0
+
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  vpc_endpoint_id        = local.firewall_endpoint_ids_by_az[local.azs[count.index]]
+}
+
+# Per-AZ firewall-subnet egress default: from the firewall endpoint, send
+# onward Internet-bound traffic to the existing shared NAT gateway.
+resource "aws_route" "firewall_default_via_nat" {
+  count = var.enable_portal_inspection && var.enable_nat_gateway ? var.az_count : 0
+
+  route_table_id         = aws_route_table.firewall[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[0].id
+}

--- a/platform/terraform/modules/portal/vpc/main.tf
+++ b/platform/terraform/modules/portal/vpc/main.tf
@@ -82,15 +82,19 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_route_table" "public" {
+  count = var.az_count
+
   vpc_id = aws_vpc.this.id
 
   tags = merge(local.common_tags, {
-    Name = "${var.name_prefix}-public-rt"
+    Name = "${var.name_prefix}-public-rt-${local.azs[count.index]}"
   })
 }
 
 resource "aws_route" "public_internet" {
-  route_table_id         = aws_route_table.public.id
+  count = var.az_count
+
+  route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.this.id
 }
@@ -99,7 +103,7 @@ resource "aws_route_table_association" "public" {
   count = var.az_count
 
   subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.public.id
+  route_table_id = aws_route_table.public[count.index].id
 }
 
 # ------------------------------------------------------------------------------
@@ -149,17 +153,27 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_route_table" "private" {
+  count = var.az_count
+
   vpc_id = aws_vpc.this.id
 
   tags = merge(local.common_tags, {
-    Name = "${var.name_prefix}-private-rt"
+    Name = "${var.name_prefix}-private-rt-${local.azs[count.index]}"
   })
 }
 
 resource "aws_route" "private_nat" {
-  count = var.enable_nat_gateway ? 1 : 0
+  # When portal inspection is enabled, each private route table's default
+  # route is owned by inspection.tf (private 0/0 -> same-AZ firewall
+  # endpoint -> NAT) so private egress traverses the same firewall
+  # endpoint as the NAT return path. Keeping a direct private->NAT
+  # default here would make the inspection path asymmetric: NAT return
+  # packets would enter the firewall via the public route table while
+  # the initiating leg bypassed it, breaking stateful inspection for
+  # unrelated private egress flows.
+  count = var.enable_nat_gateway && !var.enable_portal_inspection ? var.az_count : 0
 
-  route_table_id         = aws_route_table.private.id
+  route_table_id         = aws_route_table.private[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.this[0].id
 }
@@ -168,7 +182,7 @@ resource "aws_route_table_association" "private" {
   count = var.az_count
 
   subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private.id
+  route_table_id = aws_route_table.private[count.index].id
 }
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/modules/portal/vpc/outputs.tf
+++ b/platform/terraform/modules/portal/vpc/outputs.tf
@@ -35,12 +35,31 @@ output "availability_zones" {
   value       = local.azs
 }
 
-output "private_route_table_id" {
-  description = "ID of the private route table"
-  value       = aws_route_table.private.id
+output "private_route_table_ids" {
+  description = "IDs of the per-AZ private route tables (ordered by availability_zones)."
+  value       = aws_route_table.private[*].id
 }
 
 output "flow_logs_log_group_name" {
   description = "Name of the CloudWatch log group for VPC flow logs"
   value       = var.enable_flow_logs ? aws_cloudwatch_log_group.flow_logs[0].name : ""
+}
+
+# ------------------------------------------------------------------------------
+# Portal east-west inspection (#122)
+# ------------------------------------------------------------------------------
+
+output "inspection_enabled" {
+  description = "Whether the portal east-west inspection boundary is enabled."
+  value       = var.enable_portal_inspection
+}
+
+output "firewall_endpoint_ids_by_az" {
+  description = "Map of availability_zone -> portal Network Firewall endpoint ID. Empty map when inspection is disabled."
+  value       = var.enable_portal_inspection ? local.firewall_endpoint_ids_by_az : {}
+}
+
+output "firewall_log_group_name" {
+  description = "Name of the CloudWatch log group receiving Network Firewall FLOW / ALERT logs. Empty string when inspection is disabled."
+  value       = var.enable_portal_inspection ? aws_cloudwatch_log_group.firewall[0].name : ""
 }

--- a/platform/terraform/modules/portal/vpc/variables.tf
+++ b/platform/terraform/modules/portal/vpc/variables.tf
@@ -38,3 +38,28 @@ variable "log_retention_days" {
   description = "CloudWatch log retention in days for VPC flow logs"
   type        = number
 }
+
+# ------------------------------------------------------------------------------
+# Portal east-west inspection (#122)
+# ------------------------------------------------------------------------------
+
+variable "enable_portal_inspection" {
+  description = "Insert an AWS Network Firewall east-west inspection boundary between the portal public (ALB) tier and the private (Django / RDS / Redis / Guacamole) tier."
+  type        = bool
+}
+
+variable "enable_log_aggregation" {
+  description = "Whether the env root's log aggregation pipeline is enabled. Used only to fail closed: enable_portal_inspection requires enable_log_aggregation = true so firewall FLOW / ALERT logs reach the existing pipeline instead of dead-ending in CloudWatch."
+  type        = bool
+}
+
+variable "firewall_log_retention_days" {
+  description = "CloudWatch retention in days for Network Firewall FLOW / ALERT logs."
+  type        = number
+}
+
+variable "firewall_subnet_cidr" {
+  description = "CIDR block for the dedicated portal inspection firewall subnet. Must not overlap with public, private, or other reserved subnets in vpc_cidr. Default places it at the top of the VPC /16 to avoid collision with the public/private /20 tiers."
+  type        = string
+  default     = ""
+}

--- a/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/networking.md
+++ b/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/networking.md
@@ -26,6 +26,7 @@ graph TB
             ALB["ALB"]
             PortalNAT["NAT Gateway"]
         end
+        FirewallSubnetPortal["Portal Firewall Subnets (×N AZs)"]
         subgraph PrivateSubnets["Private Subnets (×3 AZs)"]
             EC2["EC2/ASG"]
             RDS["RDS"]
@@ -40,10 +41,10 @@ graph TB
     end
 
     Internet --> WAF --> ALB
-    ALB --> EC2
+    ALB --> FirewallSubnetPortal --> EC2
     EC2 --> RDS
     EC2 --> Redis
-    PrivateSubnets --> PortalNAT --> Internet
+    PrivateSubnets --> FirewallSubnetPortal --> PortalNAT --> Internet
     EC2 <-->|VPC peering| UserSubnets
 
     UserSubnets --> FirewallSubnet --> NATSubnet --> Internet
@@ -54,16 +55,78 @@ graph TB
 | Subnet Type | Components |
 |-------------|------------|
 | Public (×3 AZs) | ALB, NAT Gateway |
+| Firewall (×N AZs) | AWS Network Firewall endpoint per AZ; east-west inspection between public and private tiers |
 | Private (×3 AZs) | EC2 (single instance or ASG, configurable), RDS subnet group, Redis subnet group |
 
 Components:
 - **WAF** - Rate limiting, IP reputation, OWASP rules. Attached to ALB.
 - **ALB** - Public-facing. HTTPS only (HTTP redirects).
 - **NAT Gateway** - Single, in one public subnet.
-- **RDS** - Subnet group spans all private subnets (Multi-AZ capable).
-- **Redis** - Subnet group spans all private subnets.
+- **Portal Network Firewall** - East-west inspection between the public (ALB) tier and the private services tier. Stateful pass-through with baseline ALERT rules on protocols that have no legitimate east-west use (SSH/RDP/ICMP). FLOW + ALERT logs feed the existing `log-aggregation` pipeline. Gated by `enable_portal_inspection`; requires `enable_log_aggregation = true` so logs do not silently dead-end.
+- **RDS** - Subnet group spans all private subnets (Multi-AZ capable). Ingress restricted to the portal EC2 / Django security group (SG-to-SG, not VPC CIDR).
+- **Redis** - Subnet group spans all private subnets. Ingress restricted to the portal EC2 / Django security group (SG-to-SG, not VPC CIDR).
 
-Defined in `platform/terraform/modules/portal/vpc/` and `platform/terraform/modules/portal/alb/`.
+Defined in `platform/terraform/modules/portal/vpc/` (including `inspection.tf`) and `platform/terraform/modules/portal/alb/`.
+
+#### Portal east-west inspection (#122)
+
+Defense-in-depth boundary between the portal public tier and the
+private services tier:
+
+- **Mechanism**: AWS Network Firewall, the same managed primitive the
+  range VPC uses for egress filtering.
+- **Path**: ALB → firewall endpoint → Django EC2 (and the return path).
+  The VPC has per-AZ public, private, and firewall route tables, plus
+  one Network Firewall endpoint per AZ via the firewall's
+  `subnet_mapping`. Each AZ's public RT keeps its IGW default and adds
+  a more-specific route to every private subnet CIDR via that AZ's
+  firewall endpoint; each AZ's private RT routes every public subnet
+  CIDR via that AZ's firewall endpoint and redirects its 0/0 default
+  through that endpoint; each AZ's firewall RT default sends onward
+  Internet-bound traffic to the shared NAT gateway. The full route
+  matrix ensures cross-AZ flows (created by ALB cross-zone load
+  balancing and by the single shared NAT) cannot fall back to the
+  implicit local VPC route and bypass inspection.
+- **Stateful trade-off**: ALB always has cross-zone load balancing on
+  (the platform cannot turn it off), and the portal runs a single
+  shared NAT. With per-AZ firewall endpoints, cross-AZ flows are
+  inspected by different endpoints on the forward and return legs
+  (asymmetric stateful). This is compatible with the visibility-first
+  v1 policy because rules fire per packet on whichever endpoint
+  observes them and FLOW logs from both endpoints reconstruct the
+  flow. A stateful drop-by-default posture would require a centralized
+  inspection topology (Transit Gateway with single endpoint, GWLB
+  with consistent hashing, or single-AZ appliance mode); all of those
+  are deferred beyond this issue.
+- **Policy**: stateful default pass with a baseline rule group that
+  ALERTs on protocols that should not appear east-west (SSH, RDP,
+  ICMP). FLOW logs capture every inspected flow. Visibility-first;
+  nothing is dropped by default.
+- **Logging**: FLOW + ALERT to a CMK-encrypted CloudWatch log group,
+  subscribed through `module.log_aggregation` so the existing
+  CloudWatch → Firehose → S3 / SQS pipeline carries portal-firewall
+  records.
+- **Fail-closed**: `enable_portal_inspection = true` requires
+  `enable_log_aggregation = true`; a precondition on
+  `aws_networkfirewall_firewall.portal` fails the plan otherwise.
+- **Microsegmentation**: portal RDS and Redis ingress are
+  SG-to-SG references from the portal EC2 / Django security group,
+  not a broad `vpc_cidr` allowlist.
+
+##### v1 deferrals
+
+- **Stateful symmetric inspection for cross-AZ flows**: see the
+  stateful trade-off above. Requires a centralized inspection topology
+  (Transit Gateway with single endpoint, GWLB with consistent hashing,
+  or single-AZ appliance mode).
+- **Intra-private-tier inspection** (Django ↔ RDS, Django ↔ Redis):
+  these services share the private subnets, so route-table-based
+  inspection cannot apply (same-subnet traffic bypasses route
+  lookup). v1 enforces SG-to-SG microsegmentation as the boundary for
+  this traffic. A follow-up can split RDS / Redis into a dedicated
+  data subnet tier so the firewall covers Django ↔ data as well.
+- **Portal ↔ range peering traffic**: not in scope; the range-side
+  Network Firewall already owns the range egress boundary.
 
 ### Range VPC
 


### PR DESCRIPTION
## Summary

Insert an AWS Network Firewall east-west inspection boundary between the portal public ALB tier and the private services tier (Django EC2, RDS, Redis, Guacamole ECS). Per-AZ firewall subnets and endpoints avoid a zonal failure dependency on the ingress path. A complete public<->private route matrix (every public RT routes every private subnet CIDR via its same-AZ firewall endpoint, and symmetrically) prevents cross-AZ flows from ALB cross-zone load balancing and the shared NAT from bypassing inspection via implicit local VPC routes. FLOW + ALERT logs feed the existing log-aggregation pipeline; enable_portal_inspection fails the plan if enable_log_aggregation is off. Portal RDS and Redis ingress tighten from broad vpc_cidr allowlists to SG-to-SG references from the portal EC2/Django security group.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #122

## ADR Impact

- ADR-021
- ADR-004-R11

## Changes

- New module: platform/terraform/modules/portal/vpc/inspection.tf — per-AZ firewall subnets, per-AZ route tables, Network Firewall with subnet_mapping per AZ, baseline ALERT-only stateful rule group on SSH/RDP/ICMP, CMK-encrypted CloudWatch log group, logging configuration, complete public<->private route matrix.
- Portal VPC module: public/private route tables now per-AZ (count = az_count); private_route_table_id output renamed to private_route_table_ids (list); new firewall_endpoint_ids_by_az map output (keyed by AZ).
- Portal RDS and Redis modules: added allowed_security_group_ids variable plus a lifecycle precondition; SG-based ingress preferred over CIDR-based.
- Env roots (dev + prod): wire enable_portal_inspection, enable_log_aggregation = true (fail-closed contract), firewall_log_retention_days; pass allowed_security_group_ids = [module.ec2.security_group_id] to RDS / Redis; subscribe the firewall log group through module.log_aggregation; convert portal_to_range peering route to count = az_count.
- ADR exceptions: existing CKV2_AWS_63 (Network Firewall cross-resource logging) exception widened to cover the new portal/vpc/inspection.tf file.
- Threat-model and topology doc (networking.md): new boundary, route matrix, stateful asymmetry trade-off, v1 deferrals (cross-AZ stateful symmetry, intra-private-tier inspection, portal<->range peering inspection).
- Side fix: portal Redis single-node snapshot_retention_limit raised from 0 to 1 (CKV_AWS_134) — surfaced by the new lifecycle precondition; dead code path in current deployments (replication = true in both envs).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

No automated test framework for Terraform IaC in this repo; verification is via terraform validate, tflint, Checkov, ADR guard, and Vale (docs). All gates clean pre-push. Per-AZ firewall behavior cannot be unit-tested in-repo; it will exercise on first deploy.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: Issue #122 ← platform/terraform/modules/portal/vpc/inspection.tf, Issue #122 ← platform/terraform/modules/portal/vpc/main.tf, Issue #122 ← platform/terraform/modules/portal/rds/main.tf, Issue #122 ← platform/terraform/modules/portal/redis/main.tf, Issue #122 ← shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/networking.md
- TESTS: Issue #122 ← terraform validate (dev + prod portal roots), Issue #122 ← tflint --recursive (platform/terraform), Issue #122 ← Checkov (pre-commit), Issue #122 ← scripts/adr_guard/adr_guard.py --all --level ci

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/122.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.