### PR TITLE
Prepare Polaris aws-dev standalone range

### DIFF
--- a/scenario-dev/polaris/README.md
+++ b/scenario-dev/polaris/README.md
@@ -85,7 +85,14 @@ first instead of assuming the older design prose is correct.
 
 ## Getting started
 
-1. **Deploy** — on the range host (ctf-range-builder GCP VM):
+For AWS standalone/default-VPC bring-up, use
+[`scripts/polaris-aws-range/README.md`](../../scripts/polaris-aws-range/README.md).
+That path provisions the Ubuntu range host and A2 Windows DC in AWS, then runs
+the same `tests/` validation scripts over SSM.
+
+Legacy local-compose flow:
+
+1. **Deploy** — on the range host:
    ```
    rsync -a scenario-dev/polaris/ ctf-range-builder:/home/atomik/range/
    ssh ctf-range-builder 'bash /home/atomik/range/tests/setup.sh'
@@ -95,7 +102,7 @@ first instead of assuming the older design prose is correct.
    ```
    ssh ctf-range-builder 'bash /home/atomik/range/tests/run-all-smoketests.sh'
    ```
-   Expected: `16 / 16 asset sweeps PASS`, `NORTHSTORM full range: PASS`.
+   Expected: all listed asset sweeps pass and `NORTHSTORM full range: PASS`.
    Infrastructure-level: per-asset connectivity + cross-cutting network
    isolation. Does not verify CTFd challenge content.
 
@@ -121,7 +128,7 @@ first instead of assuming the older design prose is correct.
 |--------|--------------------------|---------------------|-----|
 | A0     | shared                   | a14-kali            | a14 is on shared |
 | A1     | corporate                | a14-kali            | a14 is on corporate |
-| A2     | external GCP VM          | a14-kali            | routed via host |
+| A2     | adjacent Windows VM      | a14-kali            | routed via host/VPC |
 | A3     | corporate                | a14-kali            | a14 reaches on corporate |
 | A4     | corporate                | a14-kali            | a14 is on corporate |
 | A5     | scada (VLAN 40)          | a15-ops-eng         | only A15 reaches scada |

--- a/scenario-dev/polaris/build/A4-file-share/build_documents.py
+++ b/scenario-dev/polaris/build/A4-file-share/build_documents.py
@@ -495,7 +495,7 @@ def server_inventory():
         cell.fill = header_fill
 
     data = [
-        ("dc01.boreas.local", "172.20.10.10", 10, "Windows Server 2022", "4 vCPU", "8 GB", "100 GB", "Domain Controller", "d.kowalski"),
+        ("dc01.boreas.local", "resolve via DNS", "range subnet", "Windows Server 2022", "4 vCPU", "8 GB", "100 GB", "Domain Controller", "d.kowalski"),
         ("mail.boreas.local", "172.20.10.20", 10, "Debian 12", "2 vCPU", "4 GB", "50 GB", "Postfix/Dovecot/Roundcube", "d.kowalski"),
         ("intranet.boreas.local", "172.20.10.30", 10, "Debian 12", "2 vCPU", "4 GB", "30 GB", "Flask wiki/CMS", "d.kowalski"),
         ("fileserv.boreas.local", "172.20.10.40", 10, "Debian 12", "2 vCPU", "4 GB", "200 GB", "Samba file shares", "d.kowalski"),

--- a/scenario-dev/polaris/build/a14/entrypoint.sh
+++ b/scenario-dev/polaris/build/a14/entrypoint.sh
@@ -35,6 +35,9 @@ if [[ -n "${KALI_SPLICE_PRIVATE_KEY_B64:-}" ]]; then
     printf '%s' "$KALI_SPLICE_PRIVATE_KEY_B64" | base64 -d > /home/kali/.ssh/splice_relay
     chown kali:kali /home/kali/.ssh/splice_relay
     chmod 600 /home/kali/.ssh/splice_relay
+    install -d -m 700 /root/.ssh
+    cp /home/kali/.ssh/splice_relay /root/.ssh/splice_relay
+    chmod 600 /root/.ssh/splice_relay
 
     config_file=/home/kali/.ssh/config
     if ! [[ -f "$config_file" ]] || ! grep -q '^Host splice-relay' "$config_file"; then
@@ -49,6 +52,20 @@ Host splice-relay
 CFG_EOF
         chown kali:kali "$config_file"
         chmod 600 "$config_file"
+    fi
+
+    root_config_file=/root/.ssh/config
+    if ! [[ -f "$root_config_file" ]] || ! grep -q '^Host splice-relay' "$root_config_file"; then
+        cat >> "$root_config_file" <<'CFG_EOF'
+
+Host splice-relay
+    User root
+    IdentityFile ~/.ssh/splice_relay
+    IdentitiesOnly yes
+    StrictHostKeyChecking accept-new
+    UserKnownHostsFile ~/.ssh/known_hosts
+CFG_EOF
+        chmod 600 "$root_config_file"
     fi
 fi
 

--- a/scenario-dev/polaris/build/dns/db.boreas-systems.ctf
+++ b/scenario-dev/polaris/build/dns/db.boreas-systems.ctf
@@ -15,7 +15,7 @@ lab-dc  IN      A       172.20.30.10
 eng-ws01 IN     A       172.20.30.10
 researchdb IN   A       172.20.30.30
 fileserv IN     A       172.20.10.40
-dc01    IN      A       10.1.100.11
+dc01    IN      A       __DC01_IP__
 @       IN      MX  10  mail.boreas-systems.ctf.
 @       IN      TXT     "v=spf1 ip4:172.20.10.0/24 ip4:172.20.30.0/24 -all"
 _flag   IN      TXT     "FLAG{5e9c2a0f73b148d6}"

--- a/scenario-dev/polaris/build/dns/entrypoint.sh
+++ b/scenario-dev/polaris/build/dns/entrypoint.sh
@@ -1,13 +1,10 @@
 #!/bin/sh
 # POLARIS dns container entrypoint.
 #
-# Substitutes the __DC01_IP__ placeholder in the boreas.local zone file
-# with the value of the DC01_IP environment variable (set by
-# docker-compose.override.yml on the host). Without this the zone file
-# would hard-code the single-range .11 address and every range would
-# resolve dc01.boreas.local to range 0's DC — same domain name in every
-# range forest is fine because AD is isolated, but the IN-A record
-# must be per-range.
+# Substitutes the __DC01_IP__ placeholder in DNS zone files with the value of
+# the DC01_IP environment variable set by docker-compose.override.yml on the
+# host. The domain name is intentionally the same in every range forest because
+# AD is isolated, but the IN-A records must be per-range.
 set -eu
 
 if [ -z "${DC01_IP:-}" ]; then
@@ -15,10 +12,11 @@ if [ -z "${DC01_IP:-}" ]; then
     exit 1
 fi
 
-ZONE=/etc/bind/db.boreas.local
-if grep -q "__DC01_IP__" "$ZONE"; then
-    sed -i "s|__DC01_IP__|${DC01_IP}|g" "$ZONE"
-    echo "dns entrypoint: dc01.boreas.local -> ${DC01_IP}"
-fi
+for ZONE in /etc/bind/db.boreas.local /etc/bind/db.boreas-systems.ctf; do
+    if grep -q "__DC01_IP__" "$ZONE"; then
+        sed -i "s|__DC01_IP__|${DC01_IP}|g" "$ZONE"
+        echo "dns entrypoint: ${ZONE} dc01 -> ${DC01_IP}"
+    fi
+done
 
 exec named -g -c /etc/bind/named.conf

--- a/scenario-dev/polaris/build/docker-compose.yml
+++ b/scenario-dev/polaris/build/docker-compose.yml
@@ -14,10 +14,10 @@
 #   A7:  shared + lab (reachable from both Kali and Lab)
 #   DNS: shared + corporate + lab (name resolution everywhere)
 #
-# A2 (Windows Server 2022 AD DC for boreas.local) is an EC2 instance
-# adjacent to the docker-compose host, at 10.1.100.11 in the range VPC.
-# Reachable from the compose corporate network via the host's iptables
-# MASQUERADE path (docker bridge -> host eth0 -> VPC).
+# A2 (Windows Server 2022 AD DC for boreas.local) is an EC2 instance adjacent
+# to the docker-compose host in the range subnet. The bootstrap path rewrites
+# DNS to the current range's A2 private IP. A2 is reachable from compose
+# networks via the host's iptables MASQUERADE path.
 
 networks:
   shared:

--- a/scenario-dev/polaris/tests/isolation-smoketest.sh
+++ b/scenario-dev/polaris/tests/isolation-smoketest.sh
@@ -5,31 +5,26 @@
 # network boundaries: every attack path the design says MUST work,
 # works; every path the design says MUST NOT work, fails.
 #
-# Runs from the range host (ctf-range-builder). Uses `docker exec`
-# into each source container and python3 sockets to probe TCP
-# reachability — python3 is present on every relevant container
+# Runs from the range host. Uses `docker exec` into each source container and
+# python3 sockets to probe TCP reachability — python3 is present on every relevant container
 # (alpine, debian, kali) which is not true for bash /dev/tcp.
 #
 # Usage:
-#     bash /home/atomik/range/isolation-smoketest.sh
+#     bash tests/isolation-smoketest.sh
 #
 # Exits 0 on full pass, 1 on any failure.
 
 set -u
 
-# A2 DC IP. Default to the production range-VPC pinned address (`.11` in
-# the polaris /28 carved by `scripts/polaris-aws-range/`), but resolve
-# `dc01.boreas.local` from inside the dns container if available so the
-# test works in any account / VPC layout where the DC isn't pinned to
-# 10.1.100.11. Earlier this was hardcoded to 10.1.100.11 which made the
-# test fail in any non-production VPC bake even when the DC was
-# perfectly healthy.
+# A2 DC IP. Resolve `dc01.boreas.local` from inside the dns container so the
+# test works in any account / VPC layout where the Windows DC is not pinned to
+# a legacy range address.
 A2_DC_IP="${A2_DC_IP:-}"
 if [[ -z "$A2_DC_IP" ]]; then
     A2_DC_IP="$(docker exec dns dig +short @127.0.0.1 dc01.boreas.local 2>/dev/null | head -n1)"
 fi
 if [[ -z "$A2_DC_IP" ]]; then
-    A2_DC_IP="10.1.100.11"  # production fallback
+    A2_DC_IP="10.1.100.11"  # legacy fallback
     echo "[isolation] WARN: dc01.boreas.local did not resolve via dns container — falling back to $A2_DC_IP" >&2
 fi
 echo "[isolation] A2 DC IP: $A2_DC_IP"
@@ -73,12 +68,12 @@ must_not_reach() {
 }
 
 echo "NORTHSTORM network isolation smoketest"
-echo "Topology: shared/corporate/scada/lab/bunker-ot bridges + A2 VM at 10.100.0.4"
+echo "Topology: shared/corporate/scada/lab/bunker-ot bridges + A2 VM at $A2_DC_IP"
 
 # =============================================================================
 # A14 Kali (shared + corporate)
-# Design: can reach A0, A1, A3, A4, A7, A2 (GCP VM), DNS. Cannot reach lab,
-# scada, or bunker-ot directly — must pivot through A3.
+# Design: can reach A0, A1, A3, A4, A7, A2, DNS. Cannot reach lab, scada, or
+# bunker-ot directly.
 # =============================================================================
 echo
 echo "=== a14-kali (shared+corporate) ==="

--- a/scenario-dev/polaris/tests/reset.sh
+++ b/scenario-dev/polaris/tests/reset.sh
@@ -8,13 +8,15 @@
 # miss real regressions.
 #
 # Usage:
-#     bash /home/atomik/range/reset.sh
+#     bash tests/reset.sh
 #     RANGE_DIR=/other bash reset.sh
 #
 # Exits 0 when sticky services are recreated and responding.
 
 set -euo pipefail
-RANGE_DIR="${RANGE_DIR:-/home/atomik/range}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_RANGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RANGE_DIR="${RANGE_DIR:-$DEFAULT_RANGE_DIR}"
 COMPOSE_FILE="${COMPOSE_FILE:-$RANGE_DIR/build/docker-compose.yml}"
 if [[ ! -f "$COMPOSE_FILE" ]] && [[ -f "$RANGE_DIR/docker-compose.yml" ]]; then
     COMPOSE_FILE="$RANGE_DIR/docker-compose.yml"

--- a/scenario-dev/polaris/tests/run-all-smoketests.sh
+++ b/scenario-dev/polaris/tests/run-all-smoketests.sh
@@ -7,13 +7,15 @@
 # and exits non-zero on any failure.
 #
 # Usage:
-#     bash /home/atomik/range/run-all-smoketests.sh
+#     bash tests/run-all-smoketests.sh
 #     RANGE_DIR=/other bash run-all-smoketests.sh
 #
 # Exits 0 only if every asset sweep AND the isolation sweep pass.
 
 set -u
-RANGE_DIR="${RANGE_DIR:-/home/atomik/range}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_RANGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RANGE_DIR="${RANGE_DIR:-$DEFAULT_RANGE_DIR}"
 cd "$RANGE_DIR"
 
 # asset|runner|smoketest path (relative to $SMOKETESTS_DIR)|interpreter

--- a/scenario-dev/polaris/tests/scenario_smoketest/adapters/mission5_bunker.py
+++ b/scenario-dev/polaris/tests/scenario_smoketest/adapters/mission5_bunker.py
@@ -50,7 +50,7 @@ _SSH_REMOTE_PREFIX = (
     _SPLICE_TARGET,
 )
 
-_PRODUCT_NAME_RE = re.compile(r"^ProductName:\s*(\S+)\s*$", re.MULTILINE)
+_PRODUCT_NAME_RE = re.compile(r"^\s*ProductName:\s*(\S+)\s*$", re.MULTILINE)
 
 
 def _extract_product_name(devid_body: str) -> str | None:

--- a/scenario-dev/polaris/tests/setup.sh
+++ b/scenario-dev/polaris/tests/setup.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 # NORTHSTORM range setup: build all images and bring up the full topology.
 #
-# Runs from the range host (ctf-range-builder). Assumes docker-compose.yml
-# and all content dirs are already synced to $RANGE_DIR (default
-# /home/atomik/range) from the repo.
+# Runs from the range host. Assumes docker-compose.yml and all content dirs are
+# already synced to $RANGE_DIR, which defaults to this script's parent range
+# directory.
 #
 # Usage:
-#     bash /home/atomik/range/setup.sh
+#     bash tests/setup.sh
 #     RANGE_DIR=/some/other/path bash setup.sh
 #
 # Exits 0 on successful bring-up + readiness, 1 on any failure.
 
 set -euo pipefail
-RANGE_DIR="${RANGE_DIR:-/home/atomik/range}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_RANGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RANGE_DIR="${RANGE_DIR:-$DEFAULT_RANGE_DIR}"
 COMPOSE_FILE="${COMPOSE_FILE:-$RANGE_DIR/build/docker-compose.yml}"
 # Legacy flat-layout fallback: if new location doesn't exist, try $RANGE_DIR/docker-compose.yml
 if [[ ! -f "$COMPOSE_FILE" ]] && [[ -f "$RANGE_DIR/docker-compose.yml" ]]; then

--- a/scenario-dev/polaris/tests/smoketests/A14-smoketest.sh
+++ b/scenario-dev/polaris/tests/smoketests/A14-smoketest.sh
@@ -86,7 +86,7 @@ echo
 echo "--- Network reach: permitted targets ---"
 # A14 is on shared (172.20.0.0/24), corporate (172.20.10.0/24), and the
 # pre-wired splice-link to A9. Should reach A0 (shared), A1/A3/A4/A15/A16
-# (corporate), DNS (shared), A2 (GCP VM via host route), A9 (splice-link).
+# (corporate), DNS (shared), A2 (adjacent Windows DC), A9 (splice-link).
 # A7 Gitea is lab-only and NOT directly reachable from A14 — participants
 # must pivot through A16 to clone from Gitea.
 for label_host_port in \

--- a/scenario-dev/polaris/tests/smoketests/A2-smoketest.sh
+++ b/scenario-dev/polaris/tests/smoketests/A2-smoketest.sh
@@ -2,9 +2,9 @@
 # A2 Windows Domain Controller smoketest.
 #
 # Runs every flag path from an attacker's perspective against the live
-# boreas.local DC (Windows Server 2022 at 10.1.100.11 / dc01.boreas.local). Intended to
-# be executed from inside the a14-kali container. Every assertion mirrors
-# what a participant would do in a walkthrough.
+# boreas.local DC (Windows Server 2022 at dc01.boreas.local). Intended to be
+# executed from inside the a14-kali container. Every assertion mirrors what a
+# participant would do in a walkthrough.
 #
 # Usage (from the range host):
 #     docker cp smoketest.sh a14-kali:/tmp/a2-smoke.sh
@@ -59,12 +59,23 @@ tcp_open() {
     timeout 2 bash -c "exec 3<>/dev/tcp/$1/$2" 2>/dev/null && return 0 || return 1
 }
 
+tcp_open_retry() {
+    local host="$1" port="$2" attempts="${3:-15}" delay="${4:-4}" n
+    for n in $(seq 1 "$attempts"); do
+        if tcp_open "$host" "$port"; then
+            return 0
+        fi
+        sleep "$delay"
+    done
+    return 1
+}
+
 echo "A2 smoketest - target=$DC_HOST ($DC_IP) domain=$DOMAIN"
 
 echo
 echo "--- Port sweep: 53, 88, 135, 389, 445, 464, 636, 3268 ---"
 for p in 53 88 135 389 445 464 636 3268; do
-    if tcp_open "$DC_IP" "$p"; then pass "tcp/$p open"; else fail "tcp/$p not reachable"; fi
+    if tcp_open_retry "$DC_IP" "$p"; then pass "tcp/$p open"; else fail "tcp/$p not reachable"; fi
 done
 
 echo

--- a/scenario-dev/polaris/tests/test_scenario_smoketest.py
+++ b/scenario-dev/polaris/tests/test_scenario_smoketest.py
@@ -570,9 +570,9 @@ _M5_KEY_PATH = "/home/kali/.ssh/splice_relay"
 _M5_RUNNER = "a14-kali"
 _M5_EXPECTED_ANSWER = "AHS-TAIL-7741AHS-LEG-MN07AHS-ARM-AL42"
 _M5_DEVID_BODIES = {
-    "tail-ctrl": "VendorName: Aurora\nProductName: AHS-TAIL-7741\nMajorMinorRevision: 2.4\n",
-    "leg-ctrl": "VendorName: Aurora\nProductName: AHS-LEG-MN07\nMajorMinorRevision: 2.4\n",
-    "arms-ctrl": "VendorName: Aurora\nProductName: AHS-ARM-AL42\nMajorMinorRevision: 2.4\n",
+    "tail-ctrl": "Device Identification:\n  VendorName: Aurora\n  ProductName: AHS-TAIL-7741\n  MajorMinorRevision: 2.4\n",
+    "leg-ctrl": "Device Identification:\n  VendorName: Aurora\n  ProductName: AHS-LEG-MN07\n  MajorMinorRevision: 2.4\n",
+    "arms-ctrl": "Device Identification:\n  VendorName: Aurora\n  ProductName: AHS-ARM-AL42\n  MajorMinorRevision: 2.4\n",
 }
 
 

--- a/scenario-dev/polaris/tests/walkthroughs/00-range-access-docker.md
+++ b/scenario-dev/polaris/tests/walkthroughs/00-range-access-docker.md
@@ -1,6 +1,9 @@
 # Range Access — Docker Compose Environment
 
-Everything runs as containers on `ctf-range-builder` (10.100.0.5) in GCP project `prod-rwctxzl6shxk`, zone `us-east4-a`.
+The scenario runs as Docker containers on a Polaris Ubuntu host. A2 is a
+separate Windows Server 2022 VM in the same AWS /28 range subnet as the Ubuntu
+host. Historical test ranges used `ctf-range-builder`; AWS standalone ranges
+use SSM into the Polaris host.
 
 ## How to Connect
 
@@ -21,7 +24,7 @@ The Kali container is on two networks: `shared` (172.20.0.x) and `corporate` (17
 | A4 File Share | fileserv.boreas.local | 172.20.10.40 | 445 | `smbclient //172.20.10.40/Public` |
 | A15 Ops Eng | ops-eng01.boreas.local | 172.20.10.50 | 22, 80 | Pivot host for SCADA (flag 37 gate) |
 | A16 Research Analyst | analyst01.boreas.local | 172.20.10.60 | 22, 8080 | Pivot host for Lab + Gitea (flag 38) |
