### PR TITLE
security: remediate platform dependency advisories

### DIFF
--- a/.gc/baselines/python-dependency-policy.json
+++ b/.gc/baselines/python-dependency-policy.json
@@ -4,51 +4,5 @@
   "gate_id": "python.shifter.shifter.platform.dependency_policy",
   "scope": "shifter/shifter_platform",
   "captured_from": "uv audit",
-  "findings": [
-    {
-      "id": "PYSEC-2026-197",
-      "package": "django",
-      "fixed_in": ["5.2.15", "6.0.6"]
-    },
-    {
-      "id": "PYSEC-2026-198",
-      "package": "django",
-      "fixed_in": ["5.2.15", "6.0.6"]
-    },
-    {
-      "id": "PYSEC-2026-199",
-      "package": "django",
-      "fixed_in": ["5.2.15", "6.0.6"]
-    },
-    {
-      "id": "PYSEC-2026-200",
-      "package": "django",
-      "fixed_in": ["5.2.15", "6.0.6"]
-    },
-    {
-      "id": "PYSEC-2026-201",
-      "package": "django",
-      "fixed_in": ["5.2.15", "6.0.6"]
-    },
-    {
-      "id": "PYSEC-2026-175",
-      "package": "pyjwt",
-      "fixed_in": ["2.13.0"]
-    },
-    {
-      "id": "PYSEC-2026-177",
-      "package": "pyjwt",
-      "fixed_in": ["2.13.0"]
-    },
-    {
-      "id": "PYSEC-2026-178",
-      "package": "pyjwt",
-      "fixed_in": ["2.13.0"]
-    },
-    {
-      "id": "PYSEC-2026-179",
-      "package": "pyjwt",
-      "fixed_in": ["2.13.0"]
-    }
-  ]
+  "findings": []
 }

--- a/changelog.d/895.security.md
+++ b/changelog.d/895.security.md
@@ -1,0 +1,4 @@
+**Baselined Django and PyJWT advisories are remediated.** The platform now
+requires Django 6.0.6 or newer and constrains transitive PyJWT resolution to
+2.13.0 or newer, allowing the dependency-policy baseline entries for issue 895
+to be cleared.

--- a/shifter/shifter_platform/pyproject.toml
+++ b/shifter/shifter_platform/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "channels",
     "channels-redis",
     "daphne",
-    "django>=6.0.4",
+    "django>=6.0.6",
     "django-encrypted-model-fields>=0.6.5",
     "django-health-check<5.0",
     "django-ses",
@@ -169,6 +169,7 @@ constraint-dependencies = [
     "virtualenv>=20.36.1",
     "pygments>=2.20.0",
     "requests>=2.33.0",
+    "pyjwt>=2.13.0",
 ]
 
 [tool.django-stubs]

--- a/shifter/shifter_platform/uv.lock
+++ b/shifter/shifter_platform/uv.lock
@@ -15,6 +15,7 @@ constraints = [
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "pyasn1", specifier = ">=0.6.3" },
     { name = "pygments", specifier = ">=2.20.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "ujson", specifier = ">=5.12.0" },
@@ -690,16 +691,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.5"
+version = "6.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/5b/1328f8b84fce040c404f76822bf8c57d254e368e8cbd8bd67ec2b26d75f5/django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0", size = 8368680, upload-time = "2026-05-05T13:54:33.532Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
 ]
 
 [[package]]
@@ -1802,11 +1803,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -2155,7 +2156,7 @@ requires-dist = [
     { name = "channels" },
     { name = "channels-redis" },
     { name = "daphne" },
-    { name = "django", specifier = ">=6.0.4" },
+    { name = "django", specifier = ">=6.0.6" },
     { name = "django-encrypted-model-fields", specifier = ">=0.6.5" },
     { name = "django-health-check", specifier = "<5.0" },
     { name = "django-ses" },


### PR DESCRIPTION
## Summary

Remediates the baselined platform dependency advisories by raising the Django floor to the fixed 6.0.6 release, constraining transitive PyJWT resolution to 2.13.0 or newer, regenerating the platform uv lockfile, and clearing the dependency-policy baseline now that `uv audit` is clean.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #895

## ADR Impact

- ADR-021

## Changes

- Raised the platform Django dependency floor from `>=6.0.4` to `>=6.0.6` and regenerated `uv.lock` to Django 6.0.6.
- Added a `pyjwt>=2.13.0` uv constraint so transitive OIDC/Firebase resolution cannot fall below the fixed PyJWT release.
- Cleared the nine remediated Django/PyJWT entries from `.gc/baselines/python-dependency-policy.json`.
- Added `changelog.d/895.security.md` for the security dependency remediation.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local validation passed: `uv audit`; dependency-policy baseline runner; `ruff format --check .`; `ruff check .`; `ruff check --select C901 .`; `lint-imports --config ../../.importlinter`; mypy baseline runner; Bandit; secret scan; platform pytest (`3723 passed`); `python3 scripts/adr_guard/adr_guard.py --all --level ci`; Codex pre-push review cycle; test-quality pre-push review cycle; and `pre-commit run --all-files`.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: Issue #895 ← shifter/shifter_platform/pyproject.toml, Issue #895 ← shifter/shifter_platform/uv.lock, Issue #895 ← .gc/baselines/python-dependency-policy.json

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/895.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.