### PR TITLE
security: bump hono to 4.12.23 across mcp packages

### DIFF
--- a/changelog.d/870.security.md
+++ b/changelog.d/870.security.md
@@ -1,0 +1,4 @@
+Bump `hono` 4.12.18 → 4.12.23 in the `mcp/ngfw`, `mcp/ops`, and
+`mcp/planner` lockfiles (transitive via `@modelcontextprotocol/sdk`),
+clearing advisories GHSA-2gcr-mfcq-wcc3, GHSA-3hrh-pfw6-9m5x,
+GHSA-f577-qrjj-4474, and GHSA-xrhx-7g5j-rcj5 (all patched in 4.12.21).

--- a/mcp/ngfw/package-lock.json
+++ b/mcp/ngfw/package-lock.json
@@ -1163,9 +1163,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/mcp/ops/package-lock.json
+++ b/mcp/ops/package-lock.json
@@ -1163,9 +1163,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }

--- a/mcp/planner/package-lock.json
+++ b/mcp/planner/package-lock.json
@@ -1161,9 +1161,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }


### PR DESCRIPTION
## Summary

`hono` was pinned at `4.12.18` in three MCP package lockfiles, below the first patched release `4.12.21`. `hono` is transitive via `@modelcontextprotocol/sdk` (range `^4.11.4` already permits the patch), so this refreshes only the lockfile `hono` entry to `4.12.23` via `npm update hono --package-lock-only` — no `package.json` change.

Clears advisories GHSA-2gcr-mfcq-wcc3, GHSA-3hrh-pfw6-9m5x, GHSA-f577-qrjj-4474, GHSA-xrhx-7g5j-rcj5 (all patched in `4.12.21`).

## Changes

- `mcp/ngfw/package-lock.json`: `hono` 4.12.18 → 4.12.23
- `mcp/ops/package-lock.json`: `hono` 4.12.18 → 4.12.23
- `mcp/planner/package-lock.json`: `hono` 4.12.18 → 4.12.23
- `changelog.d/870.security.md`: security fragment

## Testing

- ADR guard (`scripts/adr_guard/adr_guard.py --all --level ci`) passed.
- Pre-commit ran the `mcp/ngfw` and `mcp/ops` Node test suites against the bumped lockfiles — both passed.
- `npm audit` confirms `hono` is no longer flagged in any of the three packages; lockfiles re-resolve idempotently (`npm install --package-lock-only` reports up to date).

Closes #870