-| A2 Windows DC | dc01.boreas.local | 10.1.100.11 | 53, 88, 135, 389, 445, 464, 636, 3268, 3269, 49152-65535 | Windows Server 2022 AD DC in the range VPC (adjacent to the docker host) — reachable from Kali via `dc01.boreas.local` through the compose DNS forwarder |
+| A2 Windows DC | dc01.boreas.local | per-range AWS private IP | 53, 88, 135, 389, 445, 464, 636, 3268, 3269, 49152-65535 | Windows Server 2022 AD DC in the same AWS /28 range subnet as the Docker host; resolve `dc01.boreas.local` from Kali instead of hardcoding an IP |
 
 ### What Kali CANNOT reach (requires pivot)
 
@@ -64,28 +67,30 @@ The Kali container uses 172.20.0.2 as its DNS server. Hostnames like `boreas-sys
 
 ## Managing the Range
 
-From the builder VM (not inside Kali). The range source lives at
-`/home/atomik/range/` (mirror of `scenario-dev/polaris/` in the repo),
-so the compose file is at `$RANGE_DIR/build/docker-compose.yml` and all
-orchestration goes through the scripts in `$RANGE_DIR/tests/`:
+From the Polaris Ubuntu host over SSM (not inside Kali). In AWS standalone
+ranges the range source lives at `/opt/polaris/scenario-dev/polaris/`, so the
+compose file is at `$RANGE_DIR/build/docker-compose.yml` and all orchestration
+goes through the scripts in `$RANGE_DIR/tests/`:
 
 ```bash
