### PR TITLE
Add shared WebSocket notifications

### DIFF
--- a/changelog.d/679.added.md
+++ b/changelog.d/679.added.md
@@ -1,0 +1,1 @@
+Added shared authenticated WebSocket notification infrastructure with topic subscriptions, persisted missed-event replay, and experiment status notification registration.

--- a/shifter/cyberscript/channels/groups.py
+++ b/shifter/cyberscript/channels/groups.py
@@ -6,6 +6,8 @@ WebSocket layer (Mission Control browser connections).
 
 from __future__ import annotations
 
+import hashlib
+
 
 def range_event_group(request_id: str | int) -> str:
     """Get the channel group name for a specific range.
@@ -62,3 +64,15 @@ def ngfw_event_group(app_id: str) -> str:
         'ngfw_status_abc-123-def'
     """
     return f"ngfw_status_{app_id}"
+
+
+def notification_user_topic_group(user_id: int, topic: str) -> str:
+    """Get the channel group name for one user's logical notification topic.
+
+    Logical notification topics are user-facing contracts and may contain
+    separators such as ``:``. Channels group names are transport details with
+    stricter character and length limits, so this helper keeps the raw topic out
+    of the group name and uses a stable digest instead.
+    """
+    digest = hashlib.sha256(str(topic).encode("utf-8")).hexdigest()[:32]
+    return f"notify_u{int(user_id)}_{digest}"

--- a/shifter/cyberscript/tests/test_channels.py
+++ b/shifter/cyberscript/tests/test_channels.py
@@ -1,41 +1,73 @@
 """Tests for shared.channels.groups module."""
 
+import pytest
+
 
 class TestRangeEventGroup:
     """Tests for range_event_group function."""
 
-    def test_returns_range_group_name(self):
-        """Function returns correctly formatted group name."""
+    @pytest.mark.parametrize(
+        ("request_id", "expected"),
+        [
+            (123, "range_status_123"),
+            ("abc-123", "range_status_abc-123"),
+        ],
+    )
+    def test_returns_range_group_name(self, request_id, expected):
+        """Function returns correctly formatted group names."""
         from cyberscript.channels.groups import range_event_group
 
-        result = range_event_group(123)
+        result = range_event_group(request_id)
 
-        assert result == "range_status_123"
-
-    def test_accepts_integer_range_id(self):
-        """Function works with integer range_id."""
-        from cyberscript.channels.groups import range_event_group
-
-        result = range_event_group(1)
-
-        assert result == "range_status_1"
+        assert result == expected
 
 
 class TestUserEventGroup:
     """Tests for user_event_group function."""
 
-    def test_returns_user_group_name(self):
+    @pytest.mark.parametrize(
+        ("user_id", "expected"),
+        [
+            (42, "user_42"),
+            (1, "user_1"),
+        ],
+    )
+    def test_returns_user_group_name(self, user_id, expected):
         """Function returns correctly formatted group name."""
         from cyberscript.channels.groups import user_event_group
 
-        result = user_event_group(42)
+        result = user_event_group(user_id)
 
-        assert result == "user_42"
+        assert result == expected
 
-    def test_accepts_integer_user_id(self):
-        """Function works with integer user_id."""
-        from cyberscript.channels.groups import user_event_group
 
-        result = user_event_group(1)
+class TestNotificationTopicGroup:
+    """Tests for notification user/topic group names."""
 
-        assert result == "user_1"
+    def test_returns_hashed_user_topic_group(self):
+        """Function keeps logical topics out of raw Channels group names."""
+        from cyberscript.channels.groups import notification_user_topic_group
+
+        result = notification_user_topic_group(42, "experiment:100")
+
+        assert result.startswith("notify_u42_")
+        assert len(result) <= 100
+        assert ":" not in result
+
+    def test_same_user_topic_is_stable(self):
+        """Function is deterministic for the same user and topic."""
+        from cyberscript.channels.groups import notification_user_topic_group
+
+        first = notification_user_topic_group(42, "experiment:100")
+        second = notification_user_topic_group(42, "experiment:100")
+
+        assert first == second
+
+    def test_different_topics_do_not_collide(self):
+        """Different logical topics produce different group names."""
+        from cyberscript.channels.groups import notification_user_topic_group
+
+        assert notification_user_topic_group(42, "experiment:100") != notification_user_topic_group(
+            42,
+            "experiment:101",
+        )

--- a/shifter/shifter_platform/cms/experiments/apps.py
+++ b/shifter/shifter_platform/cms/experiments/apps.py
@@ -10,3 +10,9 @@ class ExperimentsConfig(AppConfig):
     name = "cms.experiments"
     label = "experiments"
     verbose_name = "Experiments"
+
+    def ready(self) -> None:
+        """Register experiment notification types."""
+        from cms.experiments.notifications import register_experiment_notifications
+
+        register_experiment_notifications()

--- a/shifter/shifter_platform/cms/experiments/handlers.py
+++ b/shifter/shifter_platform/cms/experiments/handlers.py
@@ -19,6 +19,68 @@ _TERMINAL_EXPERIMENT_STATUSES = ("completed", "failed")
 logger = logging.getLogger(__name__)
 
 
