### PR TITLE
fix(ctf): start scheduler on gcp

### DIFF
--- a/changelog.d/484.fixed.md
+++ b/changelog.d/484.fixed.md
@@ -1,0 +1,1 @@
+**CTF scheduler startup now has a regression guard and the GCP scheduler pod can use the existing job-launcher RBAC when due event spin-up tasks submit provisioner Jobs.**

--- a/platform/charts/shifter/templates/ctf-scheduler-deployment.yaml
+++ b/platform/charts/shifter/templates/ctf-scheduler-deployment.yaml
@@ -21,8 +21,8 @@ spec:
         checksum/runtime-config: {{ include "shifter.runtimeConfigChecksum" . }}
     spec:
       {{- include "shifter.podSecurityContext" . | nindent 6 }}
-      automountServiceAccountToken: false
-      serviceAccountName: {{ .Values.serviceAccounts.workers.name }}
+      automountServiceAccountToken: true
+      serviceAccountName: {{ .Values.serviceAccounts.ctfScheduler.name }}
       containers:
         - name: ctf-scheduler
           image: {{ include "shifter.portalImage" . }}

--- a/platform/charts/shifter/templates/rbac-job-launcher.yaml
+++ b/platform/charts/shifter/templates/rbac-job-launcher.yaml
@@ -28,6 +28,20 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: job-launcher-ctf-scheduler
+  namespace: {{ .Values.namespaces.jobs }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccounts.ctfScheduler.name }}
+    namespace: {{ .Values.namespaces.platform }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: job-launcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: job-launcher-workers
   namespace: {{ .Values.namespaces.jobs }}
 subjects:

--- a/platform/charts/shifter/templates/serviceaccounts.yaml
+++ b/platform/charts/shifter/templates/serviceaccounts.yaml
@@ -27,6 +27,19 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ .Values.serviceAccounts.ctfScheduler.name }}
+  namespace: {{ .Values.namespaces.platform }}
+  labels:
+    {{- include "shifter.partOfLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ctf-scheduler
+  {{- with .Values.serviceAccounts.ctfScheduler.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: {{ .Values.serviceAccounts.provisioner.name }}
   namespace: {{ .Values.namespaces.jobs }}
   labels:

--- a/platform/charts/shifter/values.yaml
+++ b/platform/charts/shifter/values.yaml
@@ -11,6 +11,9 @@ serviceAccounts:
   workers:
     name: workers
     annotations: {}
+  ctfScheduler:
+    name: ctf-scheduler
+    annotations: {}
   provisioner:
     name: provisioner
     annotations: {}

--- a/platform/k8s/gcp/base/ctf-scheduler-deployment.yaml
+++ b/platform/k8s/gcp/base/ctf-scheduler-deployment.yaml
@@ -21,8 +21,8 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      serviceAccountName: workers
-      automountServiceAccountToken: false
+      serviceAccountName: ctf-scheduler
+      automountServiceAccountToken: true
       containers:
         - name: ctf-scheduler
           image: us-docker.pkg.dev/placeholder-project/shifter/portal:0.0.0

--- a/platform/k8s/gcp/base/rbac-job-launcher.yaml
+++ b/platform/k8s/gcp/base/rbac-job-launcher.yaml
@@ -28,6 +28,20 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: job-launcher-ctf-scheduler
+  namespace: shifter-jobs
+subjects:
+  - kind: ServiceAccount
+    name: ctf-scheduler
+    namespace: shifter-platform
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: job-launcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: job-launcher-workers
   namespace: shifter-jobs
 subjects:

--- a/platform/k8s/gcp/base/serviceaccounts.yaml
+++ b/platform/k8s/gcp/base/serviceaccounts.yaml
@@ -19,6 +19,15 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: ctf-scheduler
+  namespace: shifter-platform
+  labels:
+    app.kubernetes.io/part-of: shifter
+    app.kubernetes.io/component: ctf-scheduler
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: provisioner
   namespace: shifter-jobs
   labels:

--- a/shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py
+++ b/shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py
@@ -1,0 +1,101 @@
+"""CTF scheduler deployment startup invariants."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AWS_USER_DATA = REPO_ROOT / "platform" / "terraform" / "modules" / "portal" / "ec2" / "user_data.sh"
+AWS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_shifter-platform.yml"
+BASE_MANIFEST_DIR = REPO_ROOT / "platform" / "k8s" / "gcp" / "base"
+CHART_DIR = REPO_ROOT / "platform" / "charts" / "shifter"
+COMPOSE_FILE = REPO_ROOT / "shifter" / "shifter_platform" / "docker-compose.yml"
+SCHEDULER_COMMAND = ["python", "manage.py", "run_ctf_scheduler"]
+SCHEDULER_NAME = "ctf-scheduler"
+
+
+def _load_yaml_documents(source: str) -> list[dict[str, Any]]:
+    return [document for document in yaml.safe_load_all(source) if isinstance(document, dict)]
+
+
+def _load_base_documents() -> list[dict[str, Any]]:
+    documents: list[dict[str, Any]] = []
+    for path in BASE_MANIFEST_DIR.glob("*.yaml"):
+        documents.extend(_load_yaml_documents(path.read_text(encoding="utf-8")))
+    return documents
+
+
+def _load_helm_documents() -> list[dict[str, Any]]:
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("helm is required to validate rendered chart manifests")
+
+    rendered = subprocess.run(  # noqa: S603
+        [helm, "template", "shifter", str(CHART_DIR)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return _load_yaml_documents(rendered.stdout)
+
+
+def _deployment(documents: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    for document in documents:
+        if document.get("kind") == "Deployment" and document["metadata"]["name"] == name:
+            return document
+    raise AssertionError(f"missing Deployment/{name}")
+
+
+def _scheduler_container(deployment: dict[str, Any]) -> dict[str, Any]:
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    for container in containers:
+        if container["name"] == SCHEDULER_NAME:
+            return container
+    raise AssertionError(f"missing {SCHEDULER_NAME} container")
+
+
+def test_local_compose_starts_ctf_scheduler_service() -> None:
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    service = compose["services"][SCHEDULER_NAME]
+
+    assert service["command"] == " ".join(SCHEDULER_COMMAND)
+    assert service["restart"] == "always"
+    assert service["depends_on"]["db"]["condition"] == "service_healthy"
+    assert "ctf-scheduler-heartbeat" in " ".join(service["healthcheck"]["test"])
+
+
+@pytest.mark.parametrize("path", [AWS_USER_DATA, AWS_WORKFLOW])
+def test_aws_deploy_paths_start_ctf_scheduler_container(path: Path) -> None:
+    deployment_text = path.read_text(encoding="utf-8")
+
+    assert f"docker stop portal worker-cms worker-engine worker-mc {SCHEDULER_NAME}" in deployment_text
+    assert f"docker rm portal worker-cms worker-engine worker-mc {SCHEDULER_NAME}" in deployment_text
+    assert f"docker run -d --name {SCHEDULER_NAME} --restart unless-stopped" in deployment_text
+    assert " ".join(SCHEDULER_COMMAND) in deployment_text
+
+
+@pytest.mark.parametrize(
+    ("source_name", "loader"),
+    [
+        ("base", _load_base_documents),
+        ("helm", _load_helm_documents),
+    ],
+)
+def test_gcp_scheduler_deployment_runs_and_can_launch_jobs(source_name: str, loader: Any) -> None:
+    deployment = _deployment(loader(), SCHEDULER_NAME)
+    pod_spec = deployment["spec"]["template"]["spec"]
+    container = _scheduler_container(deployment)
+
+    assert deployment["spec"]["replicas"] == 1, f"{source_name} should run one scheduler by default"
+    assert container["args"] == SCHEDULER_COMMAND
+    assert "ctf-scheduler-heartbeat" in " ".join(container["livenessProbe"]["exec"]["command"])
+    assert pod_spec["serviceAccountName"] == SCHEDULER_NAME
+    assert pod_spec["automountServiceAccountToken"] is True, (
+        f"{source_name} scheduler must mount its dedicated token so due CTF spin-up tasks can submit GCP Jobs"
+    )

--- a/shifter/shifter_platform/tests/platform/test_gcp_job_launcher_manifests.py
+++ b/shifter/shifter_platform/tests/platform/test_gcp_job_launcher_manifests.py
@@ -16,6 +16,7 @@ CHART_DIR = REPO_ROOT / "platform" / "charts" / "shifter"
 DEFAULT_NAMESPACE = "default"
 
 JOB_LAUNCHER_DEPLOYMENTS = {
+    "ctf-scheduler": "ctf-scheduler",
     "portal-web": "portal",
     "worker-engine": "workers",
 }


### PR DESCRIPTION
## Summary

Keeps the CTF scheduler as a deployment-managed worker and gives the GCP scheduler pod a dedicated job-launcher identity so due spin-up tasks can submit provisioner Jobs without sharing the broader workers token.

## Requirement UIDs

- `CTF-1006`

## Related Issues

Closes #484

## ADR Impact

- No ADR required

## Changes

- Adds a dedicated ctf-scheduler service account and job-launcher RoleBinding in GCP base manifests and Helm.
- Runs the GCP and Helm ctf-scheduler Deployment with that dedicated mounted token for in-cluster Kubernetes auth.
- Adds platform regression tests for scheduler startup surfaces and exact job-launcher token/RBAC invariants.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local checks passed: targeted platform pytest, ruff, ruff format, import-linter, ADR guard CI, actionlint, absolute-path tflint, helm lint, kubeconform, rendered Kustomize kube-linter, and pre-commit run --all-files.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: CTF-1006 ← platform/k8s/gcp/base/ctf-scheduler-deployment.yaml, CTF-1006 ← platform/k8s/gcp/base/rbac-job-launcher.yaml, CTF-1006 ← platform/k8s/gcp/base/serviceaccounts.yaml, CTF-1006 ← platform/charts/shifter/templates/ctf-scheduler-deployment.yaml, CTF-1006 ← platform/charts/shifter/templates/rbac-job-launcher.yaml, CTF-1006 ← platform/charts/shifter/templates/serviceaccounts.yaml, CTF-1006 ← platform/charts/shifter/values.yaml
- TESTS: CTF-1006 ← shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py, CTF-1006 ← shifter/shifter_platform/tests/platform/test_gcp_job_launcher_manifests.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/484.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed