### PR TITLE
security: bump idna to >=3.15 (shifter_platform, engine/provisioner)

### DIFF
--- a/changelog.d/869.security.md
+++ b/changelog.d/869.security.md
@@ -1,0 +1,9 @@
+Bump the transitive `idna` dependency 3.13 → 3.18 in both
+`shifter/shifter_platform` and `shifter/engine/provisioner` (pulled in via
+the requests/httpx chain). Clears [GHSA-65pc-fj4g-8rjx][advisory]
+(CVE-2026-45409, moderate): specially crafted inputs to `idna.encode()`
+bypass length validation in `valid_contexto` and trigger excessive
+resource consumption (denial of service), an incomplete-remediation
+follow-up to CVE-2024-3651. First patched in idna 3.15.
+
+[advisory]: https://github.com/advisories/GHSA-65pc-fj4g-8rjx

--- a/shifter/engine/provisioner/uv.lock
+++ b/shifter/engine/provisioner/uv.lock
@@ -506,11 +506,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]

--- a/shifter/shifter_platform/uv.lock
+++ b/shifter/shifter_platform/uv.lock
@@ -1177,11 +1177,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bump the transitive `idna` dependency 3.13 → 3.18 (first patched 3.15) in both `shifter/shifter_platform` and `shifter/engine/provisioner` uv.lock files. idna is pulled in via the requests/httpx chain. Clears GHSA-65pc-fj4g-8rjx / CVE-2026-45409 (moderate): specially crafted inputs to `idna.encode()` bypass length validation in `valid_contexto` and trigger excessive resource consumption (denial of service), an incomplete-remediation follow-up to CVE-2024-3651. Resolved via `uv lock --upgrade-package idna` in each directory; no other packages re-resolved.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #869

## ADR Impact

- No ADR required

## Changes

- `shifter/shifter_platform/uv.lock`: idna 3.13 → 3.18
- `shifter/engine/provisioner/uv.lock`: idna 3.13 → 3.18
- `changelog.d/869.security.md`: security changelog fragment for the bump

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

No source/code changes (lockfile-only). ADR guard (--all --level ci) passes; pre-commit pytest for provisioner and shifter_platform pass.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/869.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.
