### PR TITLE
Follow up websocket notification Sonar coverage

### DIFF
--- a/.github/workflows/_gcp-dev.yml
+++ b/.github/workflows/_gcp-dev.yml
@@ -47,7 +47,8 @@ permissions:
 jobs:
   validate:
     name: Validate (${{ inputs.environment }})
-    runs-on: self-hosted
+    # Validation does not need deploy-network access; keep PR checks off the deploy runner pool.
+    runs-on: ubuntu-latest
     env:
       GCP_ENVIRONMENT: ${{ inputs.environment }}
       KUBECONFORM_VERSION: v0.7.0

--- a/shifter/shifter_platform/tests/cms/experiments/test_consumers.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_consumers.py
@@ -51,6 +51,7 @@ def _make_non_staff_user(pk=2):
     return user
 
 
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 class TestConsumerAuthentication:
     """5.3: Test consumer authentication (reject unauthenticated, reject non-owner)."""

--- a/shifter/shifter_platform/tests/cms/experiments/test_handlers.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_handlers.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cms.experiments.handlers import parse_sns_message, process_event
 from cms.experiments.schemas import RunStatus
 
@@ -131,3 +133,172 @@ class TestNotifications:
         _publish_experiment_status_notification(999, "failed")
 
         mock_recipient.assert_called_once_with(999)