-# Full setup: build + up + wait ready
-bash /home/atomik/range/tests/setup.sh
+export RANGE_DIR=/opt/polaris/scenario-dev/polaris
 
-# Run the full smoketest sweep (15 asset smoketests + isolation)
-bash /home/atomik/range/tests/run-all-smoketests.sh
+# Full setup: build + up + wait ready
+bash "$RANGE_DIR/tests/setup.sh"
+
+# Run the full smoketest sweep (asset smoketests + isolation)
+bash "$RANGE_DIR/tests/run-all-smoketests.sh"
 
 # Reset sticky-state services (a5/a10/a11/a12/a13) between test runs or
 # before handing to a new participant
-bash /home/atomik/range/tests/reset.sh
+bash "$RANGE_DIR/tests/reset.sh"
 
 # Raw docker compose commands. Project name defaults to "build" (the
 # parent dir of docker-compose.yml) which matches the production
 # user_data path and the polaris-splice-watcher's default
 # SPLICE_NETWORK=build_splice-link. Always cd into build/ first or pass
 # `-f` and let docker derive project=build from the file's parent dir.
-cd /home/atomik/range/build
+cd "$RANGE_DIR/build"
 docker compose ps
 docker compose down
 docker compose build a12-arms

--- a/scenario-dev/polaris/tests/walkthroughs/flags-07-19-front-office.md
+++ b/scenario-dev/polaris/tests/walkthroughs/flags-07-19-front-office.md
@@ -2,7 +2,7 @@
 
 > **Start here:** Read [00-range-access-docker.md](00-range-access-docker.md) for how to access the Docker compose range. All commands run FROM INSIDE the Kali container (`sudo docker exec -it a14-kali /bin/bash`).
 
