### PR TITLE
ci: stop code branches triggering deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,19 +151,12 @@ jobs:
           FAST_GCP_DEPLOY="false"
 
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            if [ "${{ github.base_ref }}" == "main" ]; then
-              AWS_ENV="prod"
-              AWS_IS_DEV="false"
-              RUN_AWS="true"
-            elif [ "${{ github.base_ref }}" == "aws-dev" ]; then
+            if [ "${{ github.base_ref }}" == "aws-dev" ]; then
               RUN_AWS="true"
             elif [ "${{ github.base_ref }}" == "gcp-dev" ]; then
               RUN_GCP="true"
-            elif [ "${{ github.base_ref }}" == "dev" ]; then
-              RUN_AWS="true"
-              RUN_GCP="true"
             fi
-          else
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             BRANCH="${GITHUB_REF#refs/heads/}"
             case "$BRANCH" in
               main)
@@ -184,6 +177,19 @@ jobs:
               dev)
                 RUN_AWS="true"
                 RUN_GCP="true"
+                ;;
+            esac
+          elif [ "${{ github.event_name }}" == "push" ]; then
+            BRANCH="${GITHUB_REF#refs/heads/}"
+            case "$BRANCH" in
+              aws-dev)
+                RUN_AWS="true"
+                APPLY_AWS="true"
+                ;;
+              gcp-dev)
+                RUN_GCP="true"
+                DEPLOY_GCP="true"
+                FAST_GCP_DEPLOY="true"
                 ;;
             esac
           fi
@@ -237,8 +243,8 @@ jobs:
     name: Quality
     needs: changes
     # Run Quality on PRs and direct pushes to `dev` only.
-    # Pushes to env branches (aws-dev, gcp-dev, main) only happen via merge
-    # from `dev` (per repo rule: env branches must never be ahead of dev),
+    # Pushes to deployment branches (aws-dev, gcp-dev) only happen via merge
+    # from `dev` (per repo rule: deploy branches must never be ahead of dev),
     # so the same SHA already passed Quality on its dev push and re-running
     # here is pure duplicate work. Deploy jobs already tolerate skipped
     # Quality via `(needs.quality.result == 'success' || ... == 'skipped')`.

--- a/changelog.d/892.fixed.md
+++ b/changelog.d/892.fixed.md
@@ -1,0 +1,3 @@
+**Code-branch merges no longer start deployment jobs.** `deploy.yml` now leaves
+deploy routing disabled for pull requests and pushes to `dev` or `main`; AWS/GCP
+deployment still runs from `aws-dev`, `gcp-dev`, or deliberate manual dispatch.

--- a/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
@@ -17,20 +17,24 @@ which coordinates:
 
 | Event | What Runs |
 |-------|-----------|
-| PR to any branch | Quality + Plan (no apply) |
-| Push to `dev` | Quality + AWS validation + GCP validation (no apply) |
+| PR to `dev` / `main` | Quality only; no deploy or Terraform plan jobs |
+| PR to `aws-dev` | Quality + AWS plan (no apply) |
+| PR to `gcp-dev` | Quality + GCP validate (no apply) |
+| Push to `dev` | Quality only; no deploy or Terraform plan jobs |
 | Push to `aws-dev` | Quality + AWS deploy to dev |
 | Push to `gcp-dev` | Fast GCP validation + GCP deploy |
-| Push to `main` | Quality + Plan + Apply to prod |
+| Push to `main` | Code branch update only; no deploy or Terraform plan jobs |
+| Manual dispatch on `main` | AWS prod deploy |
 
-PRs get Terraform plan comments. `dev` is the integration branch for
-cross-provider validation only. Dev deployments happen only from `aws-dev` and
+Deployment-branch PRs get Terraform plan comments. `dev` is the integration
+branch for Quality only. Dev deployments happen only from `aws-dev` and
 `gcp-dev`.
 
 `gcp-dev` pushes skip the global quality fan-out. The fast path still runs the
 provider-local guardrails in `_gcp-dev.yml`: Terraform fmt/init/validate plus
 rendered-manifest schema validation before deploy. Broad lint/test/security
-coverage runs on PRs, `dev`, and `main`.
+coverage runs on PRs and `dev`; production deployment is a deliberate manual
+dispatch from `main`.
 
 ## Workflow Files
 
@@ -78,7 +82,7 @@ The orchestrator uses path filters to run only relevant jobs:
 
 ## Quality Gate
 
-Runs on every PR and push:
+Runs on every PR and direct push to `dev`:
 
 - **ADR conformance**: `python3 scripts/adr_guard/adr_guard.py --all --level ci`
   Includes `adr-registry`, `layer-imports`, `cross-layer-model-imports`, and
