### PR TITLE
feat(portal): switch web process to gunicorn + uvicorn workers

### DIFF
--- a/changelog.d/174.changed.md
+++ b/changelog.d/174.changed.md
@@ -1,0 +1,10 @@
+Portal web process now runs Gunicorn with Uvicorn workers
+(`-k uvicorn_worker.UvicornWorker`) by default in the container
+`entrypoint.sh`, instead of a single Daphne process. An unhandled
+exception in a WebSocket consumer now crashes only one worker and
+Gunicorn restarts it, instead of taking the whole portal down. Worker
+count, bind address, and timeouts are env-owned:
+`PORTAL_WEB_WORKERS` (default `4`), `PORTAL_WEB_BIND`
+(default `0.0.0.0:8000`), `PORTAL_WEB_TIMEOUT` (default `90s`),
+`PORTAL_WEB_GRACEFUL_TIMEOUT` (default `30s`). `daphne` remains in
+`INSTALLED_APPS` for local Channels `runserver` integration.

--- a/docs/architecture/portal-asgi-process-manager-preflight-174.md
+++ b/docs/architecture/portal-asgi-process-manager-preflight-174.md
@@ -1,0 +1,190 @@
+# Portal ASGI Process Manager Preflight (#174)
+
+Status: pre-implementation guidance
+
+Date: 2026-06-03
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/174>
+
+## Scope Boundary
+
+Issue #174 switches the production portal web process from the current single
+Daphne process to a Gunicorn-managed ASGI process pool using Uvicorn workers.
+The change is a runtime/process-manager hardening change, not an application
+routing, websocket protocol, deployment-topology, auth, or channel-layer
+redesign.
+
+The GitHub issue is the source of truth. There is no Ground Control
+requirement for this run.
+
+## Architecture Decisions
+
+- Keep `config.asgi:application` as the single ASGI application contract for
+  HTTP and websocket traffic. Gunicorn/Uvicorn is only the server/process
+  manager around that application.
+- Preserve the existing portal container entrypoint as the canonical runtime
+  bootstrap. It hydrates secrets, waits for the database, runs migrations,
+  compiles messages, collects static assets, then execs the long-running web
+  process.
+- Keep all deploy targets on one default web command by changing the image
+  default. AWS Docker runs, GCP chart/Kustomize web deployments, and local
+  Docker Compose all consume the same image entrypoint unless an explicit
+  command override is provided.
+- Make the worker-count policy environment-owned. A fixed issue example of
+  four workers is acceptable as a default, but the obvious production seam is
+  an env knob such as `PORTAL_WEB_WORKERS` / `WEB_CONCURRENCY`, bounded and
+  documented, so AWS instance size and GCP pod limits can tune the process pool
+  without rebuilding the image.
+- Treat the `uvicorn.workers.UvicornWorker` string in the migrated issue as a
+  compatibility detail, not a new architecture boundary. Current Uvicorn docs
+  mark `uvicorn.workers` deprecated and recommend the separate
+  `uvicorn-worker` package
+  (<https://www.uvicorn.org/deployment/#gunicorn>). The implementation should
+  either use the supported worker package while preserving the "Gunicorn with
+  Uvicorn workers" contract, or deliberately pin and test the deprecated import
+  path.
+- Do not remove Daphne from dependencies or `INSTALLED_APPS` unless the same
+  change updates and tests the local `runserver` / Channels development
+  contract. The acceptance criterion is to stop using Daphne as the production
+  process manager, not necessarily to erase every Daphne reference.
+
+## Canonical Incumbents
+
+| Concern | Canonical incumbent | Guardrail for #174 |
+| --- | --- | --- |
+| ASGI routing and websocket auth | `shifter/shifter_platform/config/asgi.py` | Preserve `AllowedHostsOriginValidator`, `AuthMiddlewareStack`, and combined Mission Control + experiment websocket routing. |
+| Channels/Redis env binding | `config/_channels.py`, `config/settings.py`, `entrypoint.sh`, `scripts/gcp/render_runtime_env.py` | Reuse the existing `CHANNEL_LAYERS` helper and fail-closed Redis TLS/AUTH posture; do not create a server-specific Redis config. |
+| Runtime bootstrap | `shifter/shifter_platform/entrypoint.sh` and `entrypoint-lib.sh` | Keep secret hydration and Django setup before the final `exec`; do not bypass it in Kubernetes, AWS user data, or Compose. |
+| Dependency lock and image install | `shifter/shifter_platform/pyproject.toml`, `uv.lock`, `Dockerfile` | Add any Uvicorn worker dependency through the locked `uv` workflow and copy only console scripts the final command actually invokes. |
+| Portal deployment paths | AWS `platform/terraform/modules/portal/ec2/user_data.sh`, `.github/workflows/_shifter-platform.yml`, GCP `platform/k8s/gcp/base/web-deployment.yaml`, Helm `platform/charts/shifter/templates/web-deployment.yaml` | The default image command should work unchanged for all web deployments; command overrides stay reserved for workers and schedulers. |
+| Health checks | `config.middleware.HealthCheckMiddleware`, Docker `HEALTHCHECK`, AWS ALB health check path, GCP readiness/liveness probes, GCP BackendConfig | Keep `/health/` responding on port 8000 behind the same host-header bypass and proxy chain. |
+| Security settings | `config/settings.py`, `scripts/gcp/render_runtime_env.py`, ADR-008 rules | Preserve `DEBUG=false`, secure session/CSRF cookies, `SECURE_PROXY_SSL_HEADER`, `ALLOWED_HOSTS`, and trusted origins. |
+| Logging | `config._logging_config.LOGGING`, `config.logging.ECSFormatter`, `shared.log_sanitize.safe_log_value()` | Prefer existing ECS JSON logging for application logs; if server access/error logging is changed, keep stdout/stderr container logging and avoid raw secret-bearing URLs. |
+| Terminal capacity controls | `docs/architecture/terminal-websocket-capacity-847.md`, `TERMINAL_*` settings, `mission_control.consumers.SSHConsumer` | Remember that session caps are per ASGI process. More Gunicorn workers multiply process-local terminal capacity and FD usage. |
+| Enforcement | `.gc/plan-rules.md`, ADR guard, Ruff, import-linter, actionlint/TFLint/kube tools when surfaces are touched | Runtime/bootstrap edits are architecture-sensitive and must pass the repo-required checks. |
+
+## Cross-Cutting Layers
+
+- Auth surface: websocket traffic must still enter through
+  `AllowedHostsOriginValidator(AuthMiddlewareStack(URLRouter(...)))`. HTTP
+  traffic must keep Django middleware, sessions, CSRF, OIDC/magic-link auth, and
+  request ID behavior unchanged.
+- Secret-handling surface: `entrypoint.sh` hydrates DB, app, OIDC, Guacamole,
+  DC password, and Redis secret bundles before the web server starts. The final
+  server command must not place secret values in process argv, generated env
+  files, ConfigMaps, logs, or access-log lines. Passing only non-secret knobs
+  such as bind address, port, worker class, worker count, timeouts, and log level
+  in argv is acceptable.
+- Env-binding shape: reuse `DJANGO_*`, `REDIS_*`, `TERMINAL_*`,
+  `GUACAMOLE_*`, and cloud-provider env contracts as-is. Any new web-server
+  knobs should be narrow process-manager knobs, not generic app settings and not
+  provider-specific renderers.
+- Config validators: Django settings must still fail closed for missing
+  production `DJANGO_SECRET_KEY`, field encryption key, OIDC settings when
+  required, and Redis TLS password/CA. Do not paper over startup failures with a
+  Gunicorn preload, lazy import, or broad exception handling around ASGI app
+  import.
+- OS/process exposure: the process list may show Gunicorn master and worker
+  command lines, so argv must contain no secrets. Multiple workers multiply DB
+  connections, Redis channel-layer connections, websocket FDs, SSH sockets, and
+  process-local terminal session caps. Fit defaults inside the 1Gi GCP pod limit
+  and AWS instance/container FD limits.
+- Network exposure: keep the bind target at `0.0.0.0:8000` inside the container
+  and preserve the existing ALB/GCP ingress/TLS/proxy topology. Do not expose a
+  separate Uvicorn port or sidecar service.
+- Error-envelope surface: browser-facing HTTP and websocket failures should
+  continue to come from existing Django views, consumers, close codes, and
+  `shared.errors` classifiers. Do not introduce a server-wrapper exception
+  hierarchy or leak raw worker exceptions to clients.
+- Observability surface: container stdout/stderr, ECS-formatted application
+  logs, ALB/GCP health checks, and existing probes are sufficient for this
+  change. Useful server-level signal is worker boot/restart/exit and timeout
+  events, without dumping request headers, cookies, query strings, or websocket
+  payloads.
+- Persistence surface: no database schema, migration, audit table, repository,
+  DTO, or shared schema change is needed for the process-manager switch.
+
+## Extensibility Seam
+
+The seam is the portal web process-manager contract:
+
+- application import: `config.asgi:application`
+- bind address/port: container-local `0.0.0.0:8000`
+- worker implementation: Gunicorn ASGI worker backed by Uvicorn
+- worker count: environment-owned, with a conservative default
+- timeout/shutdown policy: explicit enough to tune websocket and load-balancer
+  behavior later without editing ASGI routing or deployment-specific commands
+
+Keep this seam centralized in the image entrypoint unless a future issue
+introduces a first-class chart/Terraform runtime setting.
+
+## Gotchas
+
+- Gunicorn workers are separate processes. Any process-local state, including
+  terminal session registries and in-memory channel layers, is per worker. Local
+  dev without Redis can still use the in-memory channel layer, but multi-worker
+  deployments need the existing Redis channel layer for cross-process
+  websocket/event coordination.
+- Worker count changes affect capacity in both directions: more crash
+  isolation and concurrency, but also more memory, DB connections, Redis
+  connections, file descriptors, and startup work during migrations/static
+  collection.
+- The entrypoint currently runs migrations before starting the web process.
+  That behavior is pre-existing; do not split migrations into Gunicorn hooks or
+  run them per worker.
+- Gunicorn access logs can contain request paths and query strings. Keep access
+  logging on stdout only if it does not expose tokens, signed URLs, cookies, or
+  raw websocket payloads; otherwise prefer application logs and platform logs.
+- Official Uvicorn documentation currently warns that `uvicorn.workers` is
+  deprecated. Check the chosen dependency/worker import against the locked
+  versions in `uv.lock` and add a smoke test that imports the worker class.
+- Dockerfile binary-copy mistakes fail only at container start. If the final
+  command invokes `gunicorn` or `uvicorn` directly, the production stage must
+  copy those console scripts from the builder.
+- Existing technical docs still mention Daphne as the ASGI server. Update them
+  in the implementation PR only after the runtime actually changes.
+
+## Anti-Patterns
+
+- Replacing `config.asgi:application` or duplicating ASGI routing to make the
+  server command easier.
+- Creating a second entrypoint, process supervisor, shell wrapper, settings
+  module, Redis config, logging formatter, exception hierarchy, or deployment
+  renderer for this runtime switch.
+- Bypassing `entrypoint.sh` from Kubernetes, AWS user data, or Compose to run
+  Gunicorn directly.
+- Weakening `AllowedHostsOriginValidator`, session auth, CSRF, secure cookie
+  settings, Redis TLS/AUTH validation, NetworkPolicies, ALB/GCP health checks,
+  ADR guard, import-linter, or CI checks.
+- Removing Daphne, changing `INSTALLED_APPS`, or changing local development
+  behavior as an incidental cleanup without tests and explicit scope.
+- Hard-coding production worker counts to a value that cannot be tuned per pod,
+  instance size, or event load.
+
+## Non-Goals
+
+- No websocket consumer rewrite, terminal protocol change, Guacamole redesign,
+  channel-layer redesign, or frontend reconnect-policy change.
+- No new deployment component, sidecar, target group, Kubernetes service, or
+  independently scalable terminal runtime.
+- No schema, migration, repository, DTO, serializer, service-boundary, audit,
+  or persistence change.
+- No new auth system, secret store abstraction, logging framework, health-check
+  endpoint, or workflow runner.
+- No change to worker/scheduler commands except ensuring their existing command
+  overrides still bypass the default web server command.
+
+## Validation
+
+For this implementation, run at minimum:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+cd shifter/shifter_platform && uv run ruff check .
+cd shifter/shifter_platform && uv run ruff format --check .
+```
+
+If imports or deployment manifests/workflows are touched, also run the matching
+repo gates from `.gc/plan-rules.md`: import-linter for Python imports,
+actionlint for workflows, TFLint for Terraform, and kube-linter/kubeconform for
+Kubernetes manifests.

--- a/shifter/shifter_platform/entrypoint-lib.sh
+++ b/shifter/shifter_platform/entrypoint-lib.sh
@@ -3,7 +3,7 @@
 # container start; isolated into its own file so the regression tests in
 # `tests/test_entrypoint_lib.sh` can exercise the function without
 # running the entire entrypoint (which migrates the DB, collects static
-# files, and execs daphne).
+# files, and execs the web server).
 
 # ------------------------------------------------------------------------------
 # fetch_runtime_secret

--- a/shifter/shifter_platform/entrypoint.sh
+++ b/shifter/shifter_platform/entrypoint.sh
@@ -168,15 +168,31 @@ python manage.py compilemessages
 echo "Collecting static files..."
 python manage.py collectstatic --noinput
 
-# Run command passed as arguments, or default to daphne
+# Run command passed as arguments, or default to gunicorn + uvicorn workers.
+#
+# The production portal web process runs Gunicorn managing a pool of Uvicorn
+# ASGI workers (issue #174). An unhandled exception in any WebSocket consumer
+# only crashes one worker (which Gunicorn restarts) instead of taking down the
+# whole single-process Daphne server. The worker-count, bind address, and
+# timeouts are env-owned so AWS instance sizes and GCP pod limits can tune the
+# pool without rebuilding the image. Defaults are conservative: 4 workers and
+# a 90s timeout (Gunicorn's 30s default would kill long-lived WebSocket and
+# SSH terminal connections that are the portal's main workload). The worker
+# class string is `uvicorn_worker.UvicornWorker` (the supported standalone
+# `uvicorn-worker` package) — `uvicorn.workers.UvicornWorker` is deprecated
+# upstream. `tests/test_asgi_worker_smoke.py` pins the import contract in CI.
 if [[ $# -gt 0 ]]; then
     echo "Running: $@"
     exec "$@"
 else
-    echo "Starting daphne..."
-    exec daphne config.asgi:application \
-        --bind 0.0.0.0 \
-        --port 8000 \
-        --access-log - \
-        --verbosity 1
+    echo "Starting gunicorn (uvicorn workers)..."
+    exec gunicorn config.asgi:application \
+        --worker-class uvicorn_worker.UvicornWorker \
+        --bind "${PORTAL_WEB_BIND:-0.0.0.0:8000}" \
+        --workers "${PORTAL_WEB_WORKERS:-4}" \
+        --timeout "${PORTAL_WEB_TIMEOUT:-90}" \
+        --graceful-timeout "${PORTAL_WEB_GRACEFUL_TIMEOUT:-30}" \
+        --access-logfile - \
+        --error-logfile - \
+        --log-level info
 fi

--- a/shifter/shifter_platform/pyproject.toml
+++ b/shifter/shifter_platform/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic>=2.13.4",
     "python-dotenv>=1.2.2",
     "requests",
+    "uvicorn-worker",
     "whitenoise",
 ]
 

--- a/shifter/shifter_platform/tests/test_asgi_worker_smoke.py
+++ b/shifter/shifter_platform/tests/test_asgi_worker_smoke.py
@@ -1,0 +1,27 @@
+"""Smoke test: confirm the Gunicorn worker class string boots.
+
+The portal's production process manager switched from a single Daphne
+process to Gunicorn with Uvicorn workers in issue #174. Gunicorn
+imports the worker class via ``importlib`` at master boot, so a
+dependency drift (missing ``uvicorn-worker`` package, deprecated
+``uvicorn.workers`` import path) fails only when the container
+starts. Asserting the import inside pytest surfaces the same failure
+in CI and pre-commit, before the container ever boots.
+"""
+
+from __future__ import annotations
+
+
+def test_uvicorn_worker_class_importable() -> None:
+    """``-k uvicorn_worker.UvicornWorker`` must resolve at import time.
+
+    ``entrypoint.sh`` passes ``-k uvicorn_worker.UvicornWorker`` to
+    Gunicorn. If the symbol cannot be imported, the master exits
+    before serving any HTTP or websocket traffic. The current Uvicorn
+    docs mark the legacy ``uvicorn.workers`` submodule deprecated and
+    direct users to the standalone ``uvicorn-worker`` distribution;
+    this test pins that contract.
+    """
+    from uvicorn_worker import UvicornWorker
+
+    assert UvicornWorker.__module__.startswith("uvicorn_worker")

--- a/shifter/shifter_platform/uv.lock
+++ b/shifter/shifter_platform/uv.lock
@@ -2125,6 +2125,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "uvicorn-worker" },
     { name = "whitenoise" },
 ]
 
@@ -2169,6 +2170,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "requests" },
+    { name = "uvicorn-worker" },
     { name = "whitenoise" },
 ]
 
@@ -2415,6 +2417,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+]
+
+[[package]]
+name = "uvicorn-worker"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gunicorn" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/59/9101b9c0680fd80e9d26c07deb822a5d18a324339fcf9cd017885ee808ad/uvicorn_worker-0.4.0.tar.gz", hash = "sha256:8ee5306070d8f38dce124adce488c3c0b50f20cf0c0222b12c66188da7214493", size = 9361, upload-time = "2025-09-20T10:47:01.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/25/09cd7a90c8bb7fb693be0d6704fccd5f9778d5513214b7a01cc4a94ff314/uvicorn_worker-0.4.0-py3-none-any.whl", hash = "sha256:e2ed952cef976f5e9e429d7269640bbcafbd36c80aa80f1003c8c77a6797abde", size = 5364, upload-time = "2025-09-20T10:46:59.776Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the single-process Daphne web server in the portal container with Gunicorn managing a pool of Uvicorn workers. An unhandled exception in a WebSocket consumer now crashes only one worker (Gunicorn restarts it) instead of taking the whole portal down. Process-manager hardening only — no ASGI application, routing, auth, channel-layer, or deployment-topology change.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #174

## ADR Impact

- ADR-021

## Changes

- `shifter/shifter_platform/entrypoint.sh`: default web command is now `gunicorn config.asgi:application -k uvicorn_worker.UvicornWorker ...` with env-owned `PORTAL_WEB_BIND`, `PORTAL_WEB_WORKERS`, `PORTAL_WEB_TIMEOUT`, `PORTAL_WEB_GRACEFUL_TIMEOUT` (defaults `0.0.0.0:8000`, `4`, `90s`, `30s`).
- `shifter/shifter_platform/pyproject.toml` + `uv.lock`: add the standalone `uvicorn-worker` package (current Uvicorn docs mark `uvicorn.workers` deprecated and point at this distribution).
- `shifter/shifter_platform/tests/test_asgi_worker_smoke.py` *(new)*: pytest smoke test that imports `uvicorn_worker.UvicornWorker` so a dependency-lock drift fails in CI/pre-commit before container start.
- `shifter/shifter_platform/entrypoint-lib.sh`: update the one Daphne-referencing comment to say "web server" instead.
- `docs/architecture/portal-asgi-process-manager-preflight-174.md`: codex architecture-preflight binding note captured during planning.
- `daphne` stays in `INSTALLED_APPS` and as a dependency so local Channels `runserver` integration is unchanged.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Manual post-deploy verification (out of this PR's scope): observe `gunicorn` master + 4 workers in the process list; kill one worker and confirm Gunicorn re-spawns without HTTP/WebSocket downtime.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-021 ← shifter/shifter_platform/entrypoint.sh (gated /implement run for issue #174)
- TESTS: ADR-021 ← shifter/shifter_platform/tests/test_asgi_worker_smoke.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/174.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed