### PR TITLE
security: bump asyncssh floor

### DIFF
--- a/changelog.d/868.security.md
+++ b/changelog.d/868.security.md
@@ -1,0 +1,1 @@
+Constrained `shifter_platform` to `asyncssh>=2.23.0` and refreshed the lockfile to remove vulnerable `asyncssh` 2.22.0.

--- a/shifter/shifter_platform/pyproject.toml
+++ b/shifter/shifter_platform/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Self-service cyber range platform"
 requires-python = ">=3.12"
 dependencies = [
-    "asyncssh",
+    "asyncssh>=2.23.0",
     "bleach>=6.3.0",
     "boto3",
     "channels",

--- a/shifter/shifter_platform/tests/test_dependency_security.py
+++ b/shifter/shifter_platform/tests/test_dependency_security.py
@@ -1,0 +1,29 @@
+"""Structural dependency security checks for shifter_platform."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+ASYNCSSH_MIN_VERSION = (2, 23, 0)
+
+
+def _release_tuple(version: str) -> tuple[int, int, int]:
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    assert match is not None, f"Expected numeric version, got {version!r}"
+    return tuple(int(part) for part in match.groups())
+
+
+def test_asyncssh_direct_dependency_declares_patched_floor() -> None:
+    pyproject = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert "asyncssh>=2.23.0" in pyproject["project"]["dependencies"]
+
+
+def test_asyncssh_lock_uses_patched_release() -> None:
+    lock = tomllib.loads((PACKAGE_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    locked_versions = {package["name"]: package["version"] for package in lock["package"]}
+
+    assert _release_tuple(locked_versions["asyncssh"]) >= ASYNCSSH_MIN_VERSION

--- a/shifter/shifter_platform/uv.lock
+++ b/shifter/shifter_platform/uv.lock
@@ -95,15 +95,15 @@ wheels = [
 
 [[package]]
 name = "asyncssh"
-version = "2.22.0"
+version = "2.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/d5/957886c316466349d55c4de6a688a10a98295c0b4429deb8db1a17f3eb19/asyncssh-2.22.0.tar.gz", hash = "sha256:c3ce72b01be4f97b40e62844dd384227e5ff5a401a3793007c42f86a5c8eb537", size = 540523, upload-time = "2025-12-21T23:38:30.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/fd/c34fe7e30838b4b9cc91903da26a62c6d33b673c731b3d951fcd70ab1889/asyncssh-2.23.0.tar.gz", hash = "sha256:8c54760953c1f2cf282591bcba5c8c70efc48d645bbf26bd2307a9c66a0ed1a7", size = 542154, upload-time = "2026-05-09T03:15:01.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/ae/0da2f2214fc183338af1afe5a103a2052fd03464e8eafbd827abff58a4d0/asyncssh-2.22.0-py3-none-any.whl", hash = "sha256:d16465ccdf1ed20eba1131b14415b155e047f6f5be0d19f39c2e0b61331ee0e7", size = 374938, upload-time = "2025-12-21T23:38:28.976Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b5/b1a3979f4840d1271ca8e0978dbccfb18ad2d33b4ece85cf77122fb46e5f/asyncssh-2.23.0-py3-none-any.whl", hash = "sha256:14108bfdaae17457f0c1841e883ad934271bbfdd46458aa4c4d0973451940ad0", size = 375687, upload-time = "2026-05-09T03:15:00.221Z" },
 ]
 
 [[package]]
@@ -2149,7 +2149,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncssh" },
+    { name = "asyncssh", specifier = ">=2.23.0" },
     { name = "bleach", specifier = ">=6.3.0" },
     { name = "boto3" },
     { name = "channels" },


### PR DESCRIPTION
## Summary

Bumps the direct shifter_platform asyncssh dependency to the first patched release for GHSA-g794-3fmp-753h and records a regression test so future lock refreshes cannot reintroduce the vulnerable floor.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #868

## ADR Impact

- ADR-021

## Changes

- Constrained the direct `asyncssh` dependency in `shifter/shifter_platform/pyproject.toml` to `>=2.23.0`.
- Regenerated `shifter/shifter_platform/uv.lock` with asyncssh 2.23.0 and updated resolver metadata.
- Added a dependency-security test that checks both the direct dependency floor and the locked asyncssh version.
- Added the security changelog fragment for issue 868.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Targeted tests: `uv run pytest tests/test_dependency_security.py tests/engine/ssh/test_ssh_connection.py`. Package checks: `uv lock --check`, `uv run ruff check .`, `uv run ruff format --check .`, `uv run lint-imports --config ../../.importlinter`. Repo checks: `pre-commit run --all-files`, `python3 scripts/adr_guard/adr_guard.py --all --level ci`. Pre-push review cycles: Codex clean, test-quality clean.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/868.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
