### PR TITLE
Onboard light gate pack workflow

### DIFF
--- a/.gc/baselines/docs-generic.json
+++ b/.gc/baselines/docs-generic.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "kind": "shifter-gate-baseline",
+  "gate_ids": [
+    "docs-generic.root.format",
+    "docs-generic.root.lint",
+    "docs-generic.root.docs_policy",
+    "docs-generic.root.policy",
+    "docs-generic.root.secret_scan",
+    "python.shifter.shifter.platform.secret_scan"
+  ],
+  "scope": ".",
+  "captured_from": "node .gc/gate-packs/docs-generic/check-docs.mjs on origin/dev",
+  "findings": [
+    {
+      "rule": "todo_marker",
+      "path": "scripts/ctf-scenario/setup-host.sh"
+    },
+    {
+      "rule": "private_key_marker",
+      "path": "shifter/engine/provisioner/tests/test_instance_component.py"
+    },
+    {
+      "rule": "private_key_marker",
+      "path": "shifter/engine/provisioner/utils/crypto.py"
+    }
+  ]
+}

--- a/.gc/baselines/python-dependency-policy.json
+++ b/.gc/baselines/python-dependency-policy.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "kind": "shifter-gate-baseline",
+  "gate_id": "python.shifter.shifter.platform.dependency_policy",
+  "scope": "shifter/shifter_platform",
+  "captured_from": "uv audit",
+  "findings": [
+    {
+      "id": "PYSEC-2026-197",
+      "package": "django",
+      "fixed_in": ["5.2.15", "6.0.6"]
+    },
+    {
+      "id": "PYSEC-2026-198",
+      "package": "django",
+      "fixed_in": ["5.2.15", "6.0.6"]
+    },
+    {
+      "id": "PYSEC-2026-199",
+      "package": "django",
+      "fixed_in": ["5.2.15", "6.0.6"]
+    },
+    {
+      "id": "PYSEC-2026-200",
+      "package": "django",
+      "fixed_in": ["5.2.15", "6.0.6"]
+    },
+    {
+      "id": "PYSEC-2026-201",
+      "package": "django",
+      "fixed_in": ["5.2.15", "6.0.6"]
+    },
+    {
+      "id": "PYSEC-2026-175",
+      "package": "pyjwt",
+      "fixed_in": ["2.13.0"]
+    },
+    {
+      "id": "PYSEC-2026-177",
+      "package": "pyjwt",
+      "fixed_in": ["2.13.0"]
+    },
+    {
+      "id": "PYSEC-2026-178",
+      "package": "pyjwt",
+      "fixed_in": ["2.13.0"]
+    },
+    {
+      "id": "PYSEC-2026-179",
+      "package": "pyjwt",
+      "fixed_in": ["2.13.0"]
+    }
+  ]
+}

--- a/.gc/baselines/python-type-safety.json
+++ b/.gc/baselines/python-type-safety.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "kind": "shifter-gate-baseline",
+  "gate_id": "python.shifter.shifter.platform.type_safety",
+  "scope": "shifter/shifter_platform",
+  "captured_from": "uv run mypy . --no-error-summary",
+  "findings": [
+    {
+      "kind": "mypy_internal_error",
+      "exit_code": 2,
+      "pattern": "Error constructing plugin instance of NewSemanalDjangoPlugin"
+    }
+  ]
+}

--- a/.gc/gate-packs/docs-generic/check-docs.mjs
+++ b/.gc/gate-packs/docs-generic/check-docs.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const mode = new Set(process.argv.slice(2));
+const errors = [];
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    if (['.git', '.gc', 'node_modules', 'build', 'dist'].includes(entry)) continue;
+    const p = join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p);
+    else check(p);
+  }
+}
+function check(path) {
+  const text = readFileSync(path, 'utf8');
+  if (!mode.has('--workflows') && /(^|\n)TODO(\b|:)/.test(text)) errors.push(`${path}: TODO marker`);
+  if (/-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY-----/.test(text)) errors.push(`${path}: private key marker`);
+  if (mode.has('--workflows') && /uses:\s*[^@\s]+\s*$/m.test(text)) errors.push(`${path}: unpinned workflow action`);
+}
+walk(process.cwd());
+if (errors.length) {
+  console.error(errors.join('\n'));
+  process.exit(1);
+}
+console.log('docs policy passed');

