### PR TITLE
docs: audit portal context-processor per-request cost (#852)

### DIFF
--- a/docs/architecture/portal-context-processor-audit-852.md
+++ b/docs/architecture/portal-context-processor-audit-852.md
@@ -1,0 +1,125 @@
+# Portal Context-Processor Cost Audit (#852)
+
+Status: diagnostic finding (analytical)
+
+Date: 2026-06-07
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/852>
+
+Companion preflight: [`portal-context-processor-preflight-852.md`](portal-context-processor-preflight-852.md)
+
+## Method and scope
+
+This audit is **analytical**: per-render database work is derived by reading
+the registered context processors and the service calls they make, and counting
+the ORM queries each issues. Query count is used as the cost proxy because every
+contributing processor is DB-bound (no CPU-heavy or network work beyond the
+engine ORM lookup). No empirical wall-time / p95 measurement was run; that was
+deliberately out of scope for this pass. The preflight note proposes a local
+`Client` + `CaptureQueriesContext` measurement harness as the empirical evidence
+bar — see [Decision](#ac3-decision-does-684-cover-this) for how that is routed.
+
+**Where context processors run.** Django template context processors execute
+**only on HTML template renders**. They do **not** run for:
+
+- DRF / JSON API responses,
+- the terminal WebSocket stream (`mission_control/consumers.py`),
+- any `JsonResponse`-based polling (range status, scoreboard refresh).
+
+So the per-request cost is paid on **full page navigations**, not on the
+high-frequency XHR/WebSocket traffic that dominates an active event session.
+This materially bounds the blast radius and is itself an AC#4 finding.
+
+## AC#1 — Per-render query cost
+
+Custom processors are registered in
+`shifter/shifter_platform/config/settings.py` (`TEMPLATES → OPTIONS →
+context_processors`, the four `mission_control` / `shared` / `ctf` entries).
+
+| Processor | Queries per authenticated render | Source |
+| --- | --- | --- |
+| `mission_control.active_range` | **1** baseline: latest `RangeInstance` (`filter(user_id).exclude(DESTROYING).order_by("-created_at").first()`). When a range exists: **+1** engine cross-layer (`_resolve_runtime_ips` → `engine.services.get_instance_ips_by_uuid` → `Range.objects.get(id)`), **+1** `instance.agent` FK, **+1** `instance.request` FK (no `select_related`), **+1** `is_ctf_participant_only`, **+1** `get_scenario` (registry, DB-first). → **1 (no range) … ~6 (ready range)** | `cms/services/_range_queries.py:225`, `cms/services/_common.py:227`, `engine/services/_range.py:358` |
+| `mission_control.terminal_cdn_assets` | **0** — returns a settings dict | `mission_control/context_processors.py:18` |
+| `shared.user_permissions` | **1** — `can_edit_cms_authoring` → `user.groups.filter(THREAT_RESEARCH).exists()`; **0** for staff (short-circuits before the query) | `shared/auth.py:60` |
+| `ctf.ctf_navigation` | `get_user_role`: **2** group `.exists()` + (participant) **1** `get_user_profile` `get_or_create` + **1** `CTFEvent…first()`; **plus** a second `is_ctf_participant_only` (**1**). → **~3 (non-participant) … ~5 (active participant)** | `ctf/bridges.py:29`, `shared/auth.py:38`, `management/services.py:59` |
+
+**Worst case = the live-event participant the issue is about** (CTF participant +
+active range + active event): **~12 queries per page render**. Participant
+without a range: ~7. Staff with a range: ~7.
+
+## AC#2 — Material contributors
+
+1. **`active_range`** — heaviest. Fans into the **engine layer** on every render
+   where a range exists, and does a 2-query FK **N+1** (`agent`, `request`) that
+   a single `select_related("agent", "request")` would erase.
+2. **`ctf_navigation`** — most queries for participants (group ×2 + profile +
+   event + a redundant `is_ctf_participant_only`).
+3. **Redundant `auth_user_groups` lookups** — `user.groups` is queried **5
+   separate times** per render and never cached:
+   `is_ctf_participant_only` (in `active_range`), `can_edit_cms_authoring` (in
+   `user_permissions`), two `get_user_role` `.exists()` calls, and a second
+   `is_ctf_participant_only` (in `ctf_navigation`). `is_ctf_participant_only`
+   is literally invoked **twice** per render. One request-scoped group fetch
+   collapses all five into one.
+4. `terminal_cdn_assets` and `user_permissions` are individually negligible
+   (0 and 1 query); the latter's single query is part of the group-lookup
+   redundancy above.
+
+## AC#4 — Where the global behaviour is genuinely required
+
+| Context | Required on | Not required on |
+| --- | --- | --- |
+| Full `active_range` payload (`RangeContext.instances`, runtime IP overlay, `connection_urls`, `terminal_instances`) | The terminal page (`mission_control/terminal.html`) | Everything else. The shared sidebar needs only a cheap `has_active_range` indicator, not the full payload. |
+| `has_active_range` indicator | Mission Control sidebar / dashboard banner | Anonymous, JSON, and WebSocket paths |
+| `ctf_navigation` role/event flags | Authenticated MC pages that render the CTF sidebar (`ctf/base.html`) | Anonymous, JSON, and WebSocket paths |
+| `user_permissions` (`can_access_threat_research`) | Pages rendering the Threat Research / CMS authoring links | Anonymous, JSON, and WebSocket paths |
+| `terminal_cdn_assets` | Terminal template only | Everywhere else (harmless — settings-only) |
+
+The architectural lever (deferred to follow-up, not done here): these are
+registered **globally and eagerly**. The full active-range payload is a
+terminal-page concern wrongly paid on every render. Note the preflight caveat —
+a `SimpleLazyObject` is **not** automatically cheaper if a globally-included
+template (e.g. `icon_sidebar.html`, `ctf/base.html`) reads the variable on every
+page; the real fix is page-scoped/tiered context (`none` / `nav` / `ctf` /
+`terminal_full`), not blind laziness.
+
+## AC#3 — Decision: does #684 cover this?
+
+**Partially. No, not on its own.**
+
+#684 ("Refactor Mission Control terminal and context god modules") has the
+acceptance criterion *"active_range() context assembly is extracted into a
+focused projection/service path"* — so it owns the **structural decomposition**
+of `active_range`. But #684 is a god-module refactor, not a per-request cost
+change. It does **not** cover:
+
+- the per-request laziness / page-scoping that stops non-terminal pages paying
+  for the full payload,
+- the redundant `auth_user_groups` lookups and the double `is_ctf_participant_only`,
+- the `select_related("agent", "request")` N+1 fix,
+- `ctf_navigation` / `user_permissions` cost,
+- the empirical measurement harness and safe-page documentation.
+
+These are small and independent of the god-module refactor, so they are routed
+to a dedicated follow-up issue (see below). #684 stays valid for the structural
+work; this audit does not subsume it.
+
+## Recommended follow-ups
+
+1. **Per-request context-processor cost reduction** (new issue): request-scope
+   the group lookups (collapses 5 → 1, removes the double
+   `is_ctf_participant_only`), add `select_related("agent", "request")` to
+   `get_active_range`, and make the full active-range payload terminal-page-scoped
+   rather than global (per the preflight's `none`/`nav`/`ctf`/`terminal_full`
+   seam). Land with the local `Client` + `CaptureQueriesContext` rendered-page
+   evidence the preflight specifies.
+2. #684 retains ownership of the `active_range` structural extraction.
+
+## Deviation note
+
+Per explicit direction on the tracking issue, this pass is **analytical only**.
+The preflight note sets an empirical evidence bar (rendered-page query/SQL/wall
+time + p50/p95 via `CaptureQueriesContext`). That empirical measurement is
+**deferred to the follow-up implementation issue** above, where the query-count
+reductions can be proven against rendered pages, rather than blocking this
+diagnostic/decision pass.

--- a/docs/architecture/portal-context-processor-preflight-852.md
+++ b/docs/architecture/portal-context-processor-preflight-852.md
@@ -1,0 +1,226 @@
+# Portal Context Processor Preflight (#852)
+
+Status: pre-implementation guidance
+
+Date: 2026-06-07
+
+Tracking issue: <https://github.com/Brad-Edwards/Shifter/issues/852>
+
+## Scope Boundary
+
+Issue #852 is diagnostic and design work. The shipping contract is to quantify
+the hidden per-rendered-request cost of portal context processors on event
+paths, identify material contributors, decide whether #684 is enough, and
+document where global context is truly required.
+
+This is not a portal scaling, terminal websocket, or ASGI process-manager
+change. Adjacent ownership stays with:
+
+- #851 for portal health, overload observability, and autoscaling signals.
+- #847 for terminal websocket capacity and runtime placement.
+- #174 for the production ASGI process manager.
+- #684 for Mission Control terminal/context module refactoring only where that
+  refactor explicitly covers the measured context construction work.
+
+## Architecture Decisions
+
+- Treat context construction as request-path work, not as a harmless template
+  detail. Measurement must run through rendered pages with `request=` so Django
+  invokes the same context processors and included sidebars as production.
+- Keep domain boundaries intact. Mission Control presentation code may call
+  `cms.services`; CTF role/range integration stays through `ctf.bridges` and
+  CTF services; CMS and Engine stay presentation-free.
+- The current full active-range payload is a terminal-page concern. The global
+  sidebar needs at most an active-range indicator, not `RangeContext.instances`,
+  runtime private IP overlay, `connection_urls`, or `terminal_instances`.
+- Role/navigation context is a navigation concern. Do not create a second CTF
+  role schema or duplicate group/profile/event logic to make one page faster.
+- Default optimization posture is request-scoped reuse or page-scoped context,
+  not cross-request caching. Cross-request caches for roles, range state, or
+  runtime IPs are stale and security-sensitive unless a follow-up explicitly
+  owns invalidation.
+- #684 covers #852 only if it lands evidence-backed changes to active-range /
+  terminal context construction. CTF navigation cost, rendered-page
+  measurement, and safe-page documentation are separate unless #684 is amended
+  to include them.
+- No new ADR is required before measurement. If a follow-up introduces a new
+  metrics framework, cache policy, public diagnostic endpoint, or new context
+  ownership abstraction, that follow-up should add or update architecture docs.
+
+## Current Context Surface
+
+Global template context processors are registered in
+`shifter/shifter_platform/config/settings.py` under `TEMPLATES`.
+
+| Processor | Current work | Safe global need |
+| --- | --- | --- |
+| `mission_control.context_processors.active_range` | For authenticated users, calls `cms.services.get_active_range()`, may join CMS range rows with engine runtime IPs, filters instances for CTF-only users, may call `get_scenario()`, and builds terminal JSON payloads. | Full payload is required by `mission_control/terminal.html`. The sidebar only needs a cheap `has_active_range` indicator. |
+| `mission_control.context_processors.terminal_cdn_assets` | Reads `TERMINAL_CDN_ASSETS` from settings. | Safe to leave global because it is settings-only; only terminal templates need it. |
+| `shared.context_processors.user_permissions` | Calls `shared.auth.can_edit_cms_authoring()` for sidebar visibility. | Required by the shared Mission Control sidebar for Threat Research/CMS links. |
+| `ctf.context_processors.ctf_navigation` | Calls `ctf.bridges.get_user_role()`, which checks Django groups and may resolve `UserProfile.active_ctf_event_id` plus `CTFEvent`. | Required by `ctf/base.html` and sidebars for CTF navigation decisions. |
+
+Representative rendered pages for evidence:
+
+- Mission Control: dashboard, terminal with no active range, terminal with a
+  provisioning range, terminal with a ready range.
+- CTF participant event paths: dashboard, event, challenges, challenge detail,
+  range, scoreboard, team.
+- Anonymous/auth paths: login/session-backed pages as a no-DB context baseline.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #852 |
+| --- | --- | --- |
+| Global context registration | `config/settings.py` `TEMPLATES[...]["context_processors"]` | Change global registration only with rendered-page tests proving every included template still gets required context. |
+| Active range ownership/query | `cms.services.get_active_range()`, `_validate_caller_user()`, `RangeInstance` ownership filter | Keep user ownership in CMS services. Do not move range authorization into templates, JavaScript, or request path checks. |
+| Range/instance shape | `shared.schemas.RangeContext`, `InstanceContext`, `mission_control.utils.build_connection_urls()` | Reuse the existing template-safe DTO and URL builder for full terminal payloads; no parallel terminal DTO. |
+| Runtime IP overlay | `cms.services._common._resolve_runtime_ips()` and `_instance_contexts_from_range_spec()` | Keep runtime IP lookup best-effort and joined by instance UUID. Do not duplicate range-spec flattening. |
+| CTF role context | `ctf.bridges.UserRole`, `get_user_role()`, `shared.auth` group constants | Reuse the existing role bridge and predicates. Do not invent a second role object or group-name literals. |
+| CTF participant/event resolution | `ctf.views._get_active_participant()`, `_get_participant_for_challenge()`, CTF services | Preserve active-event scoping for multi-event users; do not replace it with unscoped first-row participant lookups. |
+| CMS authoring permissions | `shared.auth.can_edit_cms_authoring()` and `shared.context_processors.user_permissions()` | Keep the Threat Research/staff policy in `shared.auth`; no duplicate permission checks in templates. |
+| Template JSON safety | Django `json_script`, `RangeContext` / `InstanceContext` validators | Continue embedding terminal payloads through `json_script`; no inline JSON interpolation. |
+| Logging | `config.logging.ECSFormatter`, `shared.log_sanitize.safe_log_value()` | Measurements/logs use aggregate counts, route names, user IDs, and sanitized IDs only. |
+| Error envelopes | `shared.errors.UserFacingError`, `safe_user_message()`, `classify_user_message()` | Any HTTP diagnostic surface must use authored messages; context processor failures stay fail-soft and logged server-side. |
+| Tests | Existing context/template tests plus Django `Client`, `RequestFactory`, `CaptureQueriesContext` | Add rendered-page evidence in the existing pytest/Django style rather than a one-off script that bypasses context processors. |
+| Import boundaries | `.importlinter` contracts | Mission Control must not import CTF; CTF must not import Mission Control or Engine; CMS must not import presentation layers. |
+
+## Cross-Cutting Layers
+
+- Auth surface: rendered portal pages enter through Django middleware,
+  `AuthenticationMiddleware`, `@login_required`, CTF decorators, and request
+  user objects. Anonymous users must keep the current fast empty-context
+  behavior. Any page-scoped or lazy context decision must be server-derived from
+  the view/template need, never from a query string, header, or client flag.
+- Authorization surface: active-range data must still come through
+  `cms.services.get_active_range(user)` or a CMS-owned lower-cost equivalent
+  that enforces the same user ownership. CTF navigation must still use
+  `ctf.bridges.get_user_role()` and active-event scoping. Templates and
+  JavaScript are consumers, not policy gates.
+- Secret-handling surface: context data may include internal private IPs,
+  instance UUIDs, websocket paths, role flags, and event IDs. These are
+  authorized UI data, not secrets, but they must not be exposed on anonymous
+  pages or logged in raw per-user detail. Do not log cookies, session IDs,
+  signed Guacamole URLs, Redis URLs, DB settings, SSH material, or full process
+  environments while measuring.
+- Env/config surface: global context registration lives in Django settings.
+  Avoid adding env knobs for this diagnostic. If a later follow-up adds one, it
+  must use the existing settings helpers and provider renderers, and it must be
+  non-secret.
+- Validation surface: keep using `RangeContext` / `InstanceContext` Pydantic
+  validators, including private-IP normalization, and CMS user validators. Do
+  not add a duplicate schema just to model partial context.
+- OS/runtime exposure: measurement artifacts should be local test output,
+  sanitized logs, or documentation. Do not introduce a public endpoint, shell
+  command with secret-bearing argv, or process/environment dump to collect query
+  counts.
+- Error-envelope surface: context processors currently fail soft to empty
+  context and log exceptions. Preserve that browser-facing behavior unless a
+  follow-up deliberately changes a page-level contract. Any user-visible
+  diagnostic response must use authored error text from `shared.errors`.
+- Observability surface: use ECS-formatted logs and sanitized IDs for any
+  temporary or permanent measurement logging. A new metrics emitter is out of
+  scope for #852 and belongs under the #851 capacity-signal contract.
+- Persistence surface: no schema, migration, audit table, or durable event log
+  is needed for this diagnostic. Store evidence in tests/docs/artifacts, not in
+  portal database tables.
+- Template/XSS surface: terminal JSON stays in `json_script`; private IPs and
+  instance names continue to pass through Django escaping and DTO validation.
+
+## Extensibility Seam
+
+The seam is context scope and depth, parameterized by server-owned page need:
+
+- `none`: anonymous or pages that do not need authenticated navigation state.
+- `nav`: role flags, `can_access_threat_research`, and a cheap active-range
+  indicator for shared sidebars.
+- `ctf`: CTF role plus active event for CTF navigation and participant views.
+- `terminal_full`: full `RangeContext`, scenario name, connection URLs,
+  terminal instance JSON, and runtime private IP overlay.
+
+Keep that seam out of CMS/Engine model logic. CMS services may expose domain
+queries, but they should not know template names, paths, or sidebar behavior.
+Future pages should be able to opt into a deeper context without re-editing the
+range projection, role bridge, or template payload schema.
+
+## Evidence Bar
+
+The measurement artifact that closes #852 should report, at minimum:
+
+- Query count, SQL time, and wall time for each global context processor on the
+  representative rendered pages above.
+- The same measurements for no active range, provisioning range, and ready range
+  with runtime IP state.
+- Service-call attribution for `get_active_range()`, runtime IP lookup,
+  `get_scenario()`, `get_user_role()`, `get_user_profile()`, CTF event lookup,
+  and group membership queries.
+- p50/p95 context construction time over repeated rendered requests, with warm
+  and cold-ish DB/queryset states called out if both are captured.
+- A table of pages where each context field is required: full terminal context,
+  active-range indicator, CTF nav flags, CMS authoring permission, or none.
+- A decision statement: #684 covers the measured work, or specific follow-up
+  issues are needed for active-range scoping, CTF role reuse, measurement
+  harness hardening, or safe-context documentation.
+
+## Gotchas
+
+- A lazy object is not automatically cheaper. If `icon_sidebar.html` or
+  `ctf/base.html` touches it on every page, the same DB work still happens.
+- `ctf_navigation` and CTF participant views both resolve role/active-event
+  context today. Measure duplicate group/profile/event work before choosing a
+  request-scoped reuse point.
+- `active_range` mutates `range_context.instances` when filtering CTF-only
+  users. Reusing the same `RangeContext` object across independent consumers or
+  requests would make that mutation dangerous.
+- Runtime IP lookup is best-effort and can hide engine/CMS cost behind a
+  successful page render. Count service calls, not only SQL queries.
+- `mission_control.dashboard.html` uses CTF-only flags for view-only behavior,
+  but it does not need full terminal payload construction.
+- `ctf/participant/range.html` already does explicit range target lookup in the
+  view. Do not mix that page-scoped range data with global Mission Control
+  terminal context.
+- Broad cross-request caching of role or range context can leak stale access
+  after group, active-event, participant status, or range lifecycle changes.
+  Prefer request-scope reuse unless a follow-up owns invalidation.
+- Import-linter forbids the tempting shortcut of centralizing all context in a
+  shared helper that imports every app.
+
+## Anti-Patterns
+
+- Passing `request.path`, template names, or a "needs terminal" flag into CMS or
+  Engine services.
+- Moving ownership/range/status/role checks into templates, JavaScript, or a
+  client-selectable context flag.
+- Creating duplicate range DTOs, CTF role schemas, permission helpers,
+  exception hierarchies, logging formatters, metrics frameworks, or validation
+  layers.
+- Treating query count alone as proof. Runtime service calls, wall time, p95,
+  and duplicate group/profile/event work matter too.
+- Making active-range context globally lazy and declaring success without
+  rendered-page measurements showing fewer queries/service calls.
+- Adding a public diagnostic endpoint for query counts or p95 timing.
+- Logging raw emails, signed Guacamole URLs, cookies, session data, Redis auth
+  URLs, DB credentials, private keys, request bodies, or raw exception text.
+- Weakening `.importlinter`, ADR guard, CSRF/session auth, CTF decorators, or
+  template escaping to simplify measurement.
+
+## Non-Goals
+
+- No implementation, context processor rewrite, cache, middleware, settings
+  change, endpoint, schema change, or database migration in this preflight.
+- No redesign of portal autoscaling, health probes, Daphne/Gunicorn runtime,
+  terminal websocket transport, Guacamole bootstrap, CTF scoring, or range
+  provisioning.
+- No new Ground Control requirement; the GitHub issue is the source of truth.
+- No new repo-wide metrics, logging, exception, schema, or auth framework.
+
+## Validation
+
+For this preflight documentation change, run:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+```
+
+Implementation follow-ups must also run the stack-native checks for changed
+surfaces, especially import-linter for Python package-boundary changes and
+targeted pytest suites for rendered context/template behavior.


### PR DESCRIPTION
## Summary

Analytical cost audit of the four global portal context processors (issue #852 — diagnostic/decision pass). Adds two docs under `docs/architecture/`: the codex preflight guardrails and the analytical query-count audit answering AC#1-4.

## Findings

- Context processors run **only on HTML page renders**, not JSON/WebSocket paths — cost is per navigation, not per poll.
- 3 of 4 custom processors hit the DB/services on every authenticated render.
- `active_range` is heaviest: fans into the engine layer + a 2-query `agent`/`request` FK N+1.
- `user.groups` is queried **5×** per render (never cached); `is_ctf_participant_only` runs twice.
- Worst case ~12 queries/render for a live-event CTF participant.

## AC#3 decision — scope ownership

#852's deliverable is this analytical audit plus the scope decision. Implementation ownership is split, not held open:

- **#684** owns the `active_range` structural extraction (its existing acceptance criterion).
- **#898** owns the per-request cost reductions (group-lookup dedup, `select_related`, terminal-page-scoping), `ctf_navigation` / `user_permissions` cost, and the empirical `Client` + `CaptureQueriesContext` measurement.

Per direction on the issue, #852 is an analytical pass; empirical rendered-page measurement is part of #898's evidence bar.

Closes #852