@@ -151,25 +155,26 @@ After Terraform apply, AWS platform deployment:
 
 ```
 Branch/Target     → Behavior
-PR to dev         → AWS plan + GCP validate
+PR to dev         → Quality only
 PR to aws-dev     → AWS dev plan
 PR to gcp-dev     → GCP validate
-PR to main        → AWS prod plan
-Push to dev       → AWS plan + GCP validate
+PR to main        → Quality only
+Push to dev       → Quality only
 Push to aws-dev   → AWS dev deploy
 Push to gcp-dev   → Fast GCP validate + GCP deploy
-Push to main      → AWS prod deploy
+Push to main      → no deploy
+Dispatch on main  → AWS prod deploy
 ```
 
 ## Provider Routing
 
 `deploy.yml` resolves branch intent explicitly:
 
-- `dev` is the shared integration branch. It must validate both provider paths when shared code changes, but it must not apply infrastructure or deploy workloads.
+- `dev` is the shared integration branch. It runs the quality gate for shared code changes, but it must not plan/apply infrastructure or deploy workloads.
 - `aws-dev` is the only branch that deploys the AWS dev environment.
 - `gcp-dev` is the only branch that deploys the GCP dev environment, and it uses the narrow GCP fast path on branch pushes.
-- `main` remains the AWS production deploy branch.
-- Shared Shifter application changes trigger both the AWS validation chain and the GCP validation chain on `dev`, so provider overlaps are caught before promotion to either deploy branch.
+- `main` is the production code branch; production deploys run only through deliberate `workflow_dispatch`.
+- Shared Shifter application changes run Quality on `dev`; provider-specific deployment validation runs on the deployment branches before apply.
 - The GCP control plane is deployed through the Helm chart in `platform/charts/shifter`, with generated values layered on top of environment defaults.
 - The GCP portal auth contract is FirebaseUI/browser-side Identity Platform auth plus server-side verified-token exchange. Do not add Django credential handling to recreate Cognito semantics.
 - Multi-cloud work enters through the shared cloud adapter layers rather than provider-specific calls in domain services.
@@ -200,7 +205,7 @@ Terraform plans are also posted as PR comments.
 - Check branch protection rules
 - Verify path filters match your changes
 - Look for `paths-filter` in deploy.yml
-- Confirm you are pushing to the right branch for the intended behavior: `dev` validates only, `aws-dev` deploys AWS dev, `gcp-dev` deploys GCP dev
+- Confirm you are pushing to the right branch for the intended behavior: `dev` runs Quality only, `aws-dev` deploys AWS dev, `gcp-dev` deploys GCP dev, and prod deploys require manual dispatch on `main`
 
 ### Terraform Plan Fails
 - Check for formatting issues: `terraform fmt -recursive`