--- a/.gc/gate-packs/docs-generic/pre-commit-config.yaml
+++ b/.gc/gate-packs/docs-generic/pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: detect-private-key
+      - id: trailing-whitespace

--- a/.gc/gate-packs/docs-generic/vale.ini
+++ b/.gc/gate-packs/docs-generic/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = .vale/styles
+MinAlertLevel = suggestion
+Packages = Google
+[*]
+BasedOnStyles = Vale, Google

--- a/.gc/gate-packs/python/gc-python-run
+++ b/.gc/gate-packs/python/gc-python-run
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -eu
+
+TOOL_PINS='
+bandit==1.9.4
+build==1.5.0
+coverage==7.14.1
+diff-cover==10.3.0
+hypothesis==6.155.2
+import-linter==2.11
+mutmut==3.6.0
+mypy==1.20.2
+nox==2026.4.10
+pip-audit==2.10.0
+pre-commit==4.6.0
+pytest==8.4.2
+pytest-cov==7.1.0
+ruff==0.15.16
+'
+
+note() {
+  printf '%s\n' "gc-python-run: $1" >&2
+}
+
+fail() {
+  printf '%s\n' "gc-python-run: $1" >&2
+  exit "${2:-1}"
+}
+
+has_pyproject_section() {
+  section=$1
+  [ -f pyproject.toml ] && grep -Eq "^[[:space:]]*\[$section\][[:space:]]*(#.*)?$" pyproject.toml
+}
+
+run_from_venv() {
+  venv_dir=$1
+  label=$2
+  shift 2
+  venv_bin=$venv_dir/bin
+  if [ ! -x "$venv_bin/python" ]; then
+    fail "$venv_dir is not a usable Python virtual environment" 127
+  fi
+  note "$label"
+  if [ "$#" -eq 0 ]; then
+    exec "$venv_bin/python"
+  fi
+  command_name=$1
+  case "$command_name" in
+    python|python3)
+      shift
+      exec "$venv_bin/python" "$@"
+      ;;
+    sh)
+      shift
+      PATH="$venv_bin:/usr/bin:/bin"
+      export PATH
+      exec /bin/sh "$@"
+      ;;
+    */*)
+      exec "$@"
+      ;;
+    *)
+      if [ -x "$venv_bin/$command_name" ]; then
+        shift
+        exec "$venv_bin/$command_name" "$@"
+      fi
+      fail "$command_name is not installed in $venv_dir" 127
+      ;;
+  esac
+}
+
+if [ "$#" -eq 0 ]; then
+  fail 'usage: gc-python-run <tool> [args...]' 64
+fi
+
+if [ "${1:-}" = "pyright-or-mypy" ]; then
+  shift
+  set -- sh -c 'if command -v pyright >/dev/null 2>&1; then exec pyright "$@"; fi; exec mypy --strict . "$@"' pyright-or-mypy "$@"
+elif [ "${1:-}" = "coverage-diff-cover" ]; then
+  shift
+  set -- sh -c 'mkdir -p .gc/reports/python && coverage run -m pytest && coverage xml -o .gc/reports/python/coverage.xml && diff-cover .gc/reports/python/coverage.xml --fail-under=90 "$@"' coverage-diff-cover "$@"
+fi
+
+if command -v uv >/dev/null 2>&1; then
+  note 'uv run'
+  exec uv run -- "$@"
+fi
+
+if command -v poetry >/dev/null 2>&1 && has_pyproject_section 'tool\.poetry'; then
+  note 'poetry run'
+  exec poetry run -- "$@"
+fi
+
+if command -v hatch >/dev/null 2>&1 && has_pyproject_section 'tool\.hatch'; then
+  note 'hatch run'
+  exec hatch run -- "$@"
+fi
+
+if [ "${VIRTUAL_ENV:-}" != "" ] && [ -x "$VIRTUAL_ENV/bin/python" ]; then
+  run_from_venv "$VIRTUAL_ENV" '$VIRTUAL_ENV'
+fi
+
+if [ -x .venv/bin/python ]; then
+  run_from_venv .venv '.venv'
+fi
+
+if [ -x venv/bin/python ]; then
+  run_from_venv venv 'venv'
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  fail 'python3 is required to create .venv for the fallback runner' 127
+fi
+
+python3 -m venv .venv
+fallback_python=.venv/bin/python
+if [ ! -x "$fallback_python" ]; then
+  fail 'python3 -m venv did not create .venv/bin/python' 127
+fi
+# shellcheck disable=SC2086
+"$fallback_python" -m pip install $TOOL_PINS
+run_from_venv .venv 'created .venv with pinned pack tools'

--- a/.gc/gate-packs/python/importlinter.ini
+++ b/.gc/gate-packs/python/importlinter.ini
@@ -1,0 +1,6 @@
+[importlinter]
+root_package = src
+
+[importlinter:contract:layers]
+name = Layered architecture
+layers = api; domain; infrastructure

--- a/.gc/gate-packs/python/pyproject.gc.toml
+++ b/.gc/gate-packs/python/pyproject.gc.toml
@@ -1,0 +1,9 @@
+[tool.coverage.run]
+branch = true
+source = ["src"]
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "C901", "S"]

--- a/.gc/gate-packs/shifter/check-docs-baseline.mjs
+++ b/.gc/gate-packs/shifter/check-docs-baseline.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const args = new Set(process.argv.slice(2));
+const repoRoot = process.cwd();
+const baselinePath = ".gc/baselines/docs-generic.json";
+const skipDirs = new Set([
+  ".git",
+  ".gc",
+  ".venv",
+  "venv",
+  "env",
+  "node_modules",
+  "build",
+  "dist",
+  "__pycache__",
+  ".pytest_cache",
+  ".mypy_cache",
+  ".ruff_cache",
+  ".terraform",
+  ".tox",
+  ".nox",
+  "coverage",
+]);
+
+function repoRelative(path) {
+  return relative(repoRoot, path).split(sep).join("/");
+}
+
+function loadBaseline() {
+  if (!existsSync(baselinePath)) return new Set();
+  const parsed = JSON.parse(readFileSync(baselinePath, "utf8"));
+  return new Set((parsed.findings ?? []).map((finding) => `${finding.rule}\t${finding.path}`));
+}
+
+function isProbablyText(buffer) {
+  if (buffer.includes(0)) return false;
+  return true;
+}
+
+function walk(dir, visit) {
+  for (const entry of readdirSync(dir)) {
+    if (skipDirs.has(entry)) continue;
+    const path = join(dir, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      walk(path, visit);
+    } else if (stat.isFile()) {
+      visit(path);
+    }
+  }
+}
+
+function collectContentFindings() {
+  const findings = [];
+  walk(repoRoot, (path) => {
+    const buffer = readFileSync(path);
+    if (!isProbablyText(buffer)) return;
+    const text = buffer.toString("utf8");
+    const rel = repoRelative(path);
+    if (!args.has("--secrets-only") && /(^|\n)TODO(\b|:)/.test(text)) {
+      findings.push({ rule: "todo_marker", path: rel });
+    }
+    if (/-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP )?PRIVATE KEY-----/.test(text)) {
+      findings.push({ rule: "private_key_marker", path: rel });
+    }
+  });
+  return findings;
+}
+
+function collectWorkflowFindings() {
+  const root = join(repoRoot, ".github", "workflows");
+  const findings = [];
+  if (!existsSync(root)) return findings;
+  walk(root, (path) => {
+    if (!/\.ya?ml$/.test(path)) return;
+    const text = readFileSync(path, "utf8");
+    const rel = repoRelative(path);
+    for (const match of text.matchAll(/uses:\s*([^@\s]+)\s*$/gm)) {
+      const target = match[1];
+      if (target.startsWith("./")) continue;
+      findings.push({ rule: "unpinned_workflow_action", path: rel });
+    }
+  });
+  return findings;
+}
+
+const baseline = loadBaseline();
+const findings = args.has("--workflows") ? collectWorkflowFindings() : collectContentFindings();
+const newFindings = findings.filter((finding) => !baseline.has(`${finding.rule}\t${finding.path}`));
+
+if (newFindings.length > 0) {
+  for (const finding of newFindings) {
+    console.error(`${finding.path}: ${finding.rule}`);
+  }
+  console.error(`new findings: ${newFindings.length}; baseline findings: ${findings.length - newFindings.length}`);
+  process.exit(1);
+}
+
+console.log(`docs policy passed; baseline findings: ${findings.length}; new findings: 0`);

--- a/.gc/gate-packs/shifter/run-mypy-baseline.mjs
+++ b/.gc/gate-packs/shifter/run-mypy-baseline.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const [baselinePath, runner = "../../.gc/gate-packs/python/gc-python-run"] = process.argv.slice(2);
+if (!baselinePath) {
+  console.error("usage: run-mypy-baseline.mjs <baseline-json> [gc-python-run]");
+  process.exit(64);
+}
+
+const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
+const findings = Array.isArray(baseline.findings) ? baseline.findings : [];
+const result = spawnSync(runner, ["mypy", ".", "--no-error-summary"], {
+  encoding: "utf8",
+  maxBuffer: 16 * 1024 * 1024,
+});
+
+if (result.status === 0) {
+  process.stdout.write(result.stdout ?? "");
+  process.stderr.write(result.stderr ?? "");
+  process.exit(0);
+}
+
+const combined = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+const matched = findings.some((finding) =>
+  finding.kind === "mypy_internal_error" &&
+  finding.exit_code === result.status &&
+  typeof finding.pattern === "string" &&
+  combined.includes(finding.pattern)
+);
+
+if (matched) {
+  process.stderr.write(combined);
+  console.log(`mypy baseline accepted; baseline findings: ${findings.length}; new findings: 0`);
+  process.exit(0);
+}
+
+process.stdout.write(result.stdout ?? "");
+process.stderr.write(result.stderr ?? "");
+process.exit(result.status ?? 1);

--- a/.gc/gate-packs/shifter/run-uv-audit-baseline.mjs
+++ b/.gc/gate-packs/shifter/run-uv-audit-baseline.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const [baselinePath] = process.argv.slice(2);
+if (!baselinePath) {
+  console.error("usage: run-uv-audit-baseline.mjs <baseline-json>");
+  process.exit(64);
+}
+
+const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
+const ids = [...new Set((baseline.findings ?? []).map((finding) => finding.id).filter(Boolean))].sort();
+const ignoreArgs = ids.flatMap((id) => ["--ignore", id]);
+const result = spawnSync("uv", ["audit", ...ignoreArgs], {
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/.gc/gates.yaml
+++ b/.gc/gates.yaml
@@ -1,0 +1,897 @@
+schema_version: 1
+engine:
+  min_version: '>=1.0.0'
+  manifest_version: 1.0.0
+defaults:
+  timeout_seconds: 900
+  provider_missing: reviewer_fallback
+  fail_fast: false
+packs:
+  - id: python
+    version: 1.0.0
+    scope: shifter/shifter_platform
+  - id: docs-generic
+    version: 1.0.0
+    scope: .
+gates:
+  - id: python.shifter.shifter.platform.format
+    capability: format
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider: ruff-format
+    command: ../../.gc/gate-packs/python/gc-python-run ruff format --check .
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.lint
+    capability: lint
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider: ruff-check
+    command: ../../.gc/gate-packs/python/gc-python-run ruff check .
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.build
+    capability: build
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/pyproject.toml
+        - shifter/shifter_platform/setup.cfg
+        - shifter/shifter_platform/setup.py
+        - shifter/shifter_platform/**/*.py
+    provider: python-build
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+    provider_missing: reviewer_fallback
+  - id: python.shifter.shifter.platform.type_safety
+    capability: type_safety
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider: pyright-or-mypy
+    command: node ../../.gc/gate-packs/shifter/run-mypy-baseline.mjs ../../.gc/baselines/python-type-safety.json ../../.gc/gate-packs/python/gc-python-run
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.unit_tests
+    capability: unit_tests
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/tests/**
+        - shifter/shifter_platform/pyproject.toml
+    provider: pytest
+    command: TESTING=1 DJANGO_DEBUG=true DJANGO_SECRET_KEY=gate-pack-local DB_HOST=${DB_HOST:-localhost} DB_PORT=${DB_PORT:-5432} DB_NAME=${DB_NAME:-shifter} DB_USER=${DB_USER:-test} DB_PASSWORD=${DB_PASSWORD:-test} ../../.gc/gate-packs/python/gc-python-run pytest tests/ --ignore=tests/documentation
+    timeout_seconds: 1200
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.integration_tests
+    capability: integration_tests
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/tests/**
+        - shifter/shifter_platform/pyproject.toml
+    provider: pytest-integration
+    timeout_seconds: 1800
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+    provider_missing: reviewer_fallback
+  - id: python.shifter.shifter.platform.contract_boundary
+    capability: contract_boundary
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider_missing: reviewer_fallback
+    threshold:
+      metric: provider_declared
+      policy: reviewer_fallback
+    thresholds:
+      platform_minimum:
+        metric: provider_declared
+        policy: reviewer_fallback
+      recommendation:
+        metric: provider_declared
+        policy: deterministic_provider_when_adopted
+  - id: python.shifter.shifter.platform.property_verification
+    capability: property_verification
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/tests/**
+        - shifter/shifter_platform/pyproject.toml
+    provider: hypothesis
+    timeout_seconds: 1800
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+    provider_missing: reviewer_fallback
+  - id: python.shifter.shifter.platform.architecture
+    capability: architecture
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider: import-linter
+    command: ../../.gc/gate-packs/python/gc-python-run lint-imports --config ../../.importlinter
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.complexity
+    capability: complexity
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider: ruff-complexity
+    command: ../../.gc/gate-packs/python/gc-python-run ruff check --select C901 .
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.mutation
+    capability: mutation
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/tests/**
+        - shifter/shifter_platform/pyproject.toml
+    provider: mutmut
+    timeout_seconds: 3600
+    threshold:
+      metric: mutation_score
+      min: 60
+    thresholds:
+      platform_minimum:
+        metric: mutation_score
+        min: 60
+      recommendation:
+        metric: mutation_score
+        min: 80
+    provider_missing: reviewer_fallback
+  - id: python.shifter.shifter.platform.diff_coverage
+    capability: diff_coverage
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/tests/**
+    provider: coverage-diff-cover
+    threshold:
+      metric: changed_line_coverage
+      min: 80
+    thresholds:
+      platform_minimum:
+        metric: changed_line_coverage
+        min: 80
+      recommendation:
+        metric: changed_line_coverage
+        min: 90
+    provider_missing: reviewer_fallback
+  - id: python.shifter.shifter.platform.sast
+    capability: sast
+    pack: python
+    cwd: .
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider: bandit
+    command: uv tool run bandit -r shifter/shifter_platform/ --skip B101 --exclude shifter/shifter_platform/tests,shifter/shifter_platform/.venv -ll
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.secret_scan
+    capability: secret_scan
+    pack: python
+    cwd: .
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*
+    provider: gitleaks
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs --secrets-only
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.dependency_policy
+    capability: dependency_policy
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/pyproject.toml
+        - shifter/shifter_platform/requirements*.txt
+        - shifter/shifter_platform/uv.lock
+        - shifter/shifter_platform/poetry.lock
+    provider: pip-audit-or-uv-audit
+    command: node ../../.gc/gate-packs/shifter/run-uv-audit-baseline.mjs ../../.gc/baselines/python-dependency-policy.json
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.accessibility
+    capability: accessibility
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: python.shifter.shifter.platform.docs_policy
+    capability: docs_policy
+    pack: python
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/*.md
+        - shifter/shifter_platform/**/*.md
+        - shifter/shifter_platform/*.markdown
+        - shifter/shifter_platform/**/*.markdown
+        - shifter/shifter_platform/docs/**
+        - shifter/shifter_platform/architecture/adrs/**
+        - shifter/shifter_platform/.ground-control.yaml
+    provider: docs-profile
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.traceability
+    capability: traceability
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*.py
+        - shifter/shifter_platform/pyproject.toml
+    provider_missing: reviewer_fallback
+    threshold:
+      metric: provider_declared
+      policy: reviewer_fallback
+    thresholds:
+      platform_minimum:
+        metric: provider_declared
+        policy: reviewer_fallback
+      recommendation:
+        metric: provider_declared
+        policy: deterministic_provider_when_adopted
+  - id: python.shifter.shifter.platform.policy
+    capability: policy
+    pack: python
+    cwd: .
+    blocking: true
+    scope: repo
+    applies_when:
+      paths:
+        - shifter/shifter_platform/**/*
+    provider: repo-policy
+    command: python3 scripts/adr_guard/adr_guard.py --all --level ci
+    timeout_seconds: 1800
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: python.shifter.shifter.platform.remote_status
+    capability: remote_status
+    pack: python
+    cwd: shifter/shifter_platform
+    blocking: true
+    scope: repo
+    applies_when:
+      paths: []
+    provider: required-statuses
+    required_statuses:
+      - ci
+    threshold:
+      metric: required_statuses
+      policy: all_success
+    thresholds:
+      platform_minimum:
+        metric: required_statuses
+        policy: all_success
+      recommendation:
+        metric: required_statuses
+        policy: all_success
+  - id: docs-generic.root.format
+    capability: format
+    pack: docs-generic
+    cwd: .
+    blocking: true
+    scope: repo
+    applies_when:
+      paths:
+        - '*.md'
+        - '**/*.md'
+        - '*.markdown'
+        - '**/*.markdown'
+        - docs/**
+        - architecture/adrs/**
+        - .ground-control.yaml
+    provider: pre-commit-docs-format
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: docs-generic.root.lint
+    capability: lint
+    pack: docs-generic
+    cwd: .
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - '*.md'
+        - '**/*.md'
+        - '*.markdown'
+        - '**/*.markdown'
+        - docs/**
+        - architecture/adrs/**
+        - .ground-control.yaml
+    provider: markdown-policy
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: docs-generic.root.build
+    capability: build
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.type_safety
+    capability: type_safety
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.unit_tests
+    capability: unit_tests
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.integration_tests
+    capability: integration_tests
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.contract_boundary
+    capability: contract_boundary
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.property_verification
+    capability: property_verification
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.architecture
+    capability: architecture
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.complexity
+    capability: complexity
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.mutation
+    capability: mutation
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.diff_coverage
+    capability: diff_coverage
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.sast
+    capability: sast
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider: semgrep-config
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+    provider_missing: not_applicable
+  - id: docs-generic.root.secret_scan
+    capability: secret_scan
+    pack: docs-generic
+    cwd: .
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - '**/*'
+    provider: gitleaks-detect-private-key
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs --secrets-only
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: docs-generic.root.dependency_policy
+    capability: dependency_policy
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .github/workflows/**
+        - .pre-commit-config.yaml
+        - '**/*.yaml'
+        - '**/*.yml'
+    provider: workflow-policy
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs --workflows
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: docs-generic.root.accessibility
+    capability: accessibility
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: not_applicable
+    threshold:
+      metric: applicability
+      policy: not_applicable
+    thresholds:
+      platform_minimum:
+        metric: applicability
+        policy: not_applicable
+      recommendation:
+        metric: applicability
+        policy: not_applicable
+  - id: docs-generic.root.docs_policy
+    capability: docs_policy
+    pack: docs-generic
+    cwd: .
+    blocking: true
+    scope: changed
+    applies_when:
+      paths:
+        - '*.md'
+        - '**/*.md'
+        - '*.markdown'
+        - '**/*.markdown'
+        - docs/**
+        - architecture/adrs/**
+        - .ground-control.yaml
+    provider: vale-markdown-policy
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: docs-generic.root.traceability
+    capability: traceability
+    pack: docs-generic
+    cwd: .
+    blocking: false
+    scope: changed
+    applies_when:
+      paths:
+        - .__gc_never__/**
+    provider_missing: reviewer_fallback
+    threshold:
+      metric: provider_declared
+      policy: reviewer_fallback
+    thresholds:
+      platform_minimum:
+        metric: provider_declared
+        policy: reviewer_fallback
+      recommendation:
+        metric: provider_declared
+        policy: deterministic_provider_when_adopted
+  - id: docs-generic.root.policy
+    capability: policy
+    pack: docs-generic
+    cwd: .
+    blocking: true
+    scope: repo
+    applies_when:
+      paths:
+        - '**/*'
+    provider: repo-policy-or-doc-policy
+    command: node .gc/gate-packs/shifter/check-docs-baseline.mjs
+    threshold:
+      metric: exit_code
+      max: 0
+    thresholds:
+      platform_minimum:
+        metric: exit_code
+        max: 0
+      recommendation:
+        metric: exit_code
+        max: 0
+  - id: docs-generic.root.remote_status
+    capability: remote_status
+    pack: docs-generic
+    cwd: .
+    blocking: true
+    scope: repo
+    applies_when:
+      paths: []
+    provider: required-statuses
+    required_statuses:
+      - ci
+    threshold:
+      metric: required_statuses
+      policy: all_success
+    thresholds:
+      platform_minimum:
+        metric: required_statuses
+        policy: all_success
+      recommendation:
+        metric: required_statuses
+        policy: all_success

