### PR TITLE
fix(portal): decouple channel-layer backend from autoscaling mode

### DIFF
--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -529,6 +529,7 @@ jobs:
           SQS_ENGINE_URL=$(get_param "$PS_PREFIX/sqs-engine-url")
           SQS_MC_URL=$(get_param "$PS_PREFIX/sqs-mc-url")
           REDIS_ENDPOINT=$(get_param "$PS_PREFIX/redis-endpoint" || echo "")
+          CHANNEL_LAYER_BACKEND=$(get_param "$PS_PREFIX/channel-layer-backend" || echo "")
           EMAIL_BACKEND=$(get_param "$PS_PREFIX/email-backend" || echo "")
           CTF_FROM_EMAIL=$(get_param "$PS_PREFIX/ctf-from-email" || echo "")
           PLATFORM_BOOTSTRAP_STAFF_EMAILS=$(get_param "$PS_PREFIX/platform-bootstrap-staff-emails" || echo "")
@@ -559,6 +560,8 @@ jobs:
           COMMON_ENV="$COMMON_ENV -e ENGINE_PRIVATE_SUBNET_IDS=$ENGINE_PRIVATE_SUBNET_IDS"
           COMMON_ENV="$COMMON_ENV -e SQS_CMS_URL=$SQS_CMS_URL -e SQS_ENGINE_URL=$SQS_ENGINE_URL -e SQS_MC_URL=$SQS_MC_URL"
           [ -n "$REDIS_ENDPOINT" ] && COMMON_ENV="$COMMON_ENV -e REDIS_HOST=$REDIS_ENDPOINT"
+          # Channel-layer backend posture (ADR-018, #849), mirrors user_data.sh.
+          [ -n "$CHANNEL_LAYER_BACKEND" ] && COMMON_ENV="$COMMON_ENV -e CHANNEL_LAYER_BACKEND=$CHANNEL_LAYER_BACKEND"
           [ -n "$EMAIL_BACKEND" ] && COMMON_ENV="$COMMON_ENV -e EMAIL_BACKEND=$EMAIL_BACKEND"
           [ -n "$CTF_FROM_EMAIL" ] && COMMON_ENV="$COMMON_ENV -e CTF_FROM_EMAIL=$CTF_FROM_EMAIL"
           [ -n "$PLATFORM_BOOTSTRAP_STAFF_EMAILS" ] && COMMON_ENV="$COMMON_ENV -e PLATFORM_BOOTSTRAP_STAFF_EMAILS=$PLATFORM_BOOTSTRAP_STAFF_EMAILS"

--- a/changelog.d/849.changed.md
+++ b/changelog.d/849.changed.md
@@ -1,0 +1,8 @@
+**Decoupled the portal Django Channels backend from autoscaling mode.** The
+channel-layer backend is now an explicit, environment-owned posture
+(`CHANNEL_LAYER_BACKEND` / the Terraform `enable_redis` knob) instead of a side
+effect of `enable_autoscaling`: a single-instance portal can run on Redis, an
+environment can disable Redis without changing ASG posture, a `redis` posture
+fails closed when `REDIS_HOST` is missing rather than silently using the
+in-memory layer, and the active backend is logged once at startup. Defaults
+preserve current behavior (dev in-memory, prod Redis). See ADR-018.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -729,5 +729,47 @@
       "docs/dev/deploy-secrets.md",
       ".gitignore"
     ]