+def _experiment_recipient_id(experiment_id: int) -> int | None:
+    """Return the owning user id for experiment notifications."""
+    try:
+        return Experiment.objects.only("user_id").get(pk=experiment_id).user_id
+    except Experiment.DoesNotExist:
+        return None
+
+
+def _publish_run_status_notification(
+    experiment_id: int,
+    run_id: int,
+    run_number: int,
+    status: str,
+    error_message: str,
+) -> None:
+    """Queue a shared notification for run-status changes."""
+    recipient_id = _experiment_recipient_id(experiment_id)
+    if recipient_id is None:
+        return
+    try:
+        from cms.experiments.notifications import publish_experiment_run_status_notification
+
+        publish_experiment_run_status_notification(
+            experiment_id=experiment_id,
+            recipient_id=recipient_id,
+            run_id=run_id,
+            run_number=run_number,
+            status=status,
+            error_message=error_message,
+        )
+    except Exception:
+        logger.warning(
+            "failed to queue experiment run notification: experiment=%s run=%s status=%s",
+            experiment_id,
+            run_id,
+            status,
+            exc_info=True,
+        )
+
+
+def _publish_experiment_status_notification(experiment_id: int, status: str) -> None:
+    """Queue a shared notification for experiment status changes."""
+    recipient_id = _experiment_recipient_id(experiment_id)
+    if recipient_id is None:
+        return
+    try:
+        from cms.experiments.notifications import publish_experiment_status_notification
+
+        publish_experiment_status_notification(
+            experiment_id=experiment_id,
+            recipient_id=recipient_id,
+            status=status,
+        )
+    except Exception:
+        logger.warning(
+            "failed to queue experiment notification: experiment=%s status=%s",
+            experiment_id,
+            status,
+            exc_info=True,
+        )
+
+
 def _broadcast_run_status(
     experiment_id: int,
     run_id: int,
@@ -34,28 +96,33 @@ def _broadcast_run_status(
         from cms.experiments.consumers import experiment_event_group
 
         channel_layer = get_channel_layer()
-        if channel_layer is None:
-            return
-
-        group = experiment_event_group(experiment_id)
-        async_to_sync(channel_layer.group_send)(
-            group,
-            {
-                "type": "experiment.run_status",
-                "run_id": run_id,
-                "run_number": run_number,
-                "status": status,
-                "error_message": error_message,
-            },
-        )
-        logger.debug(
-            "broadcast run_status: experiment=%s run=%s status=%s",
-            experiment_id,
-            run_id,
-            status,
-        )
+        if channel_layer is not None:
+            group = experiment_event_group(experiment_id)
+            async_to_sync(channel_layer.group_send)(
+                group,
+                {
+                    "type": "experiment.run_status",
+                    "run_id": run_id,
+                    "run_number": run_number,
+                    "status": status,
+                    "error_message": error_message,
+                },
+            )
+            logger.debug(
+                "broadcast run_status: experiment=%s run=%s status=%s",
+                experiment_id,
+                run_id,
+                status,
+            )
     except Exception:
         logger.warning("_broadcast_run_status: channel layer unavailable", exc_info=True)
+    _publish_run_status_notification(
+        experiment_id,
+        run_id,
+        run_number,
+        status,
+        error_message,
+    )
 
 
 def _broadcast_run_status_for(
@@ -97,25 +164,24 @@ def _broadcast_experiment_status(experiment_id: int, status: str) -> None:
         from cms.experiments.consumers import experiment_event_group
 
         channel_layer = get_channel_layer()
-        if channel_layer is None:
-            return
-
-        group = experiment_event_group(experiment_id)
-        async_to_sync(channel_layer.group_send)(
-            group,
-            {
-                "type": "experiment.status",
-                "experiment_id": experiment_id,
-                "status": status,
-            },
-        )
-        logger.debug(
-            "broadcast experiment_status: experiment=%s status=%s",
-            experiment_id,
-            status,
-        )
+        if channel_layer is not None:
+            group = experiment_event_group(experiment_id)
+            async_to_sync(channel_layer.group_send)(
+                group,
+                {
+                    "type": "experiment.status",
+                    "experiment_id": experiment_id,
+                    "status": status,
+                },
+            )
+            logger.debug(
+                "broadcast experiment_status: experiment=%s status=%s",
+                experiment_id,
+                status,
+            )
     except Exception:
         logger.warning("_broadcast_experiment_status: channel layer unavailable", exc_info=True)
+    _publish_experiment_status_notification(experiment_id, status)
 
 
 def process_event(message: str | dict) -> None:

--- a/shifter/shifter_platform/cms/experiments/notifications.py
+++ b/shifter/shifter_platform/cms/experiments/notifications.py
@@ -1,0 +1,123 @@
+"""Experiment notification registrations and publishers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+from uuid import UUID
+
+from cms.experiments.models import Experiment
+from shared.notifications import publish_notification, register_notification_type
+
+EXPERIMENT_TOPIC_PREFIX = "experiment:"
+NOTIFICATION_EXPERIMENT_RUN_STATUS = "experiment.run_status"
+NOTIFICATION_EXPERIMENT_STATUS = "experiment.status"
+
+
+def experiment_topic(experiment_id: int | str) -> str:
+    """Return the logical notification topic for an experiment."""
+    return f"{EXPERIMENT_TOPIC_PREFIX}{int(experiment_id)}"
+
+
+def _experiment_id_from_topic(topic: str) -> int | None:
+    if not topic.startswith(EXPERIMENT_TOPIC_PREFIX):
+        return None
+    raw_id = topic.removeprefix(EXPERIMENT_TOPIC_PREFIX)
+    try:
+        experiment_id = int(raw_id)
+    except ValueError:
+        return None
+    return experiment_id if experiment_id > 0 else None
+
+
+def _can_subscribe_to_experiment(user: Any, topic: str) -> bool:
+    """Authorize experiment notification subscriptions."""
+    if not getattr(user, "is_authenticated", False) or not getattr(user, "is_staff", False):
+        return False
+    experiment_id = _experiment_id_from_topic(topic)
+    if experiment_id is None:
+        return False
+    return Experiment.objects.filter(pk=experiment_id, user=user).exists()
+
+
+def _run_status_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Project a run-status notification to browser-safe fields."""
+    return {
+        "experiment_id": payload["experiment_id"],
+        "run_id": payload["run_id"],
+        "run_number": payload["run_number"],
+        "status": payload["status"],
+        "error_message": payload.get("error_message", ""),
+    }
+
+
+def _experiment_status_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Project an experiment-status notification to browser-safe fields."""
+    return {
+        "experiment_id": payload["experiment_id"],
+        "status": payload["status"],
+    }
+
+
+def register_experiment_notifications() -> None:
+    """Register experiment notification types with the shared infrastructure."""
+    register_notification_type(
+        name=NOTIFICATION_EXPERIMENT_RUN_STATUS,
+        topic_prefix=EXPERIMENT_TOPIC_PREFIX,
+        can_subscribe=_can_subscribe_to_experiment,
+        payload_handler=_run_status_payload,
+        replace=True,
+    )
+    register_notification_type(
+        name=NOTIFICATION_EXPERIMENT_STATUS,
+        topic_prefix=EXPERIMENT_TOPIC_PREFIX,
+        can_subscribe=_can_subscribe_to_experiment,
+        payload_handler=_experiment_status_payload,
+        replace=True,
+    )
+
+
+def publish_experiment_run_status_notification(
+    *,
+    experiment_id: int,
+    recipient_id: int,
+    run_id: int,
+    run_number: int,
+    status: str,
+    error_message: str = "",
+    event_id: UUID | str | None = None,
+) -> None:
+    """Queue and fan out an experiment run-status browser notification."""
+    publish_notification(
+        NOTIFICATION_EXPERIMENT_RUN_STATUS,
+        topic=experiment_topic(experiment_id),
+        payload={
+            "experiment_id": experiment_id,
+            "run_id": run_id,
+            "run_number": run_number,
+            "status": status,
+            "error_message": error_message,
+        },
+        recipient_ids=[recipient_id],
+        event_id=event_id,
+    )
+
+
+def publish_experiment_status_notification(
+    *,
+    experiment_id: int,
+    recipient_id: int,
+    status: str,
+    event_id: UUID | str | None = None,
+) -> None:
+    """Queue and fan out an experiment status browser notification."""
+    publish_notification(
+        NOTIFICATION_EXPERIMENT_STATUS,
+        topic=experiment_topic(experiment_id),
+        payload={
+            "experiment_id": experiment_id,
+            "status": status,
+        },
+        recipient_ids=[recipient_id],
+        event_id=event_id,
+    )

--- a/shifter/shifter_platform/config/asgi.py
+++ b/shifter/shifter_platform/config/asgi.py
@@ -29,12 +29,13 @@ django_asgi_app = get_asgi_application()
 # Import routing after Django setup
 from cms.experiments.routing import websocket_urlpatterns as experiment_ws_urlpatterns  # noqa: E402
 from mission_control.routing import websocket_urlpatterns  # noqa: E402
+from shared.routing import websocket_urlpatterns as shared_ws_urlpatterns  # noqa: E402
 
 application = ProtocolTypeRouter(
     {
         "http": django_asgi_app,
         "websocket": AllowedHostsOriginValidator(
-            AuthMiddlewareStack(URLRouter(websocket_urlpatterns + experiment_ws_urlpatterns))
+            AuthMiddlewareStack(URLRouter(websocket_urlpatterns + experiment_ws_urlpatterns + shared_ws_urlpatterns))
         ),
     }
 )

--- a/shifter/shifter_platform/config/settings.py
+++ b/shifter/shifter_platform/config/settings.py
@@ -185,6 +185,10 @@ REDIS_HOST = os.environ.get("REDIS_HOST", "")
 REDIS_PORT = int(os.environ.get("REDIS_PORT", "6379"))
 CHANNEL_LAYERS = _build_channel_layers(os.environ)
 
+# Shared WebSocket notification replay bounds (issue #679).
+WEBSOCKET_NOTIFICATION_MAX_REPLAY = _env_int("WEBSOCKET_NOTIFICATION_MAX_REPLAY", 100)
+WEBSOCKET_NOTIFICATION_RETENTION_DAYS = _env_int("WEBSOCKET_NOTIFICATION_RETENTION_DAYS", 7)
+
 # ------------------------------------------------------------------------------
 # Terminal WebSocket capacity controls (issue #847)
 # ------------------------------------------------------------------------------

--- a/shifter/shifter_platform/shared/channels/groups.py
+++ b/shifter/shifter_platform/shared/channels/groups.py
@@ -2,12 +2,14 @@
 
 from cyberscript.channels.groups import (
     ngfw_event_group,
+    notification_user_topic_group,
     range_event_group,
     user_event_group,
 )
 
 __all__ = [
     "ngfw_event_group",
+    "notification_user_topic_group",
     "range_event_group",
     "user_event_group",
 ]

--- a/shifter/shifter_platform/shared/consumers.py
+++ b/shifter/shifter_platform/shared/consumers.py
@@ -1,0 +1,166 @@
+"""Shared WebSocket consumers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from channels.db import database_sync_to_async
+from channels.generic.websocket import AsyncWebsocketConsumer
+from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone
+
+from shared.channels.groups import notification_user_topic_group
+from shared.enums import WebSocketCloseCode
+from shared.models import WebSocketNotification
+from shared.notifications import (
+    authorize_subscription,
+    mark_notification_delivered,
+    pending_notifications_for,
+    validate_topic,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SharedNotificationConsumer(AsyncWebsocketConsumer):
+    """Authenticated topic-subscription consumer for browser notifications."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.subscriptions: set[str] = set()
+        self._user_id: int | None = None
+
+    async def connect(self) -> None:
+        """Accept authenticated notification sockets."""
+        user = self.scope.get("user")
+        if not user or isinstance(user, AnonymousUser) or not getattr(user, "is_authenticated", False):
+            logger.warning("Unauthenticated notification WebSocket connection attempt")
+            await self.close(code=WebSocketCloseCode.NOT_AUTHENTICATED)
+            return
+
+        self._user_id = int(user.id)
+        self.subscriptions = set()
+        await self.accept()
+
+    async def disconnect(self, close_code: int) -> None:
+        """Leave all subscribed topic groups."""
+        if self._user_id is None:
+            return
+        for topic in list(self.subscriptions):
+            await self.channel_layer.group_discard(
+                notification_user_topic_group(self._user_id, topic),
+                self.channel_name,
+            )
+        self.subscriptions.clear()
+
+    async def receive(self, text_data: str | None = None, bytes_data: bytes | None = None) -> None:
+        """Parse incoming JSON control messages."""
+        if not text_data:
+            return
+        try:
+            content = json.loads(text_data)
+        except json.JSONDecodeError:
+            await self.close(code=WebSocketCloseCode.INVALID_REQUEST)
+            return
+        await self.receive_json(content)
+
+    async def receive_json(self, content: dict[str, Any]) -> None:
+        """Handle subscription control messages."""
+        message_type = content.get("type")
+        topic = content.get("topic")
+        if message_type == "subscribe" and isinstance(topic, str):
+            await self._subscribe(topic)
+        elif message_type == "unsubscribe" and isinstance(topic, str):
+            await self._unsubscribe(topic)
+        else:
+            await self.close(code=WebSocketCloseCode.INVALID_REQUEST)
+
+    async def _subscribe(self, topic: str) -> None:
+        """Authorize, join, and replay a logical topic."""
+        if self._user_id is None:
+            await self.close(code=WebSocketCloseCode.NOT_AUTHENTICATED)
+            return
+        try:
+            topic = validate_topic(topic)
+        except ValueError:
+            await self.close(code=WebSocketCloseCode.INVALID_REQUEST)
+            return
+        if not await database_sync_to_async(authorize_subscription)(self.scope["user"], topic):
+            await self.close(code=WebSocketCloseCode.PERMISSION_DENIED)
+            return
+
+        self.subscriptions.add(topic)
+        await self.channel_layer.group_add(
+            notification_user_topic_group(self._user_id, topic),
+            self.channel_name,
+        )
+        await self.send(text_data=json.dumps({"type": "subscribed", "topic": topic}))
+        await self._replay_pending(topic)
+
+    async def _unsubscribe(self, topic: str) -> None:
+        """Leave a logical topic."""
+        if self._user_id is None:
+            return
+        try:
+            topic = validate_topic(topic)
+        except ValueError:
+            await self.close(code=WebSocketCloseCode.INVALID_REQUEST)
+            return
+        if topic in self.subscriptions:
+            self.subscriptions.remove(topic)
+            await self.channel_layer.group_discard(
+                notification_user_topic_group(self._user_id, topic),
+                self.channel_name,
+            )
+        await self.send(text_data=json.dumps({"type": "unsubscribed", "topic": topic}))
+
+    async def _replay_pending(self, topic: str) -> None:
+        """Replay pending notifications for a subscribed topic."""
+        if self._user_id is None:
+            return
+        notifications = await database_sync_to_async(pending_notifications_for)(self._user_id, topic)
+        for notification in notifications:
+            await self._send_notification(notification)
+
+    async def notification_dispatch(self, event: dict[str, Any]) -> None:
+        """Handle live notification dispatch from the channel layer."""
+        if self._user_id is None:
+            return
+        notification = await self._get_notification(event.get("notification_id"))
+        if notification is None or notification.topic not in self.subscriptions:
+            return
+        if notification.expires_at <= timezone.now():
+            return
+        await self._send_notification(notification)
+
+    async def _send_notification(self, notification: WebSocketNotification) -> None:
+        """Send a notification payload and mark it delivered after success."""
+        if self._user_id is None:
+            return
+        await self.send(
+            text_data=json.dumps(
+                {
+                    "type": "notification",
+                    "id": notification.id,
+                    "event_id": str(notification.event_id),
+                    "notification_type": notification.notification_type,
+                    "topic": notification.topic,
+                    "payload": notification.payload,
+                    "created_at": notification.created_at.isoformat(),
+                },
+                default=str,
+            )
+        )
+        await database_sync_to_async(mark_notification_delivered)(notification.id, self._user_id)
+
+    @database_sync_to_async
+    def _get_notification(self, notification_id: Any) -> WebSocketNotification | None:
+        """Fetch a notification belonging to this connection's user."""
+        if self._user_id is None:
+            return None
+        try:
+            return WebSocketNotification.objects.get(id=notification_id, recipient_id=self._user_id)
+        except (TypeError, ValueError, WebSocketNotification.DoesNotExist):
+            return None

--- a/shifter/shifter_platform/shared/management/commands/prune_notifications.py
+++ b/shifter/shifter_platform/shared/management/commands/prune_notifications.py
@@ -1,0 +1,19 @@
+"""Prune expired WebSocket notification queue rows."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from shared.notifications import prune_expired_notifications
+
+
+class Command(BaseCommand):
+    """Delete expired shared WebSocket notifications."""
+
+    help = "Delete expired shared WebSocket notification queue rows."
+
+    def handle(self, *args, **options) -> None:
+        """Run notification queue pruning."""
+        deleted = prune_expired_notifications()
+        suffix = "" if deleted == 1 else "s"
+        self.stdout.write(f"Deleted {deleted} expired WebSocket notification{suffix}.")

--- a/shifter/shifter_platform/shared/migrations/0001_initial.py
+++ b/shifter/shifter_platform/shared/migrations/0001_initial.py
@@ -1,0 +1,66 @@
+# Generated for issue #679
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="WebSocketNotification",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("event_id", models.UUIDField(default=uuid.uuid4)),
+                ("notification_type", models.CharField(db_index=True, max_length=128)),
+                ("topic", models.CharField(db_index=True, max_length=128)),
+                ("payload", models.JSONField(default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True)),
+                ("delivered_at", models.DateTimeField(blank=True, db_index=True, null=True)),
+                ("expires_at", models.DateTimeField(db_index=True)),
+                (
+                    "recipient",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="websocket_notifications",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "shared_websocket_notification",
+                "ordering": ["created_at", "id"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="websocketnotification",
+            index=models.Index(fields=["recipient", "topic", "delivered_at"], name="wsn_rec_topic_delivery_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="websocketnotification",
+            index=models.Index(fields=["expires_at"], name="wsn_expires_idx"),
+        ),
+        migrations.AddConstraint(
+            model_name="websocketnotification",
+            constraint=models.UniqueConstraint(
+                fields=("recipient", "topic", "notification_type", "event_id"),
+                name="uniq_wsn_rec_topic_type_event",
+            ),
+        ),
+    ]

--- a/shifter/shifter_platform/shared/migrations/__init__.py
+++ b/shifter/shifter_platform/shared/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Shared app migrations."""

--- a/shifter/shifter_platform/shared/models.py
+++ b/shifter/shifter_platform/shared/models.py
@@ -1,0 +1,45 @@
+"""Shared Django models."""
+
+from __future__ import annotations
+
+import uuid
+
+from django.conf import settings
+from django.db import models
+
+
+class WebSocketNotification(models.Model):
+    """Durable per-recipient queue for browser WebSocket notifications."""
+
+    recipient = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="websocket_notifications",
+    )
+    event_id = models.UUIDField(default=uuid.uuid4)
+    notification_type = models.CharField(max_length=128, db_index=True)
+    topic = models.CharField(max_length=128, db_index=True)
+    payload = models.JSONField(default=dict)
+    created_at = models.DateTimeField(auto_now_add=True, db_index=True)
+    delivered_at = models.DateTimeField(blank=True, null=True, db_index=True)
+    expires_at = models.DateTimeField(db_index=True)
+
+    class Meta:
+        """Model metadata."""
+
+        db_table = "shared_websocket_notification"
+        ordering = ["created_at", "id"]
+        indexes = [
+            models.Index(fields=["recipient", "topic", "delivered_at"], name="wsn_rec_topic_delivery_idx"),
+            models.Index(fields=["expires_at"], name="wsn_expires_idx"),
+        ]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["recipient", "topic", "notification_type", "event_id"],
+                name="uniq_wsn_rec_topic_type_event",
+            ),
+        ]
+
+    def __str__(self) -> str:
+        """Return a compact diagnostic representation."""
+        return f"{self.notification_type}:{self.topic}:{self.recipient_id}"

--- a/shifter/shifter_platform/shared/notifications.py
+++ b/shifter/shifter_platform/shared/notifications.py
@@ -1,0 +1,264 @@
+"""Shared WebSocket notification registry, queue, and publisher."""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.conf import settings
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+
+from shared.channels.groups import notification_user_topic_group
+from shared.models import WebSocketNotification
+
+logger = logging.getLogger(__name__)
+
+_TOPIC_RE = re.compile(r"^[a-z][a-z0-9_.:-]{0,127}$")
+_TYPE_RE = re.compile(r"^[a-z][a-z0-9_.:-]{0,127}$")
+
+PayloadHandler = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+SubscriptionAuthorizer = Callable[[Any, str], bool]
+
+
+@dataclass(frozen=True)
+class NotificationRegistration:
+    """Registered notification type and its topic authorization contract."""
+
+    name: str
+    topic_prefix: str
+    can_subscribe: SubscriptionAuthorizer
+    payload_handler: PayloadHandler
+
+
+_registry: dict[str, NotificationRegistration] = {}
+
+
+def _identity_payload(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a shallow JSON-style payload copy."""
+    return dict(payload)
+
+
+def validate_topic(topic: str) -> str:
+    """Validate and normalize a logical notification topic."""
+    if not isinstance(topic, str) or not _TOPIC_RE.fullmatch(topic):
+        raise ValueError("notification topic must match ^[a-z][a-z0-9_.:-]{0,127}$")
+    return topic
+
+
+def _validate_notification_type(notification_type: str) -> str:
+    if not isinstance(notification_type, str) or not _TYPE_RE.fullmatch(notification_type):
+        raise ValueError("notification type must match ^[a-z][a-z0-9_.:-]{0,127}$")
+    return notification_type
+
+
+def register_notification_type(
+    *,
+    name: str,
+    topic_prefix: str,
+    can_subscribe: SubscriptionAuthorizer,
+    payload_handler: PayloadHandler | None = None,
+    replace: bool = False,
+) -> NotificationRegistration:
+    """Register a browser notification type and topic authorizer."""
+    name = _validate_notification_type(name)
+    topic_prefix = validate_topic(topic_prefix)
+    if not callable(can_subscribe):
+        raise TypeError("can_subscribe must be callable")
+    handler = payload_handler or _identity_payload
+    if not callable(handler):
+        raise TypeError("payload_handler must be callable")
+
+    existing = _registry.get(name)
+    if existing is not None and not replace:
+        return existing
+
+    registration = NotificationRegistration(
+        name=name,
+        topic_prefix=topic_prefix,
+        can_subscribe=can_subscribe,
+        payload_handler=handler,
+    )
+    _registry[name] = registration
+    return registration
+
+
+def clear_notification_registry() -> None:
+    """Clear registered notification types for tests."""
+    _registry.clear()
+
+
+def _registrations_for_topic(topic: str) -> list[NotificationRegistration]:
+    topic = validate_topic(topic)
+    return [registration for registration in _registry.values() if topic.startswith(registration.topic_prefix)]
+
+
+def authorize_subscription(user: Any, topic: str) -> bool:
+    """Return whether a user may subscribe to a logical topic."""
+    if not getattr(user, "is_authenticated", False):
+        return False
+    try:
+        registrations = _registrations_for_topic(topic)
+    except ValueError:
+        return False
+
+    for registration in registrations:
+        try:
+            if registration.can_subscribe(user, topic):
+                return True
+        except Exception:
+            logger.warning(
+                "notification authorizer failed: type=%s topic=%s user_id=%s",
+                registration.name,
+                topic,
+                getattr(user, "id", None),
+                exc_info=True,
+            )
+    return False
+
+
+def _registration_for_publish(notification_type: str, topic: str) -> NotificationRegistration:
+    notification_type = _validate_notification_type(notification_type)
+    topic = validate_topic(topic)
+    try:
+        registration = _registry[notification_type]
+    except KeyError as exc:
+        raise ValueError(f"unknown notification type: {notification_type}") from exc
+    if not topic.startswith(registration.topic_prefix):
+        raise ValueError(f"topic {topic!r} is not valid for notification type {notification_type!r}")
+    return registration
+
+
+def _coerce_event_id(event_id: uuid.UUID | str | None) -> uuid.UUID:
+    if event_id is None:
+        return uuid.uuid4()
+    if isinstance(event_id, uuid.UUID):
+        return event_id
+    return uuid.UUID(str(event_id))
+
+
+def _expires_at() -> Any:
+    retention_days = int(getattr(settings, "WEBSOCKET_NOTIFICATION_RETENTION_DAYS", 7))
+    return timezone.now() + timedelta(days=max(retention_days, 1))
+
+
+def _max_replay() -> int:
+    return max(int(getattr(settings, "WEBSOCKET_NOTIFICATION_MAX_REPLAY", 100)), 1)
+
+
+def _unique_recipient_ids(recipient_ids: Iterable[int]) -> list[int]:
+    seen: set[int] = set()
+    unique: list[int] = []
+    for recipient_id in recipient_ids:
+        normalized = int(recipient_id)
+        if normalized not in seen:
+            seen.add(normalized)
+            unique.append(normalized)
+    return unique
+
+
+def _get_or_create_notification(
+    *,
+    recipient_id: int,
+    notification_type: str,
+    topic: str,
+    event_id: uuid.UUID,
+    payload: dict[str, Any],
+    expires_at: Any,
+) -> WebSocketNotification:
+    try:
+        with transaction.atomic():
+            notification, _created = WebSocketNotification.objects.get_or_create(
+                recipient_id=recipient_id,
+                topic=topic,
+                notification_type=notification_type,
+                event_id=event_id,
+                defaults={
+                    "payload": payload,
+                    "expires_at": expires_at,
+                },
+            )
+    except IntegrityError:
+        notification = WebSocketNotification.objects.get(
+            recipient_id=recipient_id,
+            topic=topic,
+            notification_type=notification_type,
+            event_id=event_id,
+        )
+    return notification
+
+
+def publish_notification(
+    notification_type: str,
+    *,
+    topic: str,
+    payload: Mapping[str, Any],
+    recipient_ids: Iterable[int],
+    event_id: uuid.UUID | str | None = None,
+) -> list[WebSocketNotification]:
+    """Persist and fan out a browser notification to recipient topic groups."""
+    registration = _registration_for_publish(notification_type, topic)
+    projected_payload = dict(registration.payload_handler(dict(payload)))
+    normalized_event_id = _coerce_event_id(event_id)
+    expiration = _expires_at()
+    notifications = [
+        _get_or_create_notification(
+            recipient_id=recipient_id,
+            notification_type=notification_type,
+            topic=topic,
+            event_id=normalized_event_id,
+            payload=projected_payload,
+            expires_at=expiration,
+        )
+        for recipient_id in _unique_recipient_ids(recipient_ids)
+    ]
+
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        return notifications
+
+    send = async_to_sync(channel_layer.group_send)
+    for notification in notifications:
+        send(
+            notification_user_topic_group(notification.recipient_id, topic),
+            {
+                "type": "notification.dispatch",
+                "notification_id": notification.id,
+            },
+        )
+    return notifications
+
+
+def pending_notifications_for(user_id: int, topic: str) -> list[WebSocketNotification]:
+    """Return the bounded undelivered replay queue for a user/topic."""
+    topic = validate_topic(topic)
+    return list(
+        WebSocketNotification.objects.filter(
+            recipient_id=int(user_id),
+            topic=topic,
+            delivered_at__isnull=True,
+            expires_at__gt=timezone.now(),
+        ).order_by("created_at", "id")[: _max_replay()]
+    )
+
+
+def mark_notification_delivered(notification_id: int, user_id: int) -> None:
+    """Mark one queued notification delivered for the recipient."""
+    WebSocketNotification.objects.filter(
+        id=notification_id,
+        recipient_id=int(user_id),
+        delivered_at__isnull=True,
+    ).update(delivered_at=timezone.now())
+
+
+def prune_expired_notifications() -> int:
+    """Delete expired notification queue rows and return the count."""
+    deleted, _details = WebSocketNotification.objects.filter(expires_at__lte=timezone.now()).delete()
+    return deleted

--- a/shifter/shifter_platform/shared/routing.py
+++ b/shifter/shifter_platform/shared/routing.py
@@ -1,0 +1,9 @@
+"""WebSocket URL routing for shared platform notifications."""
+
+from django.urls import re_path
+
+from shared.consumers import SharedNotificationConsumer
+
+websocket_urlpatterns = [
+    re_path(r"ws/notifications/$", SharedNotificationConsumer.as_asgi()),
+]

--- a/shifter/shifter_platform/tests/cms/experiments/test_handlers.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_handlers.py
@@ -98,3 +98,36 @@ class TestProcessEvent:
         )
         # No exception raised -- event was silently dropped
         mock_orch_cls.assert_not_called()
+
+
+class TestNotifications:
+    @patch("cms.experiments.handlers.Experiment.objects.only")
+    def test_experiment_recipient_missing_experiment_returns_none(self, mock_only):
+        from cms.experiments.handlers import _experiment_recipient_id
+        from cms.experiments.models import Experiment
+
+        mock_only.return_value.get.side_effect = Experiment.DoesNotExist
+
+        assert _experiment_recipient_id(999) is None
+
+    @patch("cms.experiments.handlers._experiment_recipient_id", return_value=None)
+    def test_run_status_notification_skips_missing_recipient(self, mock_recipient):
+        from cms.experiments.handlers import _publish_run_status_notification
+
+        _publish_run_status_notification(
+            experiment_id=999,
+            run_id=5,
+            run_number=1,
+            status=RunStatus.FAILED.value,
+            error_message="missing owner",
+        )
+
+        mock_recipient.assert_called_once_with(999)
+
+    @patch("cms.experiments.handlers._experiment_recipient_id", return_value=None)
+    def test_experiment_status_notification_skips_missing_recipient(self, mock_recipient):
+        from cms.experiments.handlers import _publish_experiment_status_notification
+
+        _publish_experiment_status_notification(999, "failed")
+
+        mock_recipient.assert_called_once_with(999)

--- a/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
@@ -1,0 +1,75 @@
+"""Tests for experiment notification registration and publishing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cms.experiments.notifications import (
+    experiment_topic,
+    publish_experiment_run_status_notification,
+    register_experiment_notifications,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_notification_registry():
+    """Keep notification registrations isolated between tests."""
+    from shared.notifications import clear_notification_registry
+
+    clear_notification_registry()
+    yield
+    clear_notification_registry()
+
+
+def test_register_experiment_notifications_authorizes_staff_owner() -> None:
+    """Experiment topics use the existing staff-owner access rule."""
+    register_experiment_notifications()
+    staff_owner = MagicMock(id=7, is_staff=True, is_authenticated=True)
+
+    with patch("cms.experiments.notifications.Experiment.objects.filter") as mock_filter:
+        mock_filter.return_value.exists.return_value = True
+
+        from shared.notifications import authorize_subscription
+
+        assert authorize_subscription(staff_owner, experiment_topic(100)) is True
+
+    mock_filter.assert_called_once_with(pk=100, user=staff_owner)
+
+
+def test_register_experiment_notifications_rejects_non_staff() -> None:
+    """Experiment topics remain staff-only like the existing status socket."""
+    register_experiment_notifications()
+    non_staff = MagicMock(id=7, is_staff=False, is_authenticated=True)
+
+    from shared.notifications import authorize_subscription
+
+    assert authorize_subscription(non_staff, experiment_topic(100)) is False
+
+
+def test_publish_experiment_run_status_notification_projects_safe_payload() -> None:
+    """Experiment publishers pass only the browser-safe payload to shared notifications."""
+    with patch("cms.experiments.notifications.publish_notification") as mock_publish:
+        publish_experiment_run_status_notification(
+            experiment_id=100,
+            recipient_id=7,
+            run_id=5,
+            run_number=2,
+            status="completed",
+            error_message="",
+        )
+
+    mock_publish.assert_called_once_with(
+        "experiment.run_status",
+        topic=experiment_topic(100),
+        payload={
+            "experiment_id": 100,
+            "run_id": 5,
+            "run_number": 2,
+            "status": "completed",
+            "error_message": "",
+        },
+        recipient_ids=[7],
+        event_id=None,
+    )

--- a/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
@@ -48,6 +48,18 @@ def test_register_experiment_notifications_rejects_non_staff() -> None:
     assert authorize_subscription(non_staff, experiment_topic(100)) is False
 
 
+def test_register_experiment_notifications_rejects_invalid_topics() -> None:
+    """Experiment subscription authorization rejects malformed experiment topics."""
+    register_experiment_notifications()
+    staff_owner = MagicMock(id=7, is_staff=True, is_authenticated=True)
+
+    from shared.notifications import authorize_subscription
+
+    assert authorize_subscription(staff_owner, "range:100") is False
+    assert authorize_subscription(staff_owner, "experiment:not-int") is False
+    assert authorize_subscription(staff_owner, "experiment:0") is False
+
+
 def test_publish_experiment_run_status_notification_projects_safe_payload() -> None:
     """Experiment publishers pass only the browser-safe payload to shared notifications."""
     with patch("cms.experiments.notifications.publish_notification") as mock_publish:

--- a/shifter/shifter_platform/tests/shared/test_notification_consumer.py
+++ b/shifter/shifter_platform/tests/shared/test_notification_consumer.py
@@ -1,0 +1,146 @@
+"""Tests for the shared notification WebSocket consumer."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from channels.db import database_sync_to_async
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone
+
+from shared.channels.groups import notification_user_topic_group
+from shared.enums import WebSocketCloseCode
+from shared.models import WebSocketNotification
+
+
+@pytest.fixture(autouse=True)
+def clear_notification_registry():
+    """Keep notification registrations isolated between tests."""
+    from shared.notifications import clear_notification_registry
+
+    clear_notification_registry()
+    yield
+    clear_notification_registry()
+
+
+@pytest.fixture
+def user(db):
+    """Create a test user."""
+    return get_user_model().objects.create_user(username="owner@example.com", email="owner@example.com")
+
+
+def _register_authorized_topic() -> None:
+    from shared.notifications import register_notification_type
+
+    register_notification_type(
+        name="experiment.run_status",
+        topic_prefix="experiment:",
+        can_subscribe=lambda _user, _topic: True,
+    )
+
+
+@pytest.fixture
+def consumer():
+    """Create a notification consumer with mocked WebSocket methods."""
+    from shared.consumers import SharedNotificationConsumer
+
+    c = SharedNotificationConsumer()
+    c.channel_name = "test-channel"
+    c.channel_layer = AsyncMock()
+    c.close = AsyncMock()
+    c.accept = AsyncMock()
+    c.send = AsyncMock()
+    return c
+
+
+@pytest.mark.asyncio
+async def test_rejects_anonymous_user(consumer):
+    """Anonymous users cannot open the shared notification socket."""
+    consumer.scope = {"type": "websocket", "user": AnonymousUser()}
+
+    await consumer.connect()
+
+    consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.NOT_AUTHENTICATED)
+    consumer.accept.assert_not_awaited()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_subscribe_replays_pending_notifications_and_marks_delivered(consumer, user, settings):
+    """Subscribing joins the user/topic group and replays missed notifications."""
+    _register_authorized_topic()
+    settings.WEBSOCKET_NOTIFICATION_MAX_REPLAY = 10
+    pending = await database_sync_to_async(WebSocketNotification.objects.create)(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 7, "status": "running"},
+        expires_at=timezone.now() + timedelta(days=1),
+    )
+    consumer.scope = {"type": "websocket", "user": user}
+
+    await consumer.connect()
+    await consumer.receive_json({"type": "subscribe", "topic": "experiment:100"})
+
+    consumer.channel_layer.group_add.assert_awaited_once()
+    assert consumer.channel_layer.group_add.await_args.args == (
+        notification_user_topic_group(user.id, "experiment:100"),
+        "test-channel",
+    )
+    sent_messages = [call.kwargs["text_data"] for call in consumer.send.await_args_list]
+    assert any('"type": "subscribed"' in message for message in sent_messages)
+    assert any('"type": "notification"' in message and '"run_id": 7' in message for message in sent_messages)
+    await database_sync_to_async(pending.refresh_from_db)()
+    assert pending.delivered_at is not None
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_live_dispatch_sends_notification_and_marks_delivered(consumer, user):
+    """Live dispatch sends a stored notification for an active subscription."""
+    _register_authorized_topic()
+    notification = await database_sync_to_async(WebSocketNotification.objects.create)(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 8, "status": "completed"},
+        expires_at=timezone.now() + timedelta(days=1),
+    )
+    consumer.scope = {"type": "websocket", "user": user}
+    consumer.subscriptions = {"experiment:100"}
+    consumer._user_id = user.id
+
+    await consumer.notification_dispatch(
+        {
+            "type": "notification.dispatch",
+            "notification_id": notification.id,
+        }
+    )
+
+    consumer.send.assert_awaited_once()
+    assert '"run_id": 8' in consumer.send.await_args.kwargs["text_data"]
+    await database_sync_to_async(notification.refresh_from_db)()
+    assert notification.delivered_at is not None
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_rejects_unauthorized_subscription(consumer):
+    """A registered topic must authorize the current user before subscription."""
+    from shared.notifications import register_notification_type
+
+    register_notification_type(
+        name="experiment.run_status",
+        topic_prefix="experiment:",
+        can_subscribe=lambda _user, _topic: False,
+    )
+    user = MagicMock(id=42, is_authenticated=True)
+    consumer.scope = {"type": "websocket", "user": user}
+
+    await consumer.connect()
+    await consumer.receive_json({"type": "subscribe", "topic": "experiment:100"})
+
+    consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.PERMISSION_DENIED)

--- a/shifter/shifter_platform/tests/shared/test_notification_consumer.py
+++ b/shifter/shifter_platform/tests/shared/test_notification_consumer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -67,6 +68,69 @@ async def test_rejects_anonymous_user(consumer):
     consumer.accept.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_disconnect_before_auth_returns_without_group_updates(consumer):
+    """Disconnect is a no-op when the socket never authenticated."""
+    await consumer.disconnect(close_code=1000)
+
+    consumer.channel_layer.group_discard.assert_not_awaited()
+    assert consumer.subscriptions == set()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_discards_all_subscription_groups(consumer, user):
+    """Disconnect leaves every joined notification group."""
+    consumer._user_id = user.id
+    consumer.subscriptions = {"experiment:100", "experiment:200"}
+
+    await consumer.disconnect(close_code=1000)
+
+    discarded_groups = {call.args[0] for call in consumer.channel_layer.group_discard.await_args_list}
+    assert discarded_groups == {
+        notification_user_topic_group(user.id, "experiment:100"),
+        notification_user_topic_group(user.id, "experiment:200"),
+    }
+    assert consumer.subscriptions == set()
+
+
+@pytest.mark.asyncio
+async def test_receive_ignores_empty_messages_and_rejects_invalid_json(consumer):
+    """Raw WebSocket messages must be JSON control envelopes."""
+    await consumer.receive(text_data=None)
+    consumer.close.assert_not_awaited()
+
+    await consumer.receive(text_data="{")
+
+    consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.INVALID_REQUEST)
+
+
+@pytest.mark.asyncio
+async def test_receive_json_rejects_unknown_control_message(consumer):
+    """Only subscribe and unsubscribe control messages are accepted."""
+    await consumer.receive_json({"type": "ping", "topic": "experiment:100"})
+
+    consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.INVALID_REQUEST)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_before_auth_closes(consumer):
+    """Subscribe cannot proceed before connect establishes the user id."""
+    await consumer.receive_json({"type": "subscribe", "topic": "experiment:100"})
+
+    consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.NOT_AUTHENTICATED)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_rejects_invalid_topic(consumer, user):
+    """Invalid topic syntax closes the socket."""
+    consumer.scope = {"type": "websocket", "user": user}
+    await consumer.connect()
+
+    await consumer.receive_json({"type": "subscribe", "topic": "not valid"})
+
+    consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.INVALID_REQUEST)
+
+
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_subscribe_replays_pending_notifications_and_marks_delivered(consumer, user, settings):
@@ -95,6 +159,51 @@ async def test_subscribe_replays_pending_notifications_and_marks_delivered(consu
     assert any('"type": "notification"' in message and '"run_id": 7' in message for message in sent_messages)
     await database_sync_to_async(pending.refresh_from_db)()
     assert pending.delivered_at is not None
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_discards_known_topic_and_confirms(consumer, user):
+    """Unsubscribe leaves a joined topic group and sends an acknowledgement."""
+    consumer.scope = {"type": "websocket", "user": user}
+    await consumer.connect()
+    consumer.subscriptions = {"experiment:100"}
+
+    await consumer.receive_json({"type": "unsubscribe", "topic": "experiment:100"})
+
+    consumer.channel_layer.group_discard.assert_awaited_once_with(
+        notification_user_topic_group(user.id, "experiment:100"),
+        "test-channel",
+    )
+    payload = json.loads(consumer.send.await_args.kwargs["text_data"])
+    assert payload == {"type": "unsubscribed", "topic": "experiment:100"}
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_without_user_returns(consumer):
+    """Unsubscribe is a no-op before authentication."""
+    await consumer.receive_json({"type": "unsubscribe", "topic": "experiment:100"})
+
+    consumer.send.assert_not_awaited()
+    consumer.channel_layer.group_discard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_rejects_invalid_topic(consumer, user):
+    """Invalid unsubscribe topics close the socket."""
+    consumer.scope = {"type": "websocket", "user": user}
+    await consumer.connect()
+
+    await consumer.receive_json({"type": "unsubscribe", "topic": "not valid"})
+
+    consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.INVALID_REQUEST)
+
+
+@pytest.mark.asyncio
+async def test_replay_pending_without_user_returns(consumer):
+    """Replay cannot query without an authenticated user id."""
+    await consumer._replay_pending("experiment:100")
+
+    consumer.send.assert_not_awaited()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -126,6 +235,54 @@ async def test_live_dispatch_sends_notification_and_marks_delivered(consumer, us
     assert notification.delivered_at is not None
 
 
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_live_dispatch_ignores_unusable_notifications(consumer, user):
+    """Live dispatch ignores unauthenticated, missing, unsubscribed, and expired rows."""
+    notification = await database_sync_to_async(WebSocketNotification.objects.create)(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 8, "status": "completed"},
+        expires_at=timezone.now() + timedelta(days=1),
+    )
+    expired = await database_sync_to_async(WebSocketNotification.objects.create)(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 9, "status": "expired"},
+        expires_at=timezone.now() - timedelta(seconds=1),
+    )
+
+    await consumer.notification_dispatch({"notification_id": notification.id})
+    consumer.send.assert_not_awaited()
+
+    consumer._user_id = user.id
+    await consumer.notification_dispatch({"notification_id": "not-an-id"})
+    await consumer.notification_dispatch({"notification_id": notification.id})
+
+    consumer.subscriptions = {"experiment:100"}
+    await consumer.notification_dispatch({"notification_id": expired.id})
+
+    consumer.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_notification_without_user_returns(consumer, user):
+    """Notification send is guarded by the authenticated user id."""
+    notification = WebSocketNotification(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 8, "status": "completed"},
+        expires_at=timezone.now() + timedelta(days=1),
+    )
+
+    await consumer._send_notification(notification)
+
+    consumer.send.assert_not_awaited()
+
+
 @pytest.mark.django_db
 @pytest.mark.asyncio
 async def test_rejects_unauthorized_subscription(consumer):
@@ -144,3 +301,11 @@ async def test_rejects_unauthorized_subscription(consumer):
     await consumer.receive_json({"type": "subscribe", "topic": "experiment:100"})
 
     consumer.close.assert_awaited_once_with(code=WebSocketCloseCode.PERMISSION_DENIED)
+
+
+def test_shared_notification_websocket_route_targets_consumer():
+    """Shared notification route exposes the generic consumer."""
+    from shared.routing import websocket_urlpatterns
+
+    assert websocket_urlpatterns
+    assert websocket_urlpatterns[0].pattern.regex.pattern == "ws/notifications/$"

--- a/shifter/shifter_platform/tests/shared/test_notifications.py
+++ b/shifter/shifter_platform/tests/shared/test_notifications.py
@@ -45,6 +45,105 @@ def _register_experiment_type() -> None:
     )
 
 
+def test_register_notification_type_validates_contract() -> None:
+    """Registry entries validate names, topics, and callables."""
+    from shared.notifications import register_notification_type
+
+    registration = register_notification_type(
+        name="experiment.status",
+        topic_prefix="experiment:",
+        can_subscribe=lambda _user, _topic: True,
+    )
+
+    assert registration.payload_handler({"status": "running"}) == {"status": "running"}
+    assert (
+        register_notification_type(
+            name="experiment.status",
+            topic_prefix="experiment:",
+            can_subscribe=lambda _user, _topic: False,
+        )
+        is registration
+    )
+    with pytest.raises(ValueError):
+        register_notification_type(
+            name="Experiment",
+            topic_prefix="experiment:",
+            can_subscribe=lambda _user, _topic: True,
+        )
+    with pytest.raises(ValueError):
+        register_notification_type(
+            name="experiment.status",
+            topic_prefix="not valid",
+            can_subscribe=lambda _user, _topic: True,
+        )
+    with pytest.raises(TypeError):
+        register_notification_type(name="experiment.status", topic_prefix="experiment:", can_subscribe=True)
+    with pytest.raises(TypeError):
+        register_notification_type(
+            name="experiment.status",
+            topic_prefix="experiment:",
+            can_subscribe=lambda _user, _topic: True,
+            payload_handler=True,
+            replace=True,
+        )
+
+
+def test_authorize_subscription_handles_invalid_and_failing_authorizers(caplog) -> None:
+    """Authorization failures deny access without breaking the socket path."""
+    from shared.notifications import authorize_subscription, register_notification_type
+
+    authenticated = MagicMock(is_authenticated=True, id=7)
+    unauthenticated = MagicMock(is_authenticated=False, id=8)
+
+    def failing_authorizer(_user, _topic):
+        raise RuntimeError("boom")
+
+    register_notification_type(
+        name="experiment.status",
+        topic_prefix="experiment:",
+        can_subscribe=failing_authorizer,
+    )
+
+    assert authorize_subscription(unauthenticated, "experiment:100") is False
+    assert authorize_subscription(authenticated, "not valid") is False
+    assert authorize_subscription(authenticated, "experiment:100") is False
+    assert "notification authorizer failed" in caplog.text
+
+
+def test_publish_notification_validates_registration_and_event_id(user) -> None:
+    """Publish rejects unknown contracts and accepts string event ids."""
+    from shared.notifications import publish_notification
+
+    with pytest.raises(ValueError, match="unknown notification type"):
+        publish_notification(
+            "experiment.status",
+            topic="experiment:100",
+            payload={},
+            recipient_ids=[user.id],
+        )
+
+    _register_experiment_type()
+    with pytest.raises(ValueError, match="not valid for notification type"):
+        publish_notification(
+            "experiment.run_status",
+            topic="range:100",
+            payload={"run_id": 7, "status": "running"},
+            recipient_ids=[user.id],
+        )
+
+    with patch("shared.notifications.get_channel_layer", return_value=None):
+        [notification] = publish_notification(
+            "experiment.run_status",
+            topic="experiment:100",
+            payload={"run_id": 7, "status": "running"},
+            recipient_ids=[user.id, user.id],
+            event_id="12345678-1234-5678-1234-567812345678",
+        )
+
+    assert str(notification.event_id) == "12345678-1234-5678-1234-567812345678"
+    assert WebSocketNotification.objects.count() == 1
+
+
 @pytest.mark.django_db
 def test_publish_notification_persists_and_fans_out(user):
     """Publishing stores a per-recipient row and sends to the user/topic group."""
@@ -109,6 +208,7 @@ def test_publish_notification_is_idempotent_per_recipient_topic_type_and_event(u
 
     assert first[0].id == second[0].id
     assert WebSocketNotification.objects.count() == 1
+    assert str(WebSocketNotification.objects.get()) == f"experiment.run_status:experiment:100:{user.id}"
 
 
 @pytest.mark.django_db

--- a/shifter/shifter_platform/tests/shared/test_notifications.py
+++ b/shifter/shifter_platform/tests/shared/test_notifications.py
@@ -1,0 +1,173 @@
+"""Tests for shared WebSocket notification infrastructure."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.utils import timezone
+
+from shared.models import WebSocketNotification
+
+
+@pytest.fixture(autouse=True)
+def clear_notification_registry():
+    """Keep notification registrations isolated between tests."""
+    from shared.notifications import clear_notification_registry
+
+    clear_notification_registry()
+    yield
+    clear_notification_registry()
+
+
+@pytest.fixture
+def user(db):
+    """Create a test user."""
+    return get_user_model().objects.create_user(username="owner@example.com", email="owner@example.com")
+
+
+def _register_experiment_type() -> None:
+    from shared.notifications import register_notification_type
+
+    register_notification_type(
+        name="experiment.run_status",
+        topic_prefix="experiment:",
+        can_subscribe=lambda _user, _topic: True,
+        payload_handler=lambda payload: {
+            "run_id": payload["run_id"],
+            "status": payload["status"],
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_publish_notification_persists_and_fans_out(user):
+    """Publishing stores a per-recipient row and sends to the user/topic group."""
+    from shared.notifications import publish_notification
+
+    _register_experiment_type()
+    event_id = uuid4()
+
+    with (
+        patch("shared.notifications.get_channel_layer") as mock_get_channel_layer,
+        patch("shared.notifications.async_to_sync") as mock_async_to_sync,
+    ):
+        mock_channel_layer = MagicMock()
+        mock_get_channel_layer.return_value = mock_channel_layer
+        mock_send = MagicMock()
+        mock_async_to_sync.return_value = mock_send
+
+        notifications = publish_notification(
+            "experiment.run_status",
+            topic="experiment:100",
+            payload={"run_id": 7, "status": "running", "unsafe": "drop"},
+            recipient_ids=[user.id],
+            event_id=event_id,
+        )
+
+    assert [notification.recipient_id for notification in notifications] == [user.id]
+    stored = WebSocketNotification.objects.get()
+    assert stored.notification_type == "experiment.run_status"
+    assert stored.topic == "experiment:100"
+    assert stored.event_id == event_id
+    assert stored.payload == {"run_id": 7, "status": "running"}
+    mock_async_to_sync.assert_called_once_with(mock_channel_layer.group_send)
+    group_name, event = mock_send.call_args.args
+    assert group_name.startswith(f"notify_u{user.id}_")
+    assert event["type"] == "notification.dispatch"
+    assert event["notification_id"] == stored.id
+
+
+@pytest.mark.django_db
+def test_publish_notification_is_idempotent_per_recipient_topic_type_and_event(user):
+    """Duplicate source events do not enqueue duplicate missed notifications."""
+    from shared.notifications import publish_notification
+
+    _register_experiment_type()
+    event_id = UUID("12345678-1234-5678-1234-567812345678")
+
+    with patch("shared.notifications.get_channel_layer", return_value=None):
+        first = publish_notification(
+            "experiment.run_status",
+            topic="experiment:100",
+            payload={"run_id": 7, "status": "running"},
+            recipient_ids=[user.id],
+            event_id=event_id,
+        )
+        second = publish_notification(
+            "experiment.run_status",
+            topic="experiment:100",
+            payload={"run_id": 7, "status": "running"},
+            recipient_ids=[user.id],
+            event_id=event_id,
+        )
+
+    assert first[0].id == second[0].id
+    assert WebSocketNotification.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_pending_notifications_exclude_delivered_and_expired(user, settings):
+    """Replay queries only return undelivered, unexpired rows for the topic."""
+    from shared.notifications import pending_notifications_for
+
+    settings.WEBSOCKET_NOTIFICATION_MAX_REPLAY = 10
+    now = timezone.now()
+    WebSocketNotification.objects.create(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"status": "running"},
+        expires_at=now + timedelta(days=1),
+    )
+    WebSocketNotification.objects.create(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"status": "delivered"},
+        delivered_at=now,
+        expires_at=now + timedelta(days=1),
+    )
+    WebSocketNotification.objects.create(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"status": "expired"},
+        expires_at=now - timedelta(seconds=1),
+    )
+
+    pending = pending_notifications_for(user.id, "experiment:100")
+
+    assert [notification.payload for notification in pending] == [{"status": "running"}]
+
+
+@pytest.mark.django_db
+def test_prune_notifications_management_command_removes_expired_rows(user):
+    """The operational cleanup command deletes expired notification rows."""
+    now = timezone.now()
+    expired = WebSocketNotification.objects.create(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"status": "expired"},
+        expires_at=now - timedelta(seconds=1),
+    )
+    active = WebSocketNotification.objects.create(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        payload={"status": "active"},
+        expires_at=now + timedelta(days=1),
+    )
+
+    out = StringIO()
+    call_command("prune_notifications", stdout=out)
+
+    assert not WebSocketNotification.objects.filter(pk=expired.pk).exists()
+    assert WebSocketNotification.objects.filter(pk=active.pk).exists()
+    assert "Deleted 1 expired WebSocket notification" in out.getvalue()


### PR DESCRIPTION
## Summary

Add shared authenticated WebSocket notification infrastructure with durable per-user replay and experiment notification registration.

## Requirement UIDs

- `PLAT-105`

## Related Issues

Closes #679

## ADR Impact

- No ADR required

## Changes

- Add a shared notification registry, durable WebSocketNotification queue, generic /ws/notifications/ consumer, and hashed user/topic Channels groups.
- Register experiment status and run-status notifications through cms.experiments while preserving existing experiment WebSocket routes.
- Add retention cleanup via prune_notifications, replay bounds settings, migration, targeted tests, and changelog fragment.
- Increase changed-line coverage for notification control-flow and experiment handler branches after the initial SonarCloud gate failure.
- **Migration reminder:** update version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java` (per `.gc/plan-rules.md`).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

pre-commit run --all-files; python3 scripts/adr_guard/adr_guard.py --all --level ci; cd shifter/shifter_platform && uv run ruff check .; cd shifter/shifter_platform && uv run ruff format --check .; cd shifter/shifter_platform && uv run lint-imports --config ../../.importlinter; cd shifter/shifter_platform && uv run pytest tests/ --ignore=tests/documentation --cov=. --cov-report=term-missing --cov-report=xml:coverage.xml; cd shifter/shifter_platform && uv run pytest tests/shared/test_notifications.py tests/shared/test_notification_consumer.py tests/cms/experiments/test_notifications.py tests/cms/experiments/test_handlers.py tests/config/test_url_registration.py; cd shifter/shifter_platform && uv run pytest tests/shared/test_notifications.py tests/shared/test_notification_consumer.py tests/cms/experiments/test_notifications.py tests/cms/experiments/test_consumers.py tests/cms/experiments/test_events.py tests/mission_control/consumers/test_range_status_consumer.py tests/config/test_url_registration.py; cd shifter/shifter_platform && uv run python manage.py check; cd shifter && uv run pytest ../cyberscript/tests/test_channels.py.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: shifter/shifter_platform/shared/notifications.py, shifter/shifter_platform/shared/consumers.py, shifter/shifter_platform/shared/models.py, shifter/shifter_platform/cms/experiments/notifications.py
- TESTS: shifter/shifter_platform/tests/shared/test_notifications.py, shifter/shifter_platform/tests/shared/test_notification_consumer.py, shifter/shifter_platform/tests/cms/experiments/test_notifications.py, shifter/shifter_platform/tests/cms/experiments/test_handlers.py, shifter/cyberscript/tests/test_channels.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/679.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.