-These flags come from the intranet (A3 at **172.20.10.30**), mail server (A1 at **172.20.10.20**), file share (A4 at **172.20.10.40**), domain controller (A2 at **10.1.100.11**, dc01.boreas.local — live Windows Server 2022 AD DC in the range VPC), and SCADA system (A5 at **172.20.40.10** web:8080 / **172.20.40.10:502** Modbus, scada network VLAN 40). All are live services — connect to them over the network, not via files on disk.
+These flags come from the intranet (A3 at **172.20.10.30**), mail server (A1 at **172.20.10.20**), file share (A4 at **172.20.10.40**), domain controller (A2 at **dc01.boreas.local** — live Windows Server 2022 AD DC in the range subnet), and SCADA system (A5 at **172.20.40.10** web:8080 / **172.20.40.10:502** Modbus, scada network VLAN 40). All are live services — connect to them over the network, not via files on disk.
 
 ---
 

--- a/scripts/polaris-aws-range/README.md
+++ b/scripts/polaris-aws-range/README.md
@@ -1,0 +1,127 @@
+# Polaris AWS Standalone Range
+
+This directory provisions a standalone Polaris/NORTHSTORM range: one Ubuntu
+Docker host plus one Windows Server 2022 A2 domain controller per range index.
+
+## aws-dev default VPC bring-up
+
+Use this path for the no-SSO `aws-dev` account in `us-east-2` when the range
+must live in the account default VPC, not the Shifter range VPC or portal VPC.
+
+1. Confirm the target account and default VPC:
+
+   ```bash
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 aws sts get-caller-identity
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 aws ec2 describe-vpcs \
+     --filters Name=is-default,Values=true
+   ```
+
+2. Build a tarball that includes both runtime content and tests. The build
+   directory is enough for `user_data`, but `tests/` must be present on the EC2
+   host if you want to run the smoke/capture checks via SSM.
+
+   ```bash
+   python -m pip install --quiet reportlab
+   out="$(mktemp -d)"
+   python scenario-dev/polaris/build/A0-boreas-website/build_pdfs.py "$out"
+   python scenario-dev/polaris/build/verify_flags_baked.py \
+     scenario-dev/polaris/build/ctfd-challenges.json "$out"
+   tar czf /tmp/polaris-build.tar.gz \
+     scenario-dev/polaris/build \
+     scenario-dev/polaris/tests
+   ```
+
+3. Create or reuse a private S3 bucket in aws-dev and upload the tarball:
+
+   ```bash
+   bucket=shifter-polaris-bake-dev-741140496509
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 aws s3api create-bucket \
+     --bucket "$bucket" \
+     --create-bucket-configuration LocationConstraint=us-east-2
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 aws s3api put-public-access-block \
+     --bucket "$bucket" \
+     --public-access-block-configuration \
+       BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 aws s3 cp \
+     /tmp/polaris-build.tar.gz \
+     "s3://${bucket}/polaris/build-aws-dev-default-vpc.tar.gz"
+   ```
+
+4. Apply Terraform from this directory. For the current aws-dev default VPC the
+   local values are:
+
+   ```hcl
+   aws_profile        = "aws-dev"
+   aws_region         = "us-east-2"
+   name_prefix        = "polaris-dev-default"
+   deployment_purpose = "default-vpc-standalone"
+
+   range_vpc_id           = "vpc-02c81b9b197f058b1"
+   polaris_cidr_block     = "172.31.240.0/24"
+   availability_zone      = "us-east-2a"
+   egress_route_target    = "igw"
+   internet_gateway_id    = "igw-0a4c93d3a0ac0463e"
+   portal_vpc_cidr        = ""
+   portal_peering_id      = ""
+   management_ingress_cidrs = []
+   publish_kali_host_ports  = false
+
+   build_tarball_bucket = "shifter-polaris-bake-dev-741140496509"
+   build_tarball_s3_uri = "s3://shifter-polaris-bake-dev-741140496509/polaris/build-aws-dev-default-vpc.tar.gz"
+   ```
+
+   Keep the values in `local.auto.tfvars` or another ignored tfvars file, then:
+
+   ```bash
+   terraform init
+   terraform apply
+   terraform output -json
+   ```
+
+5. Wait for the Ubuntu host bootstrap marker over SSM. Poll for the marker
+   instead of sleeping for a fixed duration:
+
+   ```bash
+   polaris_id="$(terraform output -json range_polaris_instance_ids | jq -r '."0"')"
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 aws ec2 wait instance-status-ok \
+     --instance-ids "$polaris_id"
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 aws ssm send-command \
+     --instance-ids "$polaris_id" \
+     --document-name AWS-RunShellScript \
+     --parameters 'commands=["grep -c \"polaris bootstrap complete\" /var/log/polaris-bootstrap.log || true"]'
+   ```
+
+6. Promote and populate the A2 DC after Terraform creates the Windows instance:
+
+   ```bash
+   a2_id="$(terraform output -json range_a2_instance_ids | jq -r '."0"')"
+   AWS_PROFILE=aws-dev AWS_REGION=us-east-2 ./a2_cold_bootstrap_parallel.sh "$a2_id"
+   ```
+
+7. Validate from the Polaris host via SSM:
+
+   ```bash
+   cd /opt/polaris/scenario-dev/polaris/tests
+   bash run-all-smoketests.sh
+   python3 -m scenario_smoketest --only 1,2,3,4,5,6,31 \
+     --json-report /tmp/polaris-scenario-smoketest.json
+   ```
+
+   `run-all-smoketests.sh` is the full infrastructure and capture sweep. The
+   full `scenario_smoketest` command intentionally fails today because only the
+   registered adapters are executable; use `--only` for the covered challenge
+   ids until adapter coverage is complete.
+
+## Networking notes
+
+Default-VPC mode creates Polaris-owned /28 subnets inside the default VPC. The
+instances receive public IPs for outbound SSM and package/build traffic, but
+the security group has no public inbound management ingress by default. Use SSM
+for operator access. Only set `management_ingress_cidrs` when SSH/RDP from a
+known operator CIDR is required. Keep `publish_kali_host_ports = false` unless
+portal/Guacamole needs the host-level A14 SSH/RDP mappings and the security
+group has matching restricted ingress.
+
+The older private range-VPC path is still available by setting
+`egress_route_target = "nat"`, `nat_gateway_id`, `range_vpc_id`,
+`polaris_cidr_block`, and optional portal peering variables explicitly.

--- a/scripts/polaris-aws-range/a2_cold_bootstrap.sh
+++ b/scripts/polaris-aws-range/a2_cold_bootstrap.sh
@@ -13,11 +13,12 @@
 #
 #   ./scripts/polaris-aws-range/a2_cold_bootstrap.sh i-xxxxxxxxxxxxxxxxx
 #
-# Requires: aws cli with panw-shifter-dev-workstation profile access to SSM.
+# Requires: aws cli with profile access to SSM. For aws-dev use
+# AWS_PROFILE=aws-dev AWS_REGION=us-east-2.
 
 set -euo pipefail
 
-AWS_PROFILE="${AWS_PROFILE:-panw-shifter-dev-workstation}"
+AWS_PROFILE="${AWS_PROFILE:-aws-dev}"
 AWS_REGION="${AWS_REGION:-us-east-2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 A2_ID="${1:-}"

--- a/scripts/polaris-aws-range/a2_cold_bootstrap_parallel.sh
+++ b/scripts/polaris-aws-range/a2_cold_bootstrap_parallel.sh
@@ -13,7 +13,7 @@
 #
 # Environment overrides (same as a2_cold_bootstrap.sh):
 #
-#   AWS_PROFILE (default: panw-shifter-dev-workstation)
+#   AWS_PROFILE (default: aws-dev)
 #   AWS_REGION  (default: us-east-2)
 #   POLARIS_BOOTSTRAP_LOG_DIR (default: /tmp/polaris-bootstrap-<epoch>)
 #
@@ -28,7 +28,7 @@
 
 set -uo pipefail
 