--- a/shifter/shifter_platform/documentation/docs/technical/dev/index.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/index.md
@@ -64,10 +64,10 @@ shifter/
 ## Git Workflow
 
 ```
-feature/* ──► dev ──► aws-dev ──► main
-              │        │          │
-              │        ▼          ▼
-              └──────► gcp-dev   prod env
+feature/* ──► dev ──► aws-dev ──► main ──workflow_dispatch──► prod env
+              │        │
+              │        ▼
+              └──────► gcp-dev
                        │
                        ▼
                     gcp dev env
@@ -77,7 +77,7 @@ feature/* ──► dev ──► aws-dev ──► main
 - **dev** - Integration, validation only
 - **aws-dev** - AWS dev deployment branch
 - **gcp-dev** - GCP dev deployment branch
-- **main** - Production, deploys to prod environment
+- **main** - Production code branch; prod deploys require manual dispatch
 
 All changes go through pull requests. Never commit directly to deploy branches.
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/principles.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/principles.md
@@ -36,8 +36,8 @@ If something is required, make it fail when missing.
 ## Git Discipline
 
 ### Branching
-- `main` is production - always deployable
-- `dev` is integration - validation only
+- `main` is the production code branch; production deploys require manual dispatch
+- `dev` is integration - Quality only, no deploy
 - `aws-dev` deploys the AWS dev environment
 - `gcp-dev` deploys the GCP dev environment through the narrow fast path
 - `feature/*` for development work

--- a/shifter/shifter_platform/documentation/docs/technical/dev/setup.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/setup.md
@@ -137,8 +137,9 @@ The CLI walks through each component, shows the plan, and asks for confirmation 
 
 **Via CI/CD:**
 
-Push to `main` to deploy the AWS production environment after bootstrap and
-backend configuration are complete.
+Run `Deploy` with `workflow_dispatch` on `main` to deploy the AWS production
+environment after bootstrap and backend configuration are complete. Pushing or
+merging to `main` updates the production code branch only; it does not deploy.
 
 **Manual deployment:**
 
@@ -203,7 +204,7 @@ Create a CNAME record pointing your domain to the ALB DNS name.
 The first deploy creates empty ECR repos. Push the portal container:
 
 ```bash
-# Via CI/CD: push to main triggers build
+# Via CI/CD: run Deploy with workflow_dispatch on main
 # Or manually:
 ./scripts/build-and-push.sh prod
 ```

--- a/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/cicd.md
+++ b/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/cicd.md
@@ -41,14 +41,15 @@ Jobs run only when relevant files change. `deploy.yml` detects changes and trigg
 
 ## Environment Targeting
 
-- Push to `dev` → validation only for AWS and GCP
+- Push to `dev` → Quality only; no deploy or Terraform plan jobs
 - Push to `aws-dev` → AWS dev deploy
 - Push to `gcp-dev` → fast GCP validate + GCP dev deploy
-- Push to `main` → AWS prod deploy
-- PRs to `dev` → cross-provider validation only
+- Push to `main` → code branch update only; no deploy or Terraform plan jobs
+- Manual dispatch on `main` → AWS prod deploy
+- PRs to `dev` → Quality only
 - PRs to `aws-dev` → AWS dev plan
 - PRs to `gcp-dev` → GCP validate
-- PRs to `main` → AWS prod plan only
+- PRs to `main` → Quality only
 
 ## Authentication
 
@@ -67,7 +68,7 @@ AWS roles defined in `platform/terraform/global/iam/github-oidc.tf`. GCP WIF con
 
 GCP now deploys through CI/CD on `gcp-dev`. The branch model is:
 
-- `dev`: validation-only integration branch for AWS and GCP
+- `dev`: Quality-only integration branch
 - `aws-dev`: AWS dev deploy branch
 - `gcp-dev`: GCP dev deploy branch
 
@@ -79,7 +80,7 @@ The GCP CI path:
 4. renders secure Helm values from Terraform outputs and Secret Manager
 5. installs or upgrades the Shifter Helm release
 
-On `gcp-dev` pushes, this path now runs as a fast deploy lane. It skips the repo-wide quality workflow and relies on the provider-local validation in `_gcp-dev.yml` so break/fix iteration on GCP does not wait for the full cross-repo lint/test matrix. The full quality gate still runs on `dev`, on PRs, and on production.
+On `gcp-dev` pushes, this path now runs as a fast deploy lane. It skips the repo-wide quality workflow and relies on the provider-local validation in `_gcp-dev.yml` so break/fix iteration on GCP does not wait for the full cross-repo lint/test matrix. The full quality gate still runs on PRs and on `dev`; production deploys are manual dispatches from `main`.
 
 The bootstrap path is security-gated and fails closed unless:
 

--- a/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/gcp-infrastructure.md
+++ b/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/gcp-infrastructure.md
@@ -100,7 +100,7 @@ GDC deployments use custom L2 networks (VXLAN-based) for per-range guest isolati
 
 The normal GCP deployment path is CI/CD:
 
-- push to `dev`: validate AWS and GCP paths, but do not deploy
+- push to `dev`: run Quality only; do not plan/apply infrastructure or deploy
 - push to `aws-dev`: deploy the AWS dev environment
 - push to `gcp-dev`: fast-validate and deploy the GCP dev environment
 
@@ -114,7 +114,7 @@ The GCP deploy flow executed by CI:
 6. installs or upgrades the Shifter chart
 7. waits for rollout and managed-certificate convergence
 
-`gcp-dev` intentionally skips the repo-wide quality workflow on branch pushes so GCP break/fix work can iterate quickly. The provider-local validation in `_gcp-dev.yml` remains mandatory before deploy, while the full lint/test/security matrix still runs on `dev`, on PRs, and on production.
+`gcp-dev` intentionally skips the repo-wide quality workflow on branch pushes so GCP break/fix work can iterate quickly. The provider-local validation in `_gcp-dev.yml` remains mandatory before deploy, while the full lint/test/security matrix still runs on PRs and on `dev`; production deploys are manual dispatches from `main`.
 
 `gdc-bootstrap` remains the operator bootstrap and recovery harness for first-time setup and controlled break-glass work, but it is no longer the normal deploy contract.
 


### PR DESCRIPTION
## Summary

- Stop `pull_request` and `push` events targeting `dev` or `main` from setting AWS/GCP deploy routes in `deploy.yml`.
- Preserve deploy behavior for `aws-dev`, `gcp-dev`, and deliberate `workflow_dispatch` runs, including prod dispatch from `main`.
- Update CI/CD docs and changelog to match the new code-branch/deploy-branch split.

Closes #892

## Verification

- `actionlint`
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- local env-routing truth table for PR/push/dispatch cases