+
+    def test_broadcast_run_status_queues_notification_when_channel_layer_fails(self):
+        from cms.experiments.handlers import _broadcast_run_status
+
+        with (
+            patch("channels.layers.get_channel_layer", side_effect=RuntimeError("unavailable")),
+            patch("cms.experiments.handlers._publish_run_status_notification") as mock_publish,
+        ):
+            _broadcast_run_status(10, 5, 1, RunStatus.FAILED.value, "SSM timeout")
+
+        mock_publish.assert_called_once_with(10, 5, 1, RunStatus.FAILED.value, "SSM timeout")
+
+    def test_broadcast_experiment_status_queues_notification_when_channel_layer_fails(self):
+        from cms.experiments.handlers import _broadcast_experiment_status
+
+        with (
+            patch("channels.layers.get_channel_layer", side_effect=RuntimeError("unavailable")),
+            patch("cms.experiments.handlers._publish_experiment_status_notification") as mock_publish,
+        ):
+            _broadcast_experiment_status(10, "failed")
+
+        mock_publish.assert_called_once_with(10, "failed")
+
+    def test_broadcast_run_status_for_missing_run_returns(self):
+        from cms.experiments.handlers import _broadcast_run_status_for
+        from cms.experiments.models import ExperimentRun
+
+        with (
+            patch("cms.experiments.handlers.ExperimentRun.objects.get", side_effect=ExperimentRun.DoesNotExist),
+            patch("cms.experiments.handlers._broadcast_run_status") as mock_broadcast,
+        ):
+            _broadcast_run_status_for(10, 999)
+
+        mock_broadcast.assert_not_called()
+
+    def test_broadcast_experiment_status_if_terminal_missing_experiment_returns(self):
+        from cms.experiments.handlers import _broadcast_experiment_status_if_terminal
+        from cms.experiments.models import Experiment
+
+        with (
+            patch("cms.experiments.handlers.Experiment.objects.get", side_effect=Experiment.DoesNotExist),
+            patch("cms.experiments.handlers._broadcast_experiment_status") as mock_broadcast,
+        ):
+            _broadcast_experiment_status_if_terminal(999)
+
+        mock_broadcast.assert_not_called()
+
+
+class TestEventHandlers:
+    def test_validate_event_ids_rejects_missing_fields(self):
+        from cms.experiments.handlers import _validate_event_ids
+
+        assert _validate_event_ids({}, "experiment.start", "experiment_id") is None
+
+    @pytest.mark.parametrize(
+        ("handler_name", "event"),
+        [
+            ("_handle_experiment_start", {}),
+            ("_handle_range_provisioned", {"experiment_id": 10}),
+            ("_handle_victim_scripts_completed", {"experiment_id": 10}),
+            ("_handle_attacker_scripts_completed", {"experiment_id": 10}),
+            ("_handle_artifacts_collected", {"experiment_id": 10}),
+            ("_handle_run_failed", {"experiment_id": 10}),
+        ],
+    )
+    def test_event_handlers_ignore_missing_ids(self, handler_name, event):
+        from cms.experiments import handlers
+
+        with (
+            patch.object(handlers, "ExperimentOrchestrator") as mock_orchestrator,
+            patch.object(handlers, "_broadcast_experiment_status") as mock_experiment_broadcast,
+            patch.object(handlers, "_broadcast_run_status_for") as mock_run_broadcast,
+            patch.object(handlers, "_broadcast_experiment_status_if_terminal") as mock_terminal_broadcast,
+        ):
+            getattr(handlers, handler_name)(event)
+
+        mock_orchestrator.assert_not_called()
+        mock_experiment_broadcast.assert_not_called()
+        mock_run_broadcast.assert_not_called()
+        mock_terminal_broadcast.assert_not_called()
+
+    def test_experiment_start_handler_schedules_runs_and_broadcasts_running(self):
+        from cms.experiments import handlers
+
+        mock_orchestrator = MagicMock()
+        with (
+            patch.object(handlers, "ExperimentOrchestrator", return_value=mock_orchestrator) as mock_orchestrator_cls,
+            patch.object(handlers, "_broadcast_experiment_status") as mock_broadcast,
+        ):
+            handlers._handle_experiment_start({"experiment_id": 10})
+
+        mock_orchestrator_cls.assert_called_once_with(10)
+        mock_orchestrator.schedule_runs.assert_called_once()
+        mock_broadcast.assert_called_once_with(10, "running")
+
+    def test_range_provisioned_handler_dispatches_and_broadcasts_run_status(self):
+        from cms.experiments import handlers
+
+        mock_orchestrator = MagicMock()
+        instances = {"attacker": {"id": "i-1"}}
+        with (
+            patch.object(handlers, "ExperimentOrchestrator", return_value=mock_orchestrator) as mock_orchestrator_cls,
+            patch.object(handlers, "_broadcast_run_status_for") as mock_broadcast,
+        ):
+            handlers._handle_range_provisioned({"experiment_id": 10, "run_id": 5, "provisioned_instances": instances})
+
+        mock_orchestrator_cls.assert_called_once_with(10)
+        mock_orchestrator.handle_range_provisioned.assert_called_once_with(5, instances)
+        mock_broadcast.assert_called_once_with(10, 5)
+
+    def test_victim_scripts_completed_handler_dispatches_and_broadcasts_run_status(self):
+        from cms.experiments import handlers
+
+        mock_orchestrator = MagicMock()
+        with (
+            patch.object(handlers, "ExperimentOrchestrator", return_value=mock_orchestrator) as mock_orchestrator_cls,
+            patch.object(handlers, "_broadcast_run_status_for") as mock_broadcast,
+        ):
+            handlers._handle_victim_scripts_completed({"experiment_id": 10, "run_id": 5})
+
+        mock_orchestrator_cls.assert_called_once_with(10)
+        mock_orchestrator.handle_victim_scripts_completed.assert_called_once_with(5)
+        mock_broadcast.assert_called_once_with(10, 5)
+
+    def test_attacker_scripts_completed_handler_dispatches_and_broadcasts_run_status(self):
+        from cms.experiments import handlers
+
+        mock_orchestrator = MagicMock()
+        with (
+            patch.object(handlers, "ExperimentOrchestrator", return_value=mock_orchestrator) as mock_orchestrator_cls,
+            patch.object(handlers, "_broadcast_run_status_for") as mock_broadcast,
+        ):
+            handlers._handle_attacker_scripts_completed({"experiment_id": 10, "run_id": 5})
+
+        mock_orchestrator_cls.assert_called_once_with(10)
+        mock_orchestrator.handle_attacker_scripts_completed.assert_called_once_with(5)
+        mock_broadcast.assert_called_once_with(10, 5)
+
+    def test_artifacts_collected_handler_dispatches_and_broadcasts_statuses(self):
+        from cms.experiments import handlers
+
+        mock_orchestrator = MagicMock()
+        with (
+            patch.object(handlers, "ExperimentOrchestrator", return_value=mock_orchestrator) as mock_orchestrator_cls,
+            patch.object(handlers, "_broadcast_run_status_for") as mock_run_broadcast,
+            patch.object(handlers, "_broadcast_experiment_status_if_terminal") as mock_terminal_broadcast,
+        ):
+            handlers._handle_artifacts_collected({"experiment_id": 10, "run_id": 5})
+
+        mock_orchestrator_cls.assert_called_once_with(10)
+        mock_orchestrator.handle_artifacts_collected.assert_called_once_with(5)
+        mock_run_broadcast.assert_called_once_with(10, 5)
+        mock_terminal_broadcast.assert_called_once_with(10)
+
+    def test_run_failed_handler_dispatches_and_broadcasts_statuses(self):
+        from cms.experiments import handlers
+
+        mock_orchestrator = MagicMock()
+        with (
+            patch.object(handlers, "ExperimentOrchestrator", return_value=mock_orchestrator) as mock_orchestrator_cls,
+            patch.object(handlers, "_broadcast_run_status_for") as mock_run_broadcast,
+            patch.object(handlers, "_broadcast_experiment_status_if_terminal") as mock_terminal_broadcast,
+        ):
+            handlers._handle_run_failed({"experiment_id": 10, "run_id": 5})
+
+        mock_orchestrator_cls.assert_called_once_with(10)
+        mock_orchestrator.handle_run_failed.assert_called_once_with(5, "Unknown error")
+        mock_run_broadcast.assert_called_once_with(10, 5, error_message="Unknown error")
+        mock_terminal_broadcast.assert_called_once_with(10)