--- a/.gc/workflow-lock.json
+++ b/.gc/workflow-lock.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "engine": {
+    "version": "1.0.0",
+    "checksum": "sha256:0282a7f9afe425f6ed0e6025a0112b2cb1c7577a5a413a0401936d3210a12081",
+    "source_url": "workflow/releases/gc-engine-1.0.0.tgz",
+    "compatible": ">=1.0.0 <2.0.0",
+    "signer": "TODO: release signer",
+    "trust_policy": "checksum-only-development",
+    "installed_at": "2026-06-07T07:03:32.913Z"
+  },
+  "packs": [
+    {
+      "id": "python",
+      "version": "1.0.0",
+      "checksum": "sha256:6ab18b56ba2f15f7ac7d81227fb34fa69232df51d6501944b38f3eacac30a067",
+      "source_url": "workflow/releases/gc-gate-pack-python-1.0.0.tgz",
+      "compatible_engine": ">=1.0.0 <2.0.0",
+      "signer": "TODO: release signer",
+      "trust_policy": "checksum-only-development",
+      "installed_at": "2026-06-07T07:03:32.821Z"
+    },
+    {
+      "id": "docs-generic",
+      "version": "1.0.0",
+      "checksum": "sha256:c6b54812e78f69f5c60e360885013783416df7552f95f8a2351a0d42c2f25a27",
+      "source_url": "workflow/releases/gc-gate-pack-docs-generic-1.0.0.tgz",
+      "compatible_engine": ">=1.0.0 <2.0.0",
+      "signer": "TODO: release signer",
+      "trust_policy": "checksum-only-development",
+      "installed_at": "2026-06-07T07:03:32.913Z"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -474,6 +474,7 @@ CLAUDE.local.md
 # per-step telemetry). Tool-generated, ephemeral; .gc/plan-rules.md stays tracked.
 .gc/sonar/
 .gc/telemetry/
+.gc/vendor/
 
 temp/
 

--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -3,11 +3,24 @@ project: shifter
 github_repo: Brad-Edwards/shifter
 workflow:
   # shifter has no single-command test suite; CI runs many parallel jobs.
-  # lint_command is the single most useful local gate.
+  # lint_command remains the legacy local gate for agents that have not
+  # switched to the committed gate manifest yet.
   lint_command: python3 scripts/adr_guard/adr_guard.py --all --level ci
-  # test_command and completion_command intentionally omitted; the
-  # implement skill will fall back to asking the agent which sub-project
-  # to test. A follow-up can add a top-level runner script.
+  engine:
+    version: ^1.0.0
+  gate_manifest: .gc/gates.yaml
+  # Light consumer onboarding: use the Python platform root plus
+  # repository-level docs/policy checks. Existing Node packages continue to
+  # run through shifter's CI until a dedicated JS/TS pack adoption is scoped.
+  packs:
+    - id: python
+      version: ^1.0.0
+      scope: shifter/shifter_platform
+      profile: uv
+    - id: docs-generic
+      version: ^1.0.0
+      scope: .
+      profile: docs
 sonarcloud:
   project_key: Brad-Edwards_shifter
   organization: brad-edwards

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: gates
+
+gates:
+	node /home/atomik/src/Ground-Control/workflow/tools/run-gates.mjs --repo . --issue 1 --base origin/dev --head HEAD


### PR DESCRIPTION
## Summary

- Declares the portable workflow engine plus `python` scoped to `shifter/shifter_platform` and `docs-generic` at repo root.
- Installs committed gate-pack assets, `.gc/gates.yaml`, `.gc/workflow-lock.json`, and a `make gates` local runner.
- Binds blocking local gates to shifter's existing uv/ruff/Bandit/import-linter/ADR guard workflows and lightweight docs/policy wrappers.
- Keeps `.gc/vendor/` ignored so release artifacts are re-materialized instead of committed.

## Baselines

- Docs/policy baseline: 3 existing findings total, including 1 TODO marker and 2 private-key markers already accepted by repo policy.
- Python dependency baseline: 9 existing `uv audit` advisory IDs for Django/PyJWT; future unlisted advisory IDs still fail.
- Python type-safety baseline: 1 current mypy/Django plugin internal error; wrapper fails if that baseline no longer matches or different output appears.

## Validation

- `make gates` -> `ok: true`, `status: passed` against `origin/dev...HEAD`.
- `python3 scripts/adr_guard/adr_guard.py --all --level ci` -> passed.
- Commit hooks passed during commit/amend.