+  },
+  {
+    "id": "ADR-018",
+    "title": "Portal channel-layer backend is explicit and decoupled from autoscaling",
+    "status": "accepted",
+    "scope": "shifter_platform",
+    "decision": "The portal Django Channels backend is selected by an explicit, environment-owned posture, not by the compute-topology flag `enable_autoscaling` (#849). A single Terraform knob `var.enable_redis` (independent of `enable_autoscaling`, defaulting dev=false / prod=true to preserve current effective behavior) governs Redis wiring: it controls whether the `redis-endpoint` SSM parameter is written and is reflected in an always-written `channel-layer-backend` SSM parameter (`redis` or `in_memory`). The portal runtime reads one contract, `CHANNEL_LAYER_BACKEND`, resolved in shifter/shifter_platform/config/_channels.py: `redis` requires `REDIS_HOST` and fails closed (ImproperlyConfigured) when absent; `in_memory` uses InMemoryChannelLayer even if a stray `REDIS_HOST` is present; unset preserves the legacy `REDIS_HOST`-presence heuristic for local dev and pytest. The active backend is logged once per process at ASGI startup with non-secret fields only. The ElastiCache resource remains always-provisioned; `enable_redis` governs wiring, not existence. AWS Redis AUTH/TLS hardening is out of scope (the ADR-008-R6 TLS path is unchanged).",
+    "rules": [
+      {
+        "id": "ADR-018-R1",
+        "description": "Channel-layer backend selection must be driven by the explicit `CHANNEL_LAYER_BACKEND` runtime contract (environment-owned via `var.enable_redis`), and must not be derived from `enable_autoscaling`. enable_autoscaling is compute topology only.",
+        "checks": []
+      },
+      {
+        "id": "ADR-018-R2",
+        "description": "A `redis` channel-layer posture must require `REDIS_HOST` and fail closed (ImproperlyConfigured) when it is absent, never silently fall back to InMemoryChannelLayer. Enforced by shifter/shifter_platform/tests/config/test_channel_layers.py in CI.",
+        "checks": []
+      },
+      {
+        "id": "ADR-018-R3",
+        "description": "The active channel-layer backend must be observable at runtime via a single non-secret startup log record (no hostname, password, CA, or connection URL). Enforced by shifter/shifter_platform/tests/config/test_channel_layers.py in CI.",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": ["ci", "agent-policy"],
+    "evidence": [
+      "shifter/shifter_platform/config/_channels.py",
+      "shifter/shifter_platform/config/asgi.py",
+      "shifter/shifter_platform/tests/config/test_channel_layers.py",
+      "platform/terraform/modules/portal/ssm/main.tf",
+      "platform/terraform/modules/portal/ec2/user_data.sh",
+      "platform/terraform/environments/dev/portal/main.tf",
+      "platform/terraform/environments/dev/portal/variables.tf",
+      "platform/terraform/environments/dev/portal/terraform.tfvars",
+      "platform/terraform/environments/prod/portal/main.tf",
+      "platform/terraform/environments/prod/portal/variables.tf",
+      "platform/terraform/environments/prod/portal/terraform.tfvars",
+      ".github/workflows/_shifter-platform.yml",
+      "docs/architecture/portal-channel-layer-backend.md",
+      "docs/architecture/aws-portal-redis-channel-layer-preflight-849.md"
+    ]
   }
 ]

--- a/docs/architecture/aws-portal-redis-channel-layer-preflight-849.md
+++ b/docs/architecture/aws-portal-redis-channel-layer-preflight-849.md
@@ -1,0 +1,230 @@
+# AWS Portal Redis Channel-Layer Preflight (#849)
+
+Status: implemented (ADR-018). See the landed decision and operating reference
+in [`portal-channel-layer-backend.md`](portal-channel-layer-backend.md).
+
+Date: 2026-06-03
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/849>
+
+## Scope Boundary
+
+This is a requirement-free preflight. GitHub issue #849 is the shipping
+contract: remove the ambiguity where AWS ElastiCache Redis can be provisioned
+while the portal runtime silently uses Django Channels'
+`InMemoryChannelLayer`.
+
+Do not implement the issue in this note. The implementation that follows must
+reuse the existing AWS portal Terraform, SSM bootstrap, Django Channels config,
+and logging contracts rather than adding a parallel cache or websocket
+configuration concept.
+
+## Architecture Decisions
+
+- Portal compute placement and channel-layer backend are separate concerns.
+  `enable_autoscaling` chooses single EC2 versus ASG capacity. It must not be
+  the source of truth for whether Django Channels uses Redis.
+- Redis provisioning and Redis runtime wiring should be independent,
+  environment-owned knobs. A single-instance dev portal must be able to use
+  Redis when Redis is provisioned, and an environment may intentionally disable
+  Redis to save cost without changing ASG posture.
+- The runtime backend should be explicit in deployed environments. Prefer a
+  narrow channel-layer backend enum such as `in_memory` or `redis` over a
+  loosely named boolean. If the deployed backend is `redis`, startup must fail
+  closed when `REDIS_HOST` is absent rather than falling back to in-memory.
+- Preserve the local developer fallback: when no explicit deployed backend is
+  set and `REDIS_HOST` is absent, `_build_channel_layers()` may keep returning
+  `InMemoryChannelLayer` for tests and local non-container runs.
+- Make the actual backend observable from the Django process. Log a single
+  non-secret startup posture record derived from the same decision path that
+  builds `CHANNEL_LAYERS`, not from Terraform assumptions.
+- Do not use this issue to harden AWS ElastiCache auth or TLS. The current AWS
+  Redis module has documented Checkov deferrals. If a later issue enables AWS
+  Redis AUTH/TLS, follow the existing GCP Redis secret/TLS pattern instead of
+  putting auth material in SSM, Docker env literals, logs, or URLs.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #849 |
+| --- | --- | --- |
+| AWS portal environment roots | `platform/terraform/environments/{dev,prod}/portal/{main.tf,variables.tf,terraform.tfvars}` | Add environment-owned Redis provisioning and channel-layer posture inputs here; keep dev/prod consistent. |
+| Redis resource ownership | `platform/terraform/modules/portal/redis/` | Reuse the existing ElastiCache module and SG-reference ingress; do not create a second Redis module or generic cache abstraction. |
+| Runtime configuration store | `platform/terraform/modules/portal/ssm/` | Reuse the existing `redis_endpoint` plus `enable_redis` SSM-parameter guard shape. Do not write empty SSM parameters or duplicate a parameter namespace. |
+| EC2 and ASG bootstrap | `platform/terraform/modules/portal/ec2/user_data.sh` | Keep SSM read and Docker env hydration centralized here for first boot and ASG refreshes. |
+| Single-instance deploy refresh | `.github/workflows/_shifter-platform.yml` | If the SSM-deploy command learns the same Redis posture, update this path too; it mirrors user-data for in-place single-instance deploys. |
+| Channels config | `shifter/shifter_platform/config/_channels.py`, `config/settings.py` | Extend the existing pure helper and tests; do not create a second settings module, DTO, or exception hierarchy. |
+| Runtime secret hydration | `shifter/shifter_platform/entrypoint.sh` | Secret values belong in Secrets Manager hydration, not in SSM String parameters or Docker command env literals. Endpoint-only AWS Redis config may remain non-secret. |
+| Logging | `config.logging.ECSFormatter`, `config._logging_config`, `shared.log_sanitize.safe_log_value()` | Emit ECS JSON logs with backend, host-present, port, and TLS booleans only. Do not log full Redis URLs, AUTH tokens, or raw secret payloads. |
+| Local development | `shifter/shifter_platform/docker-compose.yml`, `tests/config/test_channel_layers.py` | Preserve compose Redis and pytest in-memory behavior unless an explicit backend env requests Redis. |
+| GCP Redis precedent | `docs/architecture/gcp-redis-auth-tls-preflight.md`, ADR-008-R6 | Reuse the public-config / secret-value / policy-posture split if AWS Redis security posture expands later. |
+| Enforcement | `scripts/adr_guard/adr_guard.py`, `.importlinter`, `.tflint.hcl`, `actionlint` | Run the checker for every touched surface; do not weaken guardrails to make the topology switch easier. |
+
+## Cross-Cutting Layers The Design Must Pass
+
+- Auth surface: websocket requests still flow through `config/asgi.py`,
+  `AllowedHostsOriginValidator`, `AuthMiddlewareStack`, and the existing
+  consumer/service authorization paths. Redis channel-layer selection is an
+  internal fanout backend, not a new user auth boundary or public websocket
+  route.
+- Secret-handling surface: current AWS Redis endpoint and port are non-secret
+  configuration and may flow through SSM String parameters and container env.
+  Redis passwords, auth tokens, or full `redis://` / `rediss://` URLs are
+  secret-bearing. If introduced later, pass only a secret reference through
+  SSM/env and hydrate the value in `entrypoint.sh`, matching DB/app/GCP Redis
+  patterns.
+- Env-binding shape: `REDIS_HOST`, `REDIS_PORT`, `REDIS_TLS`,
+  `REDIS_SECRET_ID`, `REDIS_PASSWORD`, and `REDIS_CA_PEM` already define the
+  channel-layer config surface. A new explicit deployed-backend knob belongs at
+  this same `_build_channel_layers(env)` seam and must not conflict with
+  `REDIS_HOST` presence. The deployed `redis` backend should require
+  `REDIS_HOST`; the deployed `in_memory` backend should not accidentally carry
+  `REDIS_HOST`.
+- Terraform validation surface: module variables and environment roots should
+  reject impossible postures at validate/plan time. At minimum, a Redis runtime
+  backend must imply a provisioned endpoint, and disabled Redis provisioning
+  must not create a non-empty `redis-endpoint` SSM parameter by accident.
+- SSM/bootstrap surface: `modules/portal/ssm` owns Parameter Store names and
+  `modules/portal/ec2/user_data.sh` owns first-boot Docker env construction.
+  The single-instance GitHub Actions SSM deploy block mirrors that env
+  construction. Both paths must derive `REDIS_HOST` from the same posture
+  contract.
+- OS/process exposure: the current Docker `-e REDIS_HOST=...` exposure is
+  acceptable only because the endpoint is not a secret. Do not put future Redis
+  passwords, AUTH tokens, CA payloads, or full URLs into Docker argv, cloud-init
+  logs, generated env files, Terraform comments, or workflow logs.
+- Application config surface: `config._channels._build_channel_layers()` is the
+  authoritative parser and validator for Channels backend posture. Use
+  `django.core.exceptions.ImproperlyConfigured` for invalid runtime config,
+  matching the existing TLS/password/CA fail-closed behavior.
+- Error-envelope surface: this is startup and infrastructure configuration.
+  Failures should surface as Terraform validation errors, SSM/bootstrap
+  failures, or Django `ImproperlyConfigured` startup failures. Do not add
+  browser-facing websocket error payloads or a new application exception tree
+  for this topology ambiguity.
+- Logging/observability surface: log the active backend once per Django process
+  startup with non-secret posture fields. Useful fields are backend
+  (`redis`/`in_memory`), explicit-backend-present, redis-host-present,
+  redis-port, redis-tls-enabled, and provider/runtime environment. Avoid the
+  raw hostname unless an implementation explicitly accepts internal topology
+  disclosure.
+- Persistence surface: Redis channel-layer selection should not create a
+  database model, migration, repository, or durable audit schema. The posture is
+  deploy-time config plus startup observability.
+
+## Whole-Repo View
+
+In-scope repository surfaces for the implementation are:
+
+- `platform/terraform/environments/dev/portal/` and
+  `platform/terraform/environments/prod/portal/`
+- `platform/terraform/modules/portal/redis/`
+- `platform/terraform/modules/portal/ssm/`
+- `platform/terraform/modules/portal/ec2/`
+- `.github/workflows/_shifter-platform.yml` if single-instance SSM deploy env
+  rendering changes
+- `shifter/shifter_platform/config/_channels.py` and `config/settings.py`
+- `shifter/shifter_platform/entrypoint.sh` only if Redis secrets or TLS are
+  introduced
+- `shifter/shifter_platform/tests/config/test_channel_layers.py`
+- `shifter/shifter_platform/docker-compose.yml` for local Redis behavior
+- `docs/architecture/gcp-redis-auth-tls-preflight.md` and ADR-008-R6 as the
+  security-posture precedent, not as a mandate to change AWS Redis security in
+  this issue
+
+## Extensibility Seam
+
+The durable seam is a small channel-layer runtime posture contract:
+
+- resource posture: whether AWS Redis is provisioned
+- runtime backend: `in_memory` or `redis`
+- endpoint binding: host and port when the runtime backend is `redis`
+- security posture: plaintext private-network Redis today, optional AUTH/TLS
+  via the existing secret hydration pattern in a future issue
+
+Keep that seam environment-owned and provider-specific at the Terraform edge,
+then map it into the existing Django env contract. The next likely variation is
+single-instance dev using Redis for event-like websocket behavior, or an
+environment disabling Redis entirely for cost. Neither variation should require
+rewriting Django consumers, websocket routes, worker queue logic, or the Redis
+module.
+
+## Gotchas And Anti-Patterns
+
+- Do not keep deriving `redis_endpoint` or the SSM `enable_redis` guard from
+  `enable_autoscaling`. That is the ambiguity this issue exists to remove.
+- Do not create Redis only to leave the portal using in-memory Channels without
+  an explicit, logged posture. Provisioned-but-unused Redis can be a deliberate
+  maintenance state, but it must not be silent.
+- Do not add both `USE_REDIS`, `ENABLE_REDIS`, and backend string settings.
+  Pick one explicit runtime posture contract and let `_build_channel_layers()`
+  enforce it.
+- Do not let a deployed `redis` backend silently degrade to in-memory when the
+  SSM parameter is missing, deleted, empty, or not read by user-data.
+- Do not treat Redis channel-layer usage as a websocket correctness fix for
+  terminal byte streaming. Issue #847 keeps terminal bytes out of Redis.
+- Do not copy the GCP `REDIS_SECRET_ID`/TLS path into AWS unless the AWS Redis
+  module actually introduces auth/TLS. Endpoint-only AWS plaintext Redis does
+  not need secret hydration.
+- Do not broaden Redis security-group ingress to compensate for wiring
+  complexity. Keep the existing preferred SG-reference pattern.
+- Do not log full Redis URLs. A passwordless endpoint is still internal
+  topology and a future authenticated URL would be secret-bearing.
+- Do not make Terraform outputs, committed tfvars, or workflow variables the
+  only source of observability. The running Django process must report the
+  backend it actually selected.
+
+## Non-Goals
+
+- No change to Django websocket routing, consumer authorization, CTF domain
+  models, worker queue semantics, SQS messaging, database schemas, repositories,
+  or service DTOs.
+- No AWS ElastiCache AUTH/TLS/encryption hardening in this issue unless a
+  separate scoped change accepts the migration and secret-handling work.
+- No GCP Redis, Kubernetes, Helm, Docker Compose, or local pytest behavior
+  redesign beyond preserving compatibility with the explicit backend contract.
+- No new deployment component, Redis proxy, terminal gateway, cache abstraction,
+  exception hierarchy, or persistent runtime-posture table.
+
+## Validation Expectations
+
+Run the repo-required checks for touched surfaces:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+```
+
+If the implementation touches Terraform, also run:
+
+```bash
+cd platform/terraform && tflint --recursive --config ../../.tflint.hcl
+```
+
+If it touches the GitHub Actions single-instance deploy path, run:
+
+```bash
+actionlint
+```
+
+If it touches Django config or import boundaries, run:
+
+```bash
+cd shifter/shifter_platform && uv run lint-imports --config ../../.importlinter
+cd shifter/shifter_platform && uv run pytest tests/config/test_channel_layers.py
+```
+
+## Implementation Work Linkage
+
+Landed in one PR for #849 (ADR-018), keeping both ownership slices coherent:
+
+- Terraform posture + wiring: a portal-root `enable_redis` knob (independent of
+  `enable_autoscaling`, dev=false / prod=true) drives the `redis-endpoint` SSM
+  parameter, the always-written `channel-layer-backend` SSM parameter, the EC2
+  `user_data.sh` container env, and the `_shifter-platform.yml` single-instance
+  deploy seam.
+- Django validation + observability: `config/_channels.py` resolves the explicit
+  `CHANNEL_LAYER_BACKEND` contract (fail-closed `redis`, forced `in_memory`,
+  legacy-heuristic when unset), and `config/asgi.py` logs the active backend once
+  at startup via `log_channel_layer_posture`.
+
+The durable decision and operating guide is
+[`portal-channel-layer-backend.md`](portal-channel-layer-backend.md).

--- a/docs/architecture/portal-channel-layer-backend.md
+++ b/docs/architecture/portal-channel-layer-backend.md
@@ -1,0 +1,92 @@
+# Portal Channel-Layer Backend Posture
+
+Status: accepted (ADR-018)
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/849>
+
+## Decision
+
+The portal's Django Channels backend is selected by an **explicit, environment-owned
+posture**, decoupled from the portal autoscaling topology.
+
+- `enable_autoscaling` is **compute topology only** (single EC2 vs. Auto Scaling
+  Group). It does not decide whether Django Channels uses Redis.
+- A single Terraform knob, `enable_redis`, owns Redis wiring per environment. It is
+  independent of `enable_autoscaling`: a single-instance dev portal may use Redis,
+  and an environment may disable Redis to save cost without changing ASG posture.
+- The Django runtime reads one contract, `CHANNEL_LAYER_BACKEND` ∈ {`in_memory`,
+  `redis`}. A `redis` posture **requires** `REDIS_HOST` and **fails closed**
+  (`ImproperlyConfigured`) when it is absent, instead of silently degrading to the
+  in-memory layer.
+
+The Redis ElastiCache resource is always provisioned by the portal Terraform; the
+`enable_redis` knob governs whether it is *wired into the runtime*, not whether it
+exists. A provisioned-but-unused Redis is a legitimate (cost) posture — but it must
+not be silent.
+
+## Why
+
+Previously the Redis endpoint reached the portal only when `enable_autoscaling` was
+true: the endpoint was written to SSM and injected as `REDIS_HOST` only in ASG mode,
+and Django fell back to `InMemoryChannelLayer` whenever `REDIS_HOST` was absent. In
+toned-down dev (`enable_autoscaling = false`) the portal therefore ran on the
+in-memory channel layer even though Redis was provisioned, and the websocket fan-out
+behavior was not representative of an event-shaped deployment. Toggling ASG silently
+changed the channel-layer backend. See `aws-portal-redis-channel-layer-preflight-849.md`.
+
+## Contract
+
+| Layer | Knob | Values | Default (dev / prod) |
+| --- | --- | --- | --- |
+| Terraform (environment-owned) | `var.enable_redis` | `true` / `false` | `false` / `true` |
+| SSM parameter | `<prefix>/channel-layer-backend` | `redis` / `in_memory` (always written) | derived from `enable_redis` |
+| SSM parameter | `<prefix>/redis-endpoint` | endpoint (written only when `enable_redis`) | — |
+| Container env | `CHANNEL_LAYER_BACKEND` | `redis` / `in_memory` | from SSM |
+| Container env | `REDIS_HOST` | endpoint (set only when present) | from SSM |
+
+Runtime resolution lives in `shifter/shifter_platform/config/_channels.py`
+(`_resolve_backend`):
+
+- `CHANNEL_LAYER_BACKEND=redis` → Redis layer; missing `REDIS_HOST` fails closed.
+- `CHANNEL_LAYER_BACKEND=in_memory` → in-memory layer, even if a stray `REDIS_HOST`
+  is present (the drift is reported by the startup posture log, not acted on).
+- unset → legacy `REDIS_HOST`-presence heuristic, preserved for local dev / pytest.
+
+The `channel-layer-backend` SSM parameter is written with a non-empty value
+regardless of `enable_redis`, and independently of whether the `redis-endpoint`
+write succeeded. That independence is what makes the fail-closed meaningful: a
+`redis` posture whose endpoint never arrived stops the portal at startup rather
+than letting it serve on a silent in-memory layer.
+
+Defaults preserve current effective behavior — dev stays in-memory, prod stays on
+Redis — but the choice is now explicit, observable, and decoupled from ASG.
+
+## Observability
+
+The portal logs its active channel-layer backend once per process at ASGI startup
+(`config/asgi.py` → `log_channel_layer_posture`). The record is non-secret: it
+carries `backend`, `explicit_backend`, `redis_host_present`, `redis_port`, and
+`redis_tls`, but never the hostname, password, CA, or a connection URL.
+
+```text
+channel-layer posture: backend=redis explicit_backend=redis redis_host_present=True redis_port=6379 redis_tls=False
+```
+
+## Operating
+
+- **Run dev on Redis** (event-representative websocket behavior): set
+  `enable_redis = true` in `platform/terraform/environments/dev/portal/terraform.tfvars`
+  and apply. No change to `enable_autoscaling` is needed.
+- **Disable Redis in an environment** to save cost: set `enable_redis = false`. The
+  portal runs `CHANNEL_LAYER_BACKEND=in_memory`; the ElastiCache resource remains
+  provisioned (its lifecycle is separate) but is not wired into the runtime.
+- **Confirm the running posture**: read the portal startup log (ECS JSON) for the
+  `channel-layer posture` line.
+
+## Out of scope
+
+AWS ElastiCache AUTH/TLS hardening is not part of this contract. The TLS path
+(`REDIS_TLS` / `REDIS_PASSWORD` / `REDIS_CA_PEM`, ADR-008-R6) is unchanged; if AWS
+Redis later needs auth/TLS, follow the GCP Memorystore secret-hydration precedent in
+`gcp-redis-auth-tls-preflight.md` rather than putting auth material in SSM, Docker
+env literals, logs, or URLs.

--- a/platform/terraform/environments/dev/portal/main.tf
+++ b/platform/terraform/environments/dev/portal/main.tf
@@ -428,8 +428,9 @@ module "ssm" {
   sqs_cms_url    = module.messaging.sqs_queue_urls["cms"]
   sqs_engine_url = module.messaging.sqs_queue_urls["engine"]
   sqs_mc_url     = module.messaging.sqs_queue_urls["mc"]
-  redis_endpoint = var.enable_autoscaling ? module.redis.redis_endpoint : ""
-  enable_redis   = var.enable_autoscaling
+  # Redis wiring is environment-owned and decoupled from autoscaling (ADR-018, #849).
+  redis_endpoint = var.enable_redis ? module.redis.redis_endpoint : ""
+  enable_redis   = var.enable_redis
 
   # Database endpoint (direct RDS connection - hostname only, not endpoint with port)
   db_host_override        = module.rds.db_instance_address
@@ -484,7 +485,7 @@ module "ec2" {
   asg_min_size         = var.asg_min_size
   asg_max_size         = var.asg_max_size
   asg_desired_capacity = var.asg_desired_capacity
-  redis_endpoint       = var.enable_autoscaling ? module.redis.redis_endpoint : ""
+  redis_endpoint       = var.enable_redis ? module.redis.redis_endpoint : ""
   scale_up_threshold   = var.scale_up_threshold
   scale_down_threshold = var.scale_down_threshold
   log_retention_days   = var.log_retention_days

--- a/platform/terraform/environments/dev/portal/terraform.tfvars
+++ b/platform/terraform/environments/dev/portal/terraform.tfvars
@@ -122,6 +122,12 @@ asg_desired_capacity = 1
 scale_up_threshold   = 70
 scale_down_threshold = 30
 
+# Channel-layer backend (ADR-018, #849), decoupled from autoscaling above.
+# Dev keeps the in-memory channel layer (Redis provisioned but unused). Flip to
+# true to run the portal on Redis for event-representative websocket behavior;
+# no change to enable_autoscaling is required.
+enable_redis = false
+
 # ------------------------------------------------------------------------------
 # Redis
 # ------------------------------------------------------------------------------

--- a/platform/terraform/environments/dev/portal/variables.tf
+++ b/platform/terraform/environments/dev/portal/variables.tf
@@ -265,6 +265,19 @@ variable "enable_autoscaling" {
   type        = bool
 }
 
+variable "enable_redis" {
+  description = <<-EOT
+    Wire Redis as the Django Channels backend for the portal runtime
+    (ADR-018, #849). Environment-owned and INDEPENDENT of enable_autoscaling:
+    a single-instance dev portal may use Redis, and an environment may disable
+    Redis to save cost without changing ASG posture. When true, the Redis
+    endpoint is published to SSM and the container runs with
+    CHANNEL_LAYER_BACKEND=redis (fail-closed if the endpoint is missing); when
+    false, the portal runs CHANNEL_LAYER_BACKEND=in_memory.
+  EOT
+  type        = bool
+}
+
 variable "asg_min_size" {
   description = "Minimum number of instances in the ASG"
   type        = number

--- a/platform/terraform/environments/prod/portal/main.tf
+++ b/platform/terraform/environments/prod/portal/main.tf
@@ -423,8 +423,9 @@ module "ssm" {
   sqs_cms_url    = module.messaging.sqs_queue_urls["cms"]
   sqs_engine_url = module.messaging.sqs_queue_urls["engine"]
   sqs_mc_url     = module.messaging.sqs_queue_urls["mc"]
-  redis_endpoint = var.enable_autoscaling ? module.redis.redis_endpoint : ""
-  enable_redis   = var.enable_autoscaling
+  # Redis wiring is environment-owned and decoupled from autoscaling (ADR-018, #849).
+  redis_endpoint = var.enable_redis ? module.redis.redis_endpoint : ""
+  enable_redis   = var.enable_redis
 
   # Database endpoint (direct RDS connection - hostname only, not endpoint with port)
   db_host_override        = module.rds.db_instance_address
@@ -479,7 +480,7 @@ module "ec2" {
   asg_min_size         = var.asg_min_size
   asg_max_size         = var.asg_max_size
   asg_desired_capacity = var.asg_desired_capacity
-  redis_endpoint       = var.enable_autoscaling ? module.redis.redis_endpoint : ""
+  redis_endpoint       = var.enable_redis ? module.redis.redis_endpoint : ""
   scale_up_threshold   = var.scale_up_threshold
   scale_down_threshold = var.scale_down_threshold
   log_retention_days   = var.log_retention_days

--- a/platform/terraform/environments/prod/portal/terraform.tfvars
+++ b/platform/terraform/environments/prod/portal/terraform.tfvars
@@ -99,6 +99,10 @@ asg_desired_capacity = 2
 scale_up_threshold   = 70
 scale_down_threshold = 30
 
+# Channel-layer backend (ADR-018, #849), decoupled from autoscaling above.
+# Prod runs the portal on Redis (CHANNEL_LAYER_BACKEND=redis), as before.
+enable_redis = true
+
 # ------------------------------------------------------------------------------
 # Redis
 # ------------------------------------------------------------------------------

--- a/platform/terraform/environments/prod/portal/variables.tf
+++ b/platform/terraform/environments/prod/portal/variables.tf
@@ -193,6 +193,19 @@ variable "enable_autoscaling" {
   type        = bool
 }
 
+variable "enable_redis" {
+  description = <<-EOT
+    Wire Redis as the Django Channels backend for the portal runtime
+    (ADR-018, #849). Environment-owned and INDEPENDENT of enable_autoscaling:
+    a single-instance dev portal may use Redis, and an environment may disable
+    Redis to save cost without changing ASG posture. When true, the Redis
+    endpoint is published to SSM and the container runs with
+    CHANNEL_LAYER_BACKEND=redis (fail-closed if the endpoint is missing); when
+    false, the portal runs CHANNEL_LAYER_BACKEND=in_memory.
+  EOT
+  type        = bool
+}
+
 variable "asg_min_size" {
   description = "Minimum number of instances in the ASG"
   type        = number

--- a/platform/terraform/modules/portal/ec2/user_data.sh
+++ b/platform/terraform/modules/portal/ec2/user_data.sh
@@ -141,6 +141,7 @@ SQS_CMS_URL=$(get_param "$PS_PREFIX/sqs-cms-url")
 SQS_ENGINE_URL=$(get_param "$PS_PREFIX/sqs-engine-url")
 SQS_MC_URL=$(get_param "$PS_PREFIX/sqs-mc-url")
 REDIS_ENDPOINT=$(get_param "$PS_PREFIX/redis-endpoint" || echo "")
+CHANNEL_LAYER_BACKEND=$(get_param "$PS_PREFIX/channel-layer-backend" 2>/dev/null || echo "")
 GUACAMOLE_SECRET_ARN=$(get_param "$PS_PREFIX/guacamole-secret-arn" 2>/dev/null || echo "")
 DC_DOMAIN_PASSWORD_SECRET_ARN=$(get_param "$PS_PREFIX/dc-domain-password-secret-arn" 2>/dev/null || echo "")
 GUACAMOLE_BASE_URL=$(get_param "$PS_PREFIX/guacamole-base-url" 2>/dev/null || echo "")
@@ -179,6 +180,13 @@ COMMON_ENV="$COMMON_ENV -e SQS_MC_URL=$SQS_MC_URL"
 # Add Redis if configured
 if [[ -n "$REDIS_ENDPOINT" ]]; then
   COMMON_ENV="$COMMON_ENV -e REDIS_HOST=$REDIS_ENDPOINT"
+fi
+
+# Channel-layer backend posture (ADR-018, #849), decoupled from autoscaling.
+# When unset (pre-ADR-018 environments) Django falls back to the
+# REDIS_HOST-presence heuristic; when "redis" it fails closed without REDIS_HOST.
+if [[ -n "$CHANNEL_LAYER_BACKEND" ]]; then
+  COMMON_ENV="$COMMON_ENV -e CHANNEL_LAYER_BACKEND=$CHANNEL_LAYER_BACKEND"
 fi
 
 # Add Guacamole config if configured (for RDP integration)

--- a/platform/terraform/modules/portal/ssm/main.tf
+++ b/platform/terraform/modules/portal/ssm/main.tf
@@ -207,6 +207,20 @@ resource "aws_ssm_parameter" "redis_endpoint" {
   tags = local.common_tags
 }
 
+# Explicit channel-layer backend posture (ADR-018, #849). Always written with a
+# non-empty value so the runtime is unambiguous and independent of whether the
+# redis-endpoint write succeeded: a "redis" posture without a reachable endpoint
+# makes Django fail closed at startup instead of silently using in-memory.
+# Decoupled from enable_autoscaling — this is wiring posture, not compute topology.
+resource "aws_ssm_parameter" "channel_layer_backend" {
+  name        = "${local.ps_prefix}/channel-layer-backend"
+  description = "Django Channels backend posture (redis | in_memory)"
+  type        = "String"
+  value       = var.enable_redis ? "redis" : "in_memory"
+
+  tags = local.common_tags
+}
+
 resource "aws_ssm_parameter" "db_host_override" {
   count = var.enable_db_host_override ? 1 : 0
 

--- a/shifter/shifter_platform/config/_channels.py
+++ b/shifter/shifter_platform/config/_channels.py
@@ -5,40 +5,88 @@ Extracted from ``config/settings.py`` to keep that module under the
 imported by ``config.settings`` to populate the ``CHANNEL_LAYERS``
 setting.
 
-Three runtime postures, in order of preference, derived from the env:
-    1. REDIS_HOST empty       -> InMemoryChannelLayer (local dev,
-                                 pytest runs without a Redis dependency).
-    2. REDIS_HOST set, no TLS -> channels_redis tuple host form (plaintext
-                                 Redis on a private network — the AWS and
-                                 pre-#963 GCP shape).
-    3. REDIS_HOST + REDIS_TLS -> rediss://<password>@host:port/0 URL host.
+Backend selection (ADR-018, #849) is an explicit, environment-owned
+posture, decoupled from the portal ``enable_autoscaling`` topology:
+
+    CHANNEL_LAYER_BACKEND=redis     -> Redis channel layer; REDIS_HOST is
+                                       REQUIRED. Missing host fails closed
+                                       (ImproperlyConfigured) rather than
+                                       silently degrading to in-memory.
+    CHANNEL_LAYER_BACKEND=in_memory -> InMemoryChannelLayer, even if a stray
+                                       REDIS_HOST is present. The drift stays
+                                       observable via the startup posture log.
+    CHANNEL_LAYER_BACKEND unset     -> legacy REDIS_HOST-presence heuristic
+                                       (local dev, pytest): host present ->
+                                       Redis, absent -> InMemoryChannelLayer.
+
+Once the backend resolves to Redis, the connection posture is derived from
+the env, in order of preference:
+    1. REDIS_HOST, no TLS -> channels_redis tuple host form (plaintext Redis
+                             on a private network — the AWS and pre-#963 GCP
+                             shape).
+    2. REDIS_HOST + REDIS_TLS -> rediss://<password>@host:port/0 URL host.
                                  REDIS_PASSWORD is hydrated by entrypoint.sh
                                  from Secret Manager (ADR-008-R6).
 
-Fail closed when the TLS flag is on but no password was hydrated — silent
-fallback to plaintext is the failure mode #963 was opened to close.
+Fail closed when the TLS flag is on but no password / CA was hydrated —
+silent fallback to plaintext is the failure mode #963 was opened to close.
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
+
+from shared.log_sanitize import safe_log_value
 
 __all__ = ["_build_channel_layers"]
 
+_logger = logging.getLogger(__name__)
 
-def _build_channel_layers(env: Mapping[str, str]) -> dict[str, dict[str, object]]:
-    """Build CHANNEL_LAYERS from the given mapping (typically os.environ).
+_IN_MEMORY = "in_memory"
+_REDIS = "redis"
+_VALID_BACKENDS = (_IN_MEMORY, _REDIS)
 
-    Pure function so it is unit-testable without touching real settings.
+
+def _resolve_backend(env: Mapping[str, str]) -> str:
+    """Resolve the channel-layer backend (``in_memory`` or ``redis``).
+
+    The explicit ``CHANNEL_LAYER_BACKEND`` posture wins; it is independent of
+    the portal ``enable_autoscaling`` topology (ADR-018). A ``redis`` posture
+    requires ``REDIS_HOST`` and fails closed when it is absent. When the knob
+    is unset (local dev / pytest), the legacy ``REDIS_HOST``-presence
+    heuristic decides so those environments need no opt-in.
+    """
+    from django.core.exceptions import ImproperlyConfigured
+
+    backend = env.get("CHANNEL_LAYER_BACKEND", "").strip().lower()
+    host = env.get("REDIS_HOST", "").strip()
+
+    if backend == _REDIS:
+        if not host:
+            raise ImproperlyConfigured(
+                "CHANNEL_LAYER_BACKEND=redis requires REDIS_HOST; refusing to "
+                "fall back to InMemoryChannelLayer (the silent-degradation "
+                "failure mode #849 was opened to close)"
+            )
+        return _REDIS
+    if backend == _IN_MEMORY:
+        return _IN_MEMORY
+    if backend:
+        raise ImproperlyConfigured(f"CHANNEL_LAYER_BACKEND must be one of {_VALID_BACKENDS}, got {backend!r}")
+
+    # Unset: preserve the pre-#849 host-presence heuristic.
+    return _REDIS if host else _IN_MEMORY
+
+
+def _build_redis_layer(env: Mapping[str, str]) -> dict[str, dict[str, object]]:
+    """Build the ``channels_redis`` layer config from the env.
+
+    The caller guarantees ``REDIS_HOST`` is present (via ``_resolve_backend``).
     """
     from django.core.exceptions import ImproperlyConfigured
 
     host = env.get("REDIS_HOST", "").strip()
-    if not host:
-        return {
-            "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"},
-        }
-
     port = int(env.get("REDIS_PORT", "6379"))
     tls = env.get("REDIS_TLS", "").strip().lower() == "true"
     if tls:
@@ -96,3 +144,53 @@ def _build_channel_layers(env: Mapping[str, str]) -> dict[str, dict[str, object]
             "CONFIG": {"hosts": hosts},
         },
     }
+
+
+def _build_channel_layers(env: Mapping[str, str]) -> dict[str, dict[str, object]]:
+    """Build CHANNEL_LAYERS from the given mapping (typically os.environ).
+
+    Pure function so it is unit-testable without touching real settings.
+    """
+    if _resolve_backend(env) == _IN_MEMORY:
+        return {
+            "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"},
+        }
+    return _build_redis_layer(env)
+
+
+def describe_channel_layer_posture(env: Mapping[str, str]) -> dict[str, object]:
+    """Return the non-secret channel-layer posture for startup observability.
+
+    Reports the resolved backend plus the inputs that decided it, so a
+    provisioned-but-unused Redis (an ``in_memory`` backend with a present
+    ``REDIS_HOST``) is visible rather than silent. Carries no secret or
+    topology-disclosing values — host/password/CA are never included, only
+    booleans and the (non-secret) port.
+    """
+    raw_backend = env.get("CHANNEL_LAYER_BACKEND", "").strip()
+    host = env.get("REDIS_HOST", "").strip()
+    return {
+        "backend": _resolve_backend(env),
+        "explicit_backend": raw_backend or None,
+        "redis_host_present": bool(host),
+        "redis_port": int(env.get("REDIS_PORT", "6379")) if host else None,
+        "redis_tls": env.get("REDIS_TLS", "").strip().lower() == "true",
+    }
+
+
+def log_channel_layer_posture(env: Mapping[str, str], *, logger: logging.Logger | None = None) -> None:
+    """Emit a single non-secret startup record of the active channel-layer
+    backend (#849 AC2). Derives from the same decision path that builds
+    ``CHANNEL_LAYERS`` so the log reflects the backend actually selected, not
+    a Terraform assumption. Call once per process (see ``config/asgi.py``).
+    """
+    log = logger or _logger
+    posture = describe_channel_layer_posture(env)
+    log.info(
+        "channel-layer posture: backend=%s explicit_backend=%s redis_host_present=%s redis_port=%s redis_tls=%s",
+        safe_log_value(posture["backend"]),
+        safe_log_value(posture["explicit_backend"]),
+        posture["redis_host_present"],
+        posture["redis_port"],
+        posture["redis_tls"],
+    )

--- a/shifter/shifter_platform/config/asgi.py
+++ b/shifter/shifter_platform/config/asgi.py
@@ -26,6 +26,14 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 # Initialize Django ASGI application early to ensure AppRegistry is populated
 django_asgi_app = get_asgi_application()
 
+# Log the active channel-layer backend once per portal process (#849). This is
+# the single ASGI process that serves both HTTP and WebSocket and consumes
+# CHANNEL_LAYERS; logging is configured by get_asgi_application() above. An
+# invalid/redis-without-host posture already fails closed at settings import.
+from config._channels import log_channel_layer_posture  # noqa: E402
+
+log_channel_layer_posture(os.environ)
+
 # Import routing after Django setup
 from cms.experiments.routing import websocket_urlpatterns as experiment_ws_urlpatterns  # noqa: E402
 from mission_control.routing import websocket_urlpatterns  # noqa: E402

--- a/shifter/shifter_platform/tests/config/test_channel_layers.py
+++ b/shifter/shifter_platform/tests/config/test_channel_layers.py
@@ -3,13 +3,24 @@
 Covers the Redis AUTH/TLS contract from ADR-008-R6 (#963): the helper picks
 the right backend for local dev, plaintext-Redis, and TLS-with-password
 postures, and fails closed when TLS is enabled without a password.
+
+Also covers the explicit channel-layer backend posture from ADR-018 (#849):
+``CHANNEL_LAYER_BACKEND`` selects the backend independently of the portal
+``enable_autoscaling`` topology, fails closed when ``redis`` is requested
+without ``REDIS_HOST``, and exposes a non-secret startup posture for logging.
 """
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
+from config._channels import (
+    describe_channel_layer_posture,
+    log_channel_layer_posture,
+)
 from config.settings import _build_channel_layers
 
 
@@ -199,3 +210,172 @@ def test_tls_flag_anything_else_is_disabled(tls_value):
     )
 
     assert layers["default"]["CONFIG"]["hosts"] == [("10.0.0.20", 6379)]
+
+
+# ---------------------------------------------------------------------------
+# Explicit channel-layer backend posture (ADR-018, #849)
+#
+# CHANNEL_LAYER_BACKEND decouples the runtime backend from the portal
+# enable_autoscaling topology. A deployed `redis` posture fails closed when
+# REDIS_HOST is absent instead of silently degrading to InMemoryChannelLayer.
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_redis_backend_builds_redis_layer():
+    """CHANNEL_LAYER_BACKEND=redis with REDIS_HOST set builds the Redis layer
+    (same tuple form as the host-presence heuristic)."""
+    layers = _build_channel_layers(
+        {
+            "CHANNEL_LAYER_BACKEND": "redis",
+            "REDIS_HOST": "10.0.0.20",
+            "REDIS_PORT": "6379",
+        }
+    )
+
+    assert layers == {
+        "default": {
+            "BACKEND": "channels_redis.core.RedisChannelLayer",
+            "CONFIG": {"hosts": [("10.0.0.20", 6379)]},
+        },
+    }
+
+
+def test_explicit_redis_backend_fails_closed_without_host():
+    """The failure mode #849 exists to close: a deployed `redis` posture with
+    no REDIS_HOST must raise, never fall back to InMemoryChannelLayer."""
+    with pytest.raises(ImproperlyConfigured, match="REDIS_HOST"):
+        _build_channel_layers({"CHANNEL_LAYER_BACKEND": "redis"})
+
+
+def test_explicit_redis_backend_fails_closed_with_blank_host():
+    """Blank REDIS_HOST is the same failure mode as missing."""
+    with pytest.raises(ImproperlyConfigured, match="REDIS_HOST"):
+        _build_channel_layers({"CHANNEL_LAYER_BACKEND": "redis", "REDIS_HOST": "  "})
+
+
+def test_explicit_in_memory_backend_ignores_present_redis_host():
+    """CHANNEL_LAYER_BACKEND=in_memory forces the in-memory layer even when a
+    stray REDIS_HOST is present (deliberate cost-saving / non-event posture).
+    The drift stays observable via the startup posture, not via behavior."""
+    layers = _build_channel_layers(
+        {
+            "CHANNEL_LAYER_BACKEND": "in_memory",
+            "REDIS_HOST": "10.0.0.20",
+        }
+    )
+
+    assert layers == {
+        "default": {"BACKEND": "channels.layers.InMemoryChannelLayer"},
+    }
+
+
+@pytest.mark.parametrize("backend_value", ["REDIS", "Redis", "in_memory", "IN_MEMORY", "In_Memory"])
+def test_backend_value_is_case_insensitive(backend_value):
+    """CHANNEL_LAYER_BACKEND parsing matches the rest of the env contract:
+    case-insensitive, surrounding whitespace stripped."""
+    layers = _build_channel_layers(
+        {
+            "CHANNEL_LAYER_BACKEND": f"  {backend_value}  ",
+            "REDIS_HOST": "10.0.0.20",
+        }
+    )
+
+    if backend_value.lower() == "redis":
+        assert layers["default"]["BACKEND"] == "channels_redis.core.RedisChannelLayer"
+    else:
+        assert layers["default"]["BACKEND"] == "channels.layers.InMemoryChannelLayer"
+
+
+def test_unknown_backend_value_fails_closed():
+    """An unrecognised CHANNEL_LAYER_BACKEND is a configuration error, not a
+    silent fall-through to a default backend."""
+    with pytest.raises(ImproperlyConfigured, match="CHANNEL_LAYER_BACKEND"):
+        _build_channel_layers({"CHANNEL_LAYER_BACKEND": "memcached", "REDIS_HOST": "10.0.0.20"})
+
+
+def test_unset_backend_preserves_host_presence_heuristic():
+    """When CHANNEL_LAYER_BACKEND is unset (local dev / pytest), the legacy
+    REDIS_HOST-presence heuristic still decides — no behavior change for
+    environments that do not opt into the explicit posture."""
+    assert _build_channel_layers({})["default"]["BACKEND"] == "channels.layers.InMemoryChannelLayer"
+    assert (
+        _build_channel_layers({"REDIS_HOST": "10.0.0.20"})["default"]["BACKEND"]
+        == "channels_redis.core.RedisChannelLayer"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Startup posture observability (#849 AC2)
+# ---------------------------------------------------------------------------
+
+
+def test_describe_posture_reports_explicit_redis_fields():
+    posture = describe_channel_layer_posture(
+        {
+            "CHANNEL_LAYER_BACKEND": "redis",
+            "REDIS_HOST": "10.0.0.20",
+            "REDIS_PORT": "6380",
+            "REDIS_TLS": "true",
+        }
+    )
+
+    assert posture == {
+        "backend": "redis",
+        "explicit_backend": "redis",
+        "redis_host_present": True,
+        "redis_port": 6380,
+        "redis_tls": True,
+    }
+
+
+def test_describe_posture_reports_unset_in_memory_fields():
+    posture = describe_channel_layer_posture({})
+
+    assert posture == {
+        "backend": "in_memory",
+        "explicit_backend": None,
+        "redis_host_present": False,
+        "redis_port": None,
+        "redis_tls": False,
+    }
+
+
+def test_describe_posture_surfaces_in_memory_over_present_host_drift():
+    """in_memory backend with a present REDIS_HOST is the deliberate-but-must-
+    not-be-silent case: the posture reports both so the drift is visible."""
+    posture = describe_channel_layer_posture({"CHANNEL_LAYER_BACKEND": "in_memory", "REDIS_HOST": "10.0.0.20"})
+
+    assert posture["backend"] == "in_memory"
+    assert posture["redis_host_present"] is True
+
+
+def test_log_posture_emits_single_non_secret_record(caplog):
+    """The startup posture log makes the active backend observable in deployed
+    environments without leaking the password, CA, or even the hostname.
+
+    A propagating test logger is injected because the production ``config``
+    logger sets ``propagate: False`` (see ``config/_logging_config.py``), which
+    pytest's root-attached ``caplog`` handler cannot observe."""
+    test_logger = logging.getLogger("tests.channel_layer_posture")
+    with caplog.at_level(logging.INFO, logger=test_logger.name):
+        log_channel_layer_posture(
+            {
+                "CHANNEL_LAYER_BACKEND": "redis",
+                "REDIS_HOST": "10.0.0.20",
+                "REDIS_PORT": "6380",
+                "REDIS_TLS": "true",
+                "REDIS_PASSWORD": "supersecretauthtoken",  # NOSONAR - test fixture, not a real credential
+                "REDIS_CA_PEM": "-----BEGIN CERTIFICATE-----\nMIIBfake==\n-----END CERTIFICATE-----\n",
+            },
+            logger=test_logger,
+        )
+
+    records = [r for r in caplog.records if "channel-layer" in r.getMessage()]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "backend=redis" in message
+    assert "redis_tls=True" in message
+    # No secrets / sensitive topology in the emitted line.
+    assert "supersecretauthtoken" not in message
+    assert "BEGIN CERTIFICATE" not in message
+    assert "10.0.0.20" not in message


### PR DESCRIPTION
## Summary

Decouples the portal Django Channels backend from the `enable_autoscaling` compute-topology flag (#849). Backend selection is now an explicit, environment-owned posture: a Terraform `enable_redis` knob (independent of ASG) drives an always-written `channel-layer-backend` SSM parameter, and the portal reads one `CHANNEL_LAYER_BACKEND` runtime contract resolved in `config/_channels.py`. A `redis` posture requires `REDIS_HOST` and fails closed (ImproperlyConfigured) instead of silently degrading to the in-memory layer; the active backend is logged once at ASGI startup with non-secret fields. Defaults preserve current effective behavior (dev in-memory, prod redis). Documented in ADR-018 and a new architecture/ops reference. AWS Redis AUTH/TLS hardening is explicitly out of scope.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #849

## ADR Impact

- ADR-018
- ADR-021

## Changes

- config/_channels.py: add `_resolve_backend` (explicit `CHANNEL_LAYER_BACKEND` enum, fail-closed `redis`, forced `in_memory`, legacy `REDIS_HOST`-presence heuristic when unset), extract `_build_redis_layer`, add `describe_channel_layer_posture` + `log_channel_layer_posture`
- config/asgi.py: log the active channel-layer backend once per process after Django setup
- terraform: add environment-owned `enable_redis` var to dev/prod portal roots (dev=false, prod=true) and drive the SSM `redis-endpoint` + EC2 `redis_endpoint` from it instead of `enable_autoscaling`
- terraform/modules/portal/ssm: always-written `channel-layer-backend` String parameter (redis | in_memory)
- ec2/user_data.sh + .github/workflows/_shifter-platform.yml: read the backend SSM param and pass `CHANNEL_LAYER_BACKEND` to the container (mirrored across user-data boot and single-instance deploy)
- docs: ADR-018, docs/architecture/portal-channel-layer-backend.md, updated preflight note; changelog fragment
- tests: explicit-backend-posture and startup-observability cases in tests/config/test_channel_layers.py

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Gates run green locally: adr_guard --all --level ci; ruff check/format; lint-imports; terraform fmt + tflint; actionlint; `TESTING=1 pytest tests/config/test_channel_layers.py` (34 tests incl. fail-closed, forced in_memory, invalid-value, legacy-heuristic, and a no-secret-leak startup-log assertion). Full `pre-commit run --all-files` and the platform pytest suite passed on commit.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: ADR-018 ← shifter/shifter_platform/config/_channels.py, ADR-018 ← platform/terraform/environments/dev/portal/main.tf, ADR-018 ← platform/terraform/modules/portal/ssm/main.tf
- TESTS: ADR-018 ← shifter/shifter_platform/tests/config/test_channel_layers.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/849.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