--- a/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
@@ -8,6 +8,8 @@ import pytest
 
 from cms.experiments.notifications import (
     _experiment_id_from_topic,
+    _experiment_status_payload,
+    _run_status_payload,
     experiment_topic,
     publish_experiment_run_status_notification,
     register_experiment_notifications,
@@ -64,6 +66,35 @@ def test_register_experiment_notifications_rejects_invalid_topics() -> None:
 def test_experiment_id_from_topic_rejects_non_experiment_topic() -> None:
     """Topic parsing only accepts experiment notification topics."""
     assert _experiment_id_from_topic("range:100") is None
+
+
+def test_notification_payload_projectors_return_browser_safe_fields() -> None:
+    """Registered payload handlers strip unneeded source fields."""
+    assert _run_status_payload(
+        {
+            "experiment_id": 100,
+            "run_id": 5,
+            "run_number": 2,
+            "status": "completed",
+            "unsafe": "drop",
+        }
+    ) == {
+        "experiment_id": 100,
+        "run_id": 5,
+        "run_number": 2,
+        "status": "completed",
+        "error_message": "",
+    }
+    assert _experiment_status_payload(
+        {
+            "experiment_id": 100,
+            "status": "failed",
+            "unsafe": "drop",
+        }
+    ) == {
+        "experiment_id": 100,
+        "status": "failed",
+    }
 
 
 def test_publish_experiment_run_status_notification_projects_safe_payload() -> None:

--- a/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cms.experiments.notifications import (
+    _experiment_id_from_topic,
     experiment_topic,
     publish_experiment_run_status_notification,
     register_experiment_notifications,
@@ -58,6 +59,11 @@ def test_register_experiment_notifications_rejects_invalid_topics() -> None:
     assert authorize_subscription(staff_owner, "range:100") is False
     assert authorize_subscription(staff_owner, "experiment:not-int") is False
     assert authorize_subscription(staff_owner, "experiment:0") is False
+
+
+def test_experiment_id_from_topic_rejects_non_experiment_topic() -> None:
+    """Topic parsing only accepts experiment notification topics."""
+    assert _experiment_id_from_topic("range:100") is None
 
 
 def test_publish_experiment_run_status_notification_projects_safe_payload() -> None:

--- a/shifter/shifter_platform/tests/shared/test_notification_consumer.py
+++ b/shifter/shifter_platform/tests/shared/test_notification_consumer.py
@@ -105,6 +105,16 @@ async def test_receive_ignores_empty_messages_and_rejects_invalid_json(consumer)
 
 
 @pytest.mark.asyncio
+async def test_receive_dispatches_valid_json_control_message(consumer):
+    """Raw JSON messages are delegated to the JSON control handler."""
+    consumer.receive_json = AsyncMock()
+
+    await consumer.receive(text_data='{"type": "subscribe", "topic": "experiment:100"}')
+
+    consumer.receive_json.assert_awaited_once_with({"type": "subscribe", "topic": "experiment:100"})
+
+
+@pytest.mark.asyncio
 async def test_receive_json_rejects_unknown_control_message(consumer):
     """Only subscribe and unsubscribe control messages are accepted."""
     await consumer.receive_json({"type": "ping", "topic": "experiment:100"})
@@ -204,6 +214,13 @@ async def test_replay_pending_without_user_returns(consumer):
     await consumer._replay_pending("experiment:100")
 
     consumer.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db(transaction=True)
+async def test_get_notification_without_user_returns_none(consumer):
+    """Notification lookup cannot query before authentication."""
+    assert await consumer._get_notification(1) is None
 
 
 @pytest.mark.django_db(transaction=True)

--- a/shifter/shifter_platform/tests/shared/test_notifications.py
+++ b/shifter/shifter_platform/tests/shared/test_notifications.py
@@ -146,6 +146,24 @@ def test_publish_notification_validates_registration_and_event_id(user) -> None:
 
 
 @pytest.mark.django_db
+def test_publish_notification_generates_event_id_when_not_supplied(user):
+    """Publish generates an idempotency key when the source event has no id."""
+    from shared.notifications import publish_notification
+
+    _register_experiment_type()
+
+    with patch("shared.notifications.get_channel_layer", return_value=None):
+        [notification] = publish_notification(
+            "experiment.run_status",
+            topic="experiment:100",
+            payload={"run_id": 7, "status": "running"},
+            recipient_ids=[user.id],
+        )
+
+    assert isinstance(notification.event_id, UUID)
+
+
+@pytest.mark.django_db
 def test_publish_notification_persists_and_fans_out(user):
     """Publishing stores a per-recipient row and sends to the user/topic group."""
     from shared.notifications import publish_notification

--- a/shifter/shifter_platform/tests/shared/test_notifications.py
+++ b/shifter/shifter_platform/tests/shared/test_notifications.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 import pytest
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
+from django.db import IntegrityError
 from django.utils import timezone
 
 from shared.models import WebSocketNotification
@@ -209,6 +210,44 @@ def test_publish_notification_is_idempotent_per_recipient_topic_type_and_event(u
     assert first[0].id == second[0].id
     assert WebSocketNotification.objects.count() == 1
     assert str(WebSocketNotification.objects.get()) == f"experiment.run_status:experiment:100:{user.id}"
+
+
+@pytest.mark.django_db
+def test_publish_notification_handles_concurrent_insert_race(user):
+    """A uniqueness race falls back to the row created by the competing transaction."""
+    from shared.notifications import publish_notification
+
+    _register_experiment_type()
+    event_id = UUID("12345678-1234-5678-1234-567812345678")
+    existing = WebSocketNotification.objects.create(
+        recipient=user,
+        notification_type="experiment.run_status",
+        topic="experiment:100",
+        event_id=event_id,
+        payload={"run_id": 7, "status": "running"},
+        expires_at=timezone.now() + timedelta(days=1),
+    )
+
+    with (
+        patch("shared.notifications.WebSocketNotification.objects.get_or_create", side_effect=IntegrityError),
+        patch("shared.notifications.WebSocketNotification.objects.get", return_value=existing) as mock_get,
+        patch("shared.notifications.get_channel_layer", return_value=None),
+    ):
+        [notification] = publish_notification(
+            "experiment.run_status",
+            topic="experiment:100",
+            payload={"run_id": 7, "status": "running"},
+            recipient_ids=[user.id],
+            event_id=event_id,
+        )
+
+    assert notification == existing
+    mock_get.assert_called_once_with(
+        recipient_id=user.id,
+        topic="experiment:100",
+        notification_type="experiment.run_status",
+        event_id=event_id,
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- add focused coverage for shared WebSocket notification defensive paths, experiment notification payload projectors, and event handler dispatch/fallback branches
- mark the existing experiment status consumer auth test for transactional DB access so Channels disconnect cleanup is allowed under pytest-django
- move GCP dev validation to `ubuntu-latest` so PR validation does not queue indefinitely on unavailable self-hosted runners; deploy still uses self-hosted

## Runner investigation
- Aurora Fabricator is healthy and has six online idle `fab-warm-*` runners for KeplerOps.
- `Brad-Edwards/shifter` has no repository webhooks configured and only three stale offline repo runners (`shifter-github-runner-1..3`); no matching VMs exist on Aurora.
- The hung GCP validate job requested only `self-hosted` and had no runner assigned.

## Verification
- `uv run pytest tests/shared/test_notifications.py tests/shared/test_notification_consumer.py tests/cms/experiments/test_notifications.py tests/cms/experiments/test_handlers.py --cov=shared.notifications --cov=shared.consumers --cov=cms.experiments.notifications --cov=cms.experiments.handlers --cov-report=term-missing`
- `uv run pytest tests/cms/experiments/test_consumers.py::TestConsumerAuthentication::test_accepts_owner tests/config/test_channel_layers.py tests/test_asgi_worker_smoke.py`
- `actionlint`
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- `cd shifter/shifter_platform && uv run lint-imports --config ../../.importlinter`
- `tflint --recursive --config /home/atomik/src/shifter/.tflint.hcl --chdir platform/terraform`
- pre-commit hook on both local commits, including full `pytest (shifter_platform)`