-AWS_PROFILE="${AWS_PROFILE:-panw-shifter-dev-workstation}"
+AWS_PROFILE="${AWS_PROFILE:-aws-dev}"
 AWS_REGION="${AWS_REGION:-us-east-2}"
 export AWS_PROFILE AWS_REGION
 

--- a/scripts/polaris-aws-range/check_range_health.py
+++ b/scripts/polaris-aws-range/check_range_health.py
@@ -37,13 +37,13 @@ in batches, and writes the report.
 
 Usage::
 
-    python3 check_range_health.py --profile panw-shifter-dev-workstation
+    python3 check_range_health.py --profile aws-dev
 
     # full per-range detail table (not just issues)
-    python3 check_range_health.py --profile panw-shifter-dev-workstation --verbose
+    python3 check_range_health.py --profile aws-dev --verbose
 
     # write report to an explicit path
-    python3 check_range_health.py --profile panw-shifter-dev-workstation \\
+    python3 check_range_health.py --profile aws-dev \\
         --output /tmp/health.md
 """
 

--- a/scripts/polaris-aws-range/main.tf
+++ b/scripts/polaris-aws-range/main.tf
@@ -1,9 +1,14 @@
 #------------------------------------------------------------------------------
-# POLARIS test range — N parallel ranges inside the existing dev range VPC,
-# each one an Ubuntu polaris VM running the docker-compose stack plus a
-# Windows Server 2022 DC for BOREAS.LOCAL. Every range lives in its own
-# /28 subnet with pinned private IPs (.10 polaris, .11 DC) so compose zone
-# files and the a2_setup.ps1 contract work unchanged for any N.
+# POLARIS test range — N parallel standalone ranges in a target AWS VPC.
+# The default operator path is the aws-dev default VPC with public-IP SSM
+# egress; the older private range-VPC/NAT path remains available by setting
+# range_vpc_id, polaris_cidr_block, egress_route_target="nat", nat_gateway_id,
+# and optional portal peering/ingress values.
+#
+# Each range gets an Ubuntu polaris VM running the docker-compose stack plus
+# a Windows Server 2022 DC for BOREAS.LOCAL. Every range lives in its own /28
+# subnet with pinned private IPs (.10 polaris, .11 DC) so compose zone files
+# and the a2_setup.ps1 contract work unchanged for any N.
 #
 # Shared resources (security group, IAM role, instance profile) live in
 # shared.tf so a single copy drives all N ranges — bypasses the per-VPC
@@ -20,15 +25,80 @@
 #------------------------------------------------------------------------------
 
 locals {
-  name_prefix = "polaris-bake"
+  name_prefix = var.name_prefix
+
+  target_vpc_id        = trimspace(var.range_vpc_id) != "" ? var.range_vpc_id : data.aws_vpc.default.id
+  target_vpc_cidr      = data.aws_vpc.target.cidr_block
+  polaris_cidr_block   = trimspace(var.polaris_cidr_block) != "" ? var.polaris_cidr_block : cidrsubnet(local.target_vpc_cidr, 8, 240)
+  ubuntu_ami_id        = trimspace(var.ubuntu_ami_id) != "" ? var.ubuntu_ami_id : data.aws_ami.ubuntu_noble.id
+  a2_dc_ami_id         = trimspace(var.a2_dc_ami_id) != "" ? var.a2_dc_ami_id : data.aws_ami.windows_2022.id
+  internet_gateway_id  = trimspace(var.internet_gateway_id) != "" ? var.internet_gateway_id : one(data.aws_internet_gateway.target[*].id)
+  aws_cli_profile_args = trimspace(coalesce(var.aws_profile, "")) == "" ? "" : "--profile ${var.aws_profile} "
 
   # Per-range subnet + IP plan. For each range index, carve a /28 out of
   # var.polaris_cidr_block and pin polaris .10 / a2 .11 inside it.
   range_subnets = {
     for idx in var.range_indices : idx => {
-      cidr       = cidrsubnet(var.polaris_cidr_block, 4, tonumber(idx))
-      polaris_ip = cidrhost(cidrsubnet(var.polaris_cidr_block, 4, tonumber(idx)), 10)
-      a2_ip      = cidrhost(cidrsubnet(var.polaris_cidr_block, 4, tonumber(idx)), 11)
+      cidr       = cidrsubnet(local.polaris_cidr_block, 4, tonumber(idx))
+      polaris_ip = cidrhost(cidrsubnet(local.polaris_cidr_block, 4, tonumber(idx)), 10)
+      a2_ip      = cidrhost(cidrsubnet(local.polaris_cidr_block, 4, tonumber(idx)), 11)
     }
+  }
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_vpc" "target" {
+  id = local.target_vpc_id
+}
+
+data "aws_internet_gateway" "target" {
+  count = var.egress_route_target == "igw" && trimspace(var.internet_gateway_id) == "" ? 1 : 0
+
+  filter {
+    name   = "attachment.vpc-id"
+    values = [local.target_vpc_id]
+  }
+}
+
+data "aws_ami" "ubuntu_noble" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+data "aws_ami" "windows_2022" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["Windows_Server-2022-English-Full-Base-*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
   }
 }

--- a/scripts/polaris-aws-range/outputs.tf
+++ b/scripts/polaris-aws-range/outputs.tf
@@ -30,6 +30,11 @@ output "range_polaris_private_ips" {
   value       = { for k, i in aws_instance.polaris : k => i.private_ip }
 }
 
+output "range_polaris_public_ips" {
+  description = "polaris VM public IP per range index when associate_public_ip_address is true."
+  value       = { for k, i in aws_instance.polaris : k => i.public_ip }
+}
+
 output "range_a2_instance_ids" {
   description = "A2 Windows DC EC2 instance id per range index."
   value       = { for k, i in aws_instance.a2_dc : k => i.id }
@@ -38,6 +43,11 @@ output "range_a2_instance_ids" {
 output "range_a2_private_ips" {
   description = "A2 Windows DC private IP per range index (pinned to .11 of the subnet)."
   value       = { for k, i in aws_instance.a2_dc : k => i.private_ip }
+}
+
+output "range_a2_public_ips" {
+  description = "A2 Windows DC public IP per range index when associate_public_ip_address is true."
+  value       = { for k, i in aws_instance.a2_dc : k => i.public_ip }
 }
 
 output "range_security_group_ids" {
@@ -54,8 +64,8 @@ output "ssm_session_commands" {
   description = "aws ssm start-session commands per range, pre-formatted for copy-paste."
   value = {
     for k in var.range_indices : k => {
-      polaris = "aws --profile panw-shifter-dev-workstation --region us-east-2 ssm start-session --target ${aws_instance.polaris[k].id}"
-      a2_dc   = "aws --profile panw-shifter-dev-workstation --region us-east-2 ssm start-session --target ${aws_instance.a2_dc[k].id}"
+      polaris = "aws ${local.aws_cli_profile_args}--region ${var.aws_region} ssm start-session --target ${aws_instance.polaris[k].id}"
+      a2_dc   = "aws ${local.aws_cli_profile_args}--region ${var.aws_region} ssm start-session --target ${aws_instance.a2_dc[k].id}"
     }
   }
 }

--- a/scripts/polaris-aws-range/ranges.tf
+++ b/scripts/polaris-aws-range/ranges.tf
@@ -12,27 +12,27 @@
 resource "aws_subnet" "polaris" {
   for_each = local.range_subnets
 
-  vpc_id            = var.range_vpc_id
+  vpc_id            = local.target_vpc_id
   cidr_block        = each.value.cidr
   availability_zone = var.availability_zone
 
-  map_public_ip_on_launch = false
+  map_public_ip_on_launch = var.map_public_ip_on_launch
 
   tags = {
     Name    = "${local.name_prefix}-subnet-${each.key}"
     Project = "polaris"
-    Purpose = "bake"
+    Purpose = var.deployment_purpose
     Range   = each.key
   }
 }
 
-# Dedicated route table per range that bypasses the range Network Firewall
-# (which only allowlists GCP/Cortex IPs, not Docker Hub / apt archives).
-# Egress path: POLARIS subnet -> NAT gateway -> IGW.
+# Dedicated route table per range. Default-VPC standalone mode uses IGW
+# egress so SSM, Docker Hub, apt, and S3 work without NAT. The older
+# private range-VPC mode can still use NAT by setting egress_route_target=nat.
 resource "aws_route_table" "polaris" {
   for_each = local.range_subnets
 
-  vpc_id = var.range_vpc_id
+  vpc_id = local.target_vpc_id
 
   tags = {
     Name    = "${local.name_prefix}-rt-${each.key}"
@@ -41,18 +41,26 @@ resource "aws_route_table" "polaris" {
   }
 }
 
-resource "aws_route" "polaris_default" {
-  for_each = local.range_subnets
+resource "aws_route" "polaris_default_igw" {
+  for_each = var.egress_route_target == "igw" ? local.range_subnets : {}
+
+  route_table_id         = aws_route_table.polaris[each.key].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = local.internet_gateway_id
+}
+
+resource "aws_route" "polaris_default_nat" {
+  for_each = var.egress_route_target == "nat" ? local.range_subnets : {}
 
   route_table_id         = aws_route_table.polaris[each.key].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = var.nat_gateway_id
 }
 
-# Keep portal-to-range reachability (so the Shifter portal terminal UI +
-# Guacamole can hit the kali container's published ports).
+# Optional portal-to-range reachability (so the Shifter portal terminal UI +
+# Guacamole can hit the kali container's published ports in peered deployments).
 resource "aws_route" "polaris_portal_peering" {
-  for_each = local.range_subnets
+  for_each = trimspace(var.portal_peering_id) != "" && trimspace(var.portal_vpc_cidr) != "" ? local.range_subnets : {}
 
   route_table_id            = aws_route_table.polaris[each.key].id
   destination_cidr_block    = var.portal_vpc_cidr
@@ -84,9 +92,9 @@ resource "aws_route_table_association" "polaris" {
 resource "aws_security_group" "polaris" {
   for_each = local.range_subnets
 
-  vpc_id      = var.range_vpc_id
+  vpc_id      = local.target_vpc_id
   name        = "${local.name_prefix}-sg-${each.key}"
-  description = "POLARIS range ${each.key} - intra-${each.value.cidr} + portal-peering only"
+  description = "POLARIS range ${each.key} - intra-${each.value.cidr} + optional management ingress"
 
   ingress {
     description = "Intra-range /28 traffic (polaris VM to A2 DC and docker host-network Kali)"
@@ -96,20 +104,48 @@ resource "aws_security_group" "polaris" {
     cidr_blocks = [each.value.cidr]
   }
 
-  ingress {
-    description = "SSH from portal VPC (terminal UI key-auth)"
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = [var.portal_vpc_cidr]
+  dynamic "ingress" {
+    for_each = trimspace(var.portal_vpc_cidr) == "" ? [] : [var.portal_vpc_cidr]
+    content {
+      description = "SSH from portal VPC (terminal UI key-auth)"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
   }
 
-  ingress {
-    description = "RDP from portal VPC (Guacamole)"
-    from_port   = 3389
-    to_port     = 3389
-    protocol    = "tcp"
-    cidr_blocks = [var.portal_vpc_cidr]
+  dynamic "ingress" {
+    for_each = trimspace(var.portal_vpc_cidr) == "" ? [] : [var.portal_vpc_cidr]
+    content {
+      description = "RDP from portal VPC (Guacamole)"
+      from_port   = 3389
+      to_port     = 3389
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = toset(var.management_ingress_cidrs)
+    content {
+      description = "Operator SSH management"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = toset(var.management_ingress_cidrs)
+    content {
+      description = "Operator RDP management"
+      from_port   = 3389
+      to_port     = 3389
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
   }
 
   egress {
@@ -137,14 +173,14 @@ resource "aws_security_group" "polaris" {
 resource "aws_instance" "polaris" {
   for_each = local.range_subnets
 
-  ami                    = var.ubuntu_ami_id
+  ami                    = local.ubuntu_ami_id
   instance_type          = var.instance_type
   subnet_id              = aws_subnet.polaris[each.key].id
   private_ip             = each.value.polaris_ip
   vpc_security_group_ids = [aws_security_group.polaris[each.key].id]
   iam_instance_profile   = aws_iam_instance_profile.polaris.name
 
-  associate_public_ip_address = false
+  associate_public_ip_address = var.associate_public_ip_address
 
   metadata_options {
     http_tokens                 = "required"
@@ -152,9 +188,10 @@ resource "aws_instance" "polaris" {
   }
 
   user_data = templatefile("${path.module}/user_data.sh.tpl", {
-    tarball_s3_uri      = var.build_tarball_s3_uri
-    kali_authorized_key = var.kali_authorized_key
-    a2_private_ip       = each.value.a2_ip
+    tarball_s3_uri          = var.build_tarball_s3_uri
+    kali_authorized_key     = var.kali_authorized_key
+    a2_private_ip           = each.value.a2_ip
+    publish_kali_host_ports = var.publish_kali_host_ports
   })
 
   user_data_replace_on_change = true
@@ -190,14 +227,14 @@ resource "aws_instance" "polaris" {
 resource "aws_instance" "a2_dc" {
   for_each = local.range_subnets
 
-  ami                    = var.a2_dc_ami_id
+  ami                    = local.a2_dc_ami_id
   instance_type          = var.a2_instance_type
   subnet_id              = aws_subnet.polaris[each.key].id
   private_ip             = each.value.a2_ip
   vpc_security_group_ids = [aws_security_group.polaris[each.key].id]
   iam_instance_profile   = aws_iam_instance_profile.polaris.name
 
-  associate_public_ip_address = false
+  associate_public_ip_address = var.associate_public_ip_address
 
   get_password_data = false
 

--- a/scripts/polaris-aws-range/reset.sh
+++ b/scripts/polaris-aws-range/reset.sh
@@ -17,7 +17,7 @@
 #
 # Usage (from operator):
 #
-#   aws --profile panw-shifter-dev-workstation --region us-east-2 \
+#   aws --profile aws-dev --region us-east-2 \
 #     ssm send-command \
 #     --instance-ids <polaris-vm-id> \
 #     --document-name AWS-RunShellScript \
@@ -28,7 +28,7 @@
 
 set -euo pipefail
 
-BUILD_TARBALL_S3_URI="${BUILD_TARBALL_S3_URI:-s3://shifter-polaris-bake-158151907940/polaris/build-v1.tar.gz}"
+BUILD_TARBALL_S3_URI="${BUILD_TARBALL_S3_URI:-s3://shifter-polaris-bake-dev-741140496509/polaris/build-aws-dev-default-vpc.tar.gz}"
 POLARIS_ROOT="${POLARIS_ROOT:-/opt/polaris}"
 BUILD_DIR="${POLARIS_ROOT}/scenario-dev/polaris/build"
 REBUILD_SERVICES="${REBUILD_SERVICES:-dns a14-kali a16-research-analyst}"

--- a/scripts/polaris-aws-range/user_data.sh.tpl
+++ b/scripts/polaris-aws-range/user_data.sh.tpl
@@ -1,8 +1,9 @@
 #!/bin/bash
 # POLARIS bake-range bootstrap
 # Installs Docker + docker-compose, pulls the polaris build tarball from S3,
-# edits docker-compose.yml to publish Kali's 22 + 3389 to the EC2 host,
-# then `docker compose up -d` so the whole range comes online.
+# edits docker-compose.override.yml for the range-specific A2 DC, optionally
+# publishes Kali's 22 + 3389 to the EC2 host, then `docker compose up -d` so
+# the whole range comes online.
 set -euo pipefail
 exec > >(tee /var/log/polaris-bootstrap.log) 2>&1
 
@@ -23,10 +24,20 @@ done
 apt-get update
 apt-get install -y \
     docker.io \
-    awscli \
     jq \
     unzip \
-    curl
+    curl \
+    ca-certificates \
+    openssh-client
+
+# Ubuntu 24.04 no longer reliably exposes awscli v1 as an apt package.
+# Install AWS CLI v2 from Amazon's zip so first-boot S3 fetch works on
+# current public Ubuntu images as well as older shifter-ubuntu images.
+rm -rf /tmp/awscliv2 /tmp/awscliv2.zip
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" \
+    -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
+/tmp/awscliv2/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
 
 systemctl enable --now docker
 
@@ -45,7 +56,7 @@ chmod +x /usr/libexec/docker/cli-plugins/docker-compose
 # that we publish to the host for portal Terminal UI + Guacamole RDP.
 # Disable + mask all of them before docker compose up so first boot is
 # clean. Operator access to the VM is via SSM Session Manager, not host ssh.
-for svc in ssh xrdp xrdp-sesman apache2 smbd nmbd mysql vsftpd; do
+for svc in ssh ssh.socket sshd sshd.socket xrdp xrdp-sesman apache2 smbd nmbd mysql vsftpd; do
     systemctl disable --now "$svc" 2>/dev/null || true
     systemctl mask "$svc" 2>/dev/null || true
 done
@@ -74,36 +85,70 @@ tar xzf polaris-build.tar.gz
 # Work from the build root (where docker-compose.yml lives).
 cd /opt/polaris/scenario-dev/polaris/build
 
-# Publish the Kali container's sshd (22) and xrdp (3389) on the EC2 host
-# so the Shifter portal (terminal UI + Guacamole RDP) can reach them,
-# pass the operator SSH pubkey as a KALI_AUTHORIZED_KEY env var so the
-# a14 entrypoint can inject it into /home/kali/.ssh/authorized_keys on
-# every container start, and pass the range-specific A2 DC IP into the
-# dns container so its boreas.local zone resolves dc01 to the DC inside
-# this range's /28 (not range 0's). We use a placeholder + python replace
-# pass so the pubkey can contain any shell-meaningful characters without
-# breaking the YAML (terraform already rendered ${kali_authorized_key}
-# inline at plan time).
+# Stage the per-range splice-relay keypair. The private half lands in A14
+# through KALI_SPLICE_PRIVATE_KEY_B64 and the public half lands in A9's
+# authorized_keys through A9_AUTHORIZED_KEY. This matches the dev/test
+# prewired splice contract that A14-smoketest.sh and isolation-smoketest.sh
+# validate.
+SPLICE_KEY_DIR=/opt/polaris/.splice
+install -d -m 700 "$SPLICE_KEY_DIR"
+if [[ ! -f "$SPLICE_KEY_DIR/splice_relay" ]]; then
+    ssh-keygen -t ed25519 -N "" \
+        -C "splice-relay@aws-$(date -u +%Y%m%dT%H%M%SZ)" \
+        -f "$SPLICE_KEY_DIR/splice_relay" -q
+fi
+SPLICE_PRIVATE_KEY_B64="$(base64 -w0 < "$SPLICE_KEY_DIR/splice_relay")"
+SPLICE_PUBLIC_KEY="$(cat "$SPLICE_KEY_DIR/splice_relay.pub")"
+
+# Optionally publish the Kali container's sshd (22) and xrdp (3389) on the EC2
+# host so the Shifter portal (terminal UI + Guacamole RDP) can reach them.
+# Standalone/default-VPC mode keeps host ports unpublished and uses SSM for
+# operator access. Always pass the operator SSH pubkey as a KALI_AUTHORIZED_KEY
+# env var so the a14 entrypoint can inject it into /home/kali/.ssh/authorized_keys
+# on every container start, and pass the range-specific A2 DC IP into the dns
+# container so its boreas.local zone resolves dc01 to the DC inside this range's
+# /28 (not range 0's). We use a placeholder + python replace pass so the pubkey
+# can contain any shell-meaningful characters without breaking the YAML
+# (terraform already rendered ${kali_authorized_key} inline at plan time).
 cat > docker-compose.override.yml <<'COMPOSE_EOF'
 services:
+  a9-splice:
+    environment:
+      A9_AUTHORIZED_KEY: "__A9_AUTHORIZED_KEY_PLACEHOLDER__"
   a14-kali:
+%{ if publish_kali_host_ports }
     ports:
       - "22:22"
       - "3389:3389"
+%{ endif }
+    networks:
+      shared:
+        ipv4_address: 172.20.0.140
+      corporate:
+        ipv4_address: 172.20.10.140
+      splice-link:
+        ipv4_address: 172.20.60.140
     environment:
       KALI_AUTHORIZED_KEY: "__KALI_AUTHORIZED_KEY_PLACEHOLDER__"
+      KALI_SPLICE_PRIVATE_KEY_B64: "__KALI_SPLICE_PRIVATE_KEY_B64_PLACEHOLDER__"
   dns:
     environment:
       DC01_IP: "__DC01_IP_PLACEHOLDER__"
 COMPOSE_EOF
 
-python3 - <<'PY'
+SPLICE_PUBLIC_KEY="$SPLICE_PUBLIC_KEY" SPLICE_PRIVATE_KEY_B64="$SPLICE_PRIVATE_KEY_B64" python3 - <<'PY'
+import os
+
 key = """${kali_authorized_key}"""
 dc01_ip = """${a2_private_ip}"""
+splice_public_key = os.environ["SPLICE_PUBLIC_KEY"]
+splice_private_key_b64 = os.environ["SPLICE_PRIVATE_KEY_B64"]
 with open("docker-compose.override.yml") as f:
     content = f.read()
 content = content.replace("__KALI_AUTHORIZED_KEY_PLACEHOLDER__", key)
 content = content.replace("__DC01_IP_PLACEHOLDER__", dc01_ip)
+content = content.replace("__A9_AUTHORIZED_KEY_PLACEHOLDER__", splice_public_key)
+content = content.replace("__KALI_SPLICE_PRIVATE_KEY_B64_PLACEHOLDER__", splice_private_key_b64)
 with open("docker-compose.override.yml", "w") as f:
     f.write(content)
 PY

--- a/scripts/polaris-aws-range/variables.tf
+++ b/scripts/polaris-aws-range/variables.tf
@@ -1,3 +1,28 @@
+variable "aws_profile" {
+  description = "AWS CLI/shared-config profile for Terraform. Set to aws-dev for the no-SSO aws-dev account; leave null to use the ambient AWS credential chain."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "aws_region" {
+  description = "AWS region for the Polaris standalone range."
+  type        = string
+  default     = "us-east-2"
+}
+
+variable "name_prefix" {
+  description = "Prefix for Terraform-created Polaris AWS resources."
+  type        = string
+  default     = "polaris"
+}
+
+variable "deployment_purpose" {
+  description = "Default AWS tag Purpose value."
+  type        = string
+  default     = "standalone-range"
+}
+
 variable "range_indices" {
   description = "String indices of the POLARIS ranges to provision. Each index gets its own /28 subnet + polaris VM + A2 DC. Default is a single range so a plain `terraform apply` still produces one working range."
   type        = list(string)
@@ -10,45 +35,86 @@ variable "range_indices" {
 }
 
 variable "polaris_cidr_block" {
-  description = "Base CIDR allocated to POLARIS. Carved into /28 subnets via cidrsubnet(block, 4, i), so a /24 yields 16 ranges, a /22 yields 64, a /21 yields 128. Default /24 holds the single-range smoke case + room to grow up to 16 without re-planning the VPC."
+  description = "Base CIDR allocated to POLARIS. Carved into /28 subnets via cidrsubnet(block, 4, i), so a /24 yields 16 ranges. Leave empty to derive a high /24 from the target VPC CIDR, e.g. 172.31.240.0/24 in the aws-dev default VPC."
   type        = string
-  default     = "10.1.100.0/24"
+  default     = ""
 }
 
 variable "range_vpc_id" {
-  description = "Dev range VPC to attach POLARIS subnets to."
+  description = "Target VPC to attach POLARIS subnets to. Leave empty to use the account's default VPC."
   type        = string
-  default     = "vpc-094a142a8c363541c"
+  default     = ""
 }
 
 variable "availability_zone" {
-  description = "AZ for the POLARIS subnets (matches existing range infrastructure)."
+  description = "AZ for the POLARIS subnets."
   type        = string
   default     = "us-east-2a"
 }
 
-variable "nat_gateway_id" {
-  description = "Existing dev range NAT gateway. Used to give every POLARIS subnet direct NAT egress (bypass the domain-filtered Network Firewall so docker hub / apt repos work during bake)."
+variable "egress_route_target" {
+  description = "Default route target for each Polaris subnet: igw for default-VPC public SSM egress, nat for the old private range-VPC bake path."
   type        = string
-  default     = "nat-0728570128ae96bfc"
+  default     = "igw"
+
+  validation {
+    condition     = contains(["igw", "nat"], var.egress_route_target)
+    error_message = "egress_route_target must be either igw or nat."
+  }
+}
+
+variable "internet_gateway_id" {
+  description = "Internet gateway for igw egress mode. Leave empty to discover the IGW attached to the target VPC."
+  type        = string
+  default     = ""
+}
+
+variable "nat_gateway_id" {
+  description = "NAT gateway for nat egress mode. Required only when egress_route_target is nat."
+  type        = string
+  default     = ""
 }
 
 variable "portal_vpc_cidr" {
-  description = "Portal VPC CIDR reachable via VPC peering (so the Shifter portal terminal UI + Guacamole can reach every POLARIS kali box)."
+  description = "Optional portal VPC CIDR reachable via VPC peering, also allowed to reach host-published SSH/RDP when set. Leave empty for standalone SSM-only management."
   type        = string
-  default     = "10.0.0.0/16"
+  default     = ""
 }
 
 variable "portal_peering_id" {
-  description = "VPC peering connection from the range VPC to the portal VPC."
+  description = "Optional VPC peering connection from the Polaris VPC to the portal VPC. Leave empty for standalone default-VPC mode."
   type        = string
-  default     = "pcx-0060068d711a534f4"
+  default     = ""
+}
+
+variable "management_ingress_cidrs" {
+  description = "Optional CIDRs allowed to reach host-published SSH/RDP on the Polaris VM and A2 DC. Leave empty for SSM-only management."
+  type        = list(string)
+  default     = []
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Whether Polaris-created subnets should assign public IPs by default."
+  type        = bool
+  default     = true
+}
+
+variable "associate_public_ip_address" {
+  description = "Whether the Polaris and A2 instances should receive public IPs."
+  type        = bool
+  default     = true
+}
+
+variable "publish_kali_host_ports" {
+  description = "Publish a14-kali SSH/RDP on the Polaris EC2 host. Keep false for standalone SSM-only mode; set true only when portal/Guacamole ingress is configured."
+  type        = bool
+  default     = false
 }
 
 variable "ubuntu_ami_id" {
-  description = "Ubuntu base AMI (each host just runs Docker + the polaris docker-compose stack)."
+  description = "Ubuntu base AMI (each host just runs Docker + the polaris docker-compose stack). Leave empty to use the latest public Ubuntu 24.04 Noble amd64 AMI in the selected region."
   type        = string
-  default     = "ami-01c08a65f35fbc399" # shifter-ubuntu-1773805749
+  default     = ""
 }
 
 variable "instance_type" {
@@ -60,13 +126,21 @@ variable "instance_type" {
 variable "build_tarball_s3_uri" {
   description = "S3 URI of the polaris build tarball uploaded by the operator."
   type        = string
-  default     = "s3://shifter-polaris-bake-158151907940/polaris/build-v1.tar.gz"
+
+  validation {
+    condition     = trimspace(var.build_tarball_s3_uri) != ""
+    error_message = "build_tarball_s3_uri must be set to the uploaded Polaris build tarball S3 URI."
+  }
 }
 
 variable "build_tarball_bucket" {
   description = "S3 bucket holding the polaris build tarball (used to grant IAM read to the instance)."
   type        = string
-  default     = "shifter-polaris-bake-158151907940"
+
+  validation {
+    condition     = trimspace(var.build_tarball_bucket) != ""
+    error_message = "build_tarball_bucket must be set to the S3 bucket holding the Polaris build tarball."
+  }
 }
 
 variable "ssh_public_key_ssm_name" {
@@ -82,9 +156,9 @@ variable "kali_authorized_key" {
 }
 
 variable "a2_dc_ami_id" {
-  description = "Windows Server 2022 Full Base from Amazon. Stock base AMI boots cleanly, then we install AD-Domain-Services via SSM RunCommand after the agent reports online."
+  description = "Windows Server 2022 Full Base from Amazon. Leave empty to use the latest public Windows Server 2022 Full Base AMI in the selected region."
   type        = string
-  default     = "ami-08c41c6041bf318eb" # Windows_Server-2022-English-Full-Base-2026.03.11
+  default     = ""
 }
 
 variable "a2_instance_type" {

--- a/scripts/polaris-aws-range/versions.tf
+++ b/scripts/polaris-aws-range/versions.tf
@@ -10,14 +10,14 @@ terraform {
 }
 
 provider "aws" {
-  profile = "panw-shifter-dev-workstation"
-  region  = "us-east-2"
+  profile = var.aws_profile
+  region  = var.aws_region
 
   default_tags {
     tags = {
       Project   = "polaris"
       ManagedBy = "terraform"
-      Purpose   = "golden-range-bake"
+      Purpose   = var.deployment_purpose
     }
   }
 }


### PR DESCRIPTION
## Summary

Prepare Polaris for aws-dev/default-VPC standalone bring-up and golden-range validation by fixing the range bootstrap, per-range DNS/key handling, smoke-test readiness, and operator docs.

This PR also captures the fixes found while standing up and validating a Polaris range in the no-SSO `aws-dev` account (`us-east-2`).

## Changes

- Add `scripts/polaris-aws-range/README.md` with the aws-dev/default-VPC runbook.
- Parameterize the standalone Polaris Terraform for default-VPC, IGW egress, optional management ingress, public-IP behavior, and tarball source.
- Fix Ubuntu bootstrap for AWS CLI v2 and host-service conflicts.
- Stage per-range A9 splice SSH keys and Kali splice client config during bootstrap.
- Make A2 DNS records per-range in both `boreas.local` and `boreas-systems.ctf` zones.
- Harden A2 smoke readiness so the first post-boot sweep does not race the Windows DC.
- Make Polaris test scripts self-locate from their checked-out range root.
- Update stale Polaris walkthrough/docs references for AWS/default-VPC usage.
- Fix the covered bunker scenario-smoketest adapter to tolerate leading whitespace in Modbus device ID output.

## Validation

Local/source checks:

- `terraform fmt -check -recursive && terraform validate` in `scripts/polaris-aws-range`
- `tflint --recursive --config /home/atomik/src/shifter-aws-dev-bootstrap/.tflint.hcl`
- `python3 -m unittest test_range_health test_common test_provisioning_state -v`
- `PYTHONPATH=scenario-dev/polaris/tests /tmp/polaris-build-venv/bin/python -m pytest scenario-dev/polaris/tests/test_scenario_smoketest.py`
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- pre-commit hooks during commit, including shellcheck and secret detection

Live aws-dev validation before teardown:

- Bootstrap completed on the Polaris host.
- Full smoke passed: `18 / 18 asset sweeps PASS`, `NORTHSTORM full range: PASS`.
- Isolation passed: `PASS: 91 FAIL: 0`.
- Covered scenario verifier passed: `7 pass / 0 fail / 0 uncovered / 0 error`.
- Participant-style Kali pass verified front-office, A2, A15 SCADA pivot, A16 lab pivot, and A9/A10-A13 bunker bridge paths.

## Cleanup

The temporary aws-dev standalone test range was destroyed after validation:

- EC2: Polaris host and A2 DC terminated.
- Terraform-managed /28 subnet, route table, security group, IAM role/profile/policies destroyed.
- Terraform state is empty.
- The canonical S3 bootstrap tarball remains for future golden range work.

## Follow-up

This validates the standalone cold-build path and fixes the repo/docs, but it is not yet a golden AMI proof. Next step is to build a fresh Polaris AMI from the merged tree, provision via the normal portal/engine path, and verify the gated splice watcher behavior before load testing.
