### PR TITLE
docs: improve Polaris participant onramp UX

### DIFF
--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -134,7 +134,11 @@ publish the runtime DNS records:
   `alb_dns_name` as CNAME records. In Cloudflare, keep them DNS-only unless
   the deployment explicitly validates proxied Cloudflare behavior.
 - `ctfd_domain` points to the Terraform output `ctfd_elastic_ip` as an A
-  record.
+  record. In Cloudflare, publish the record as DNS-only until the CTFd host
+  has completed certbot and `https://<ctfd_domain>/login` works against the
+  origin. After that validation, the CTFd `A` record may be switched to
+  proxied with SSL/TLS mode `Full (strict)`. The DNS target is the bare
+  Elastic IP address, never an `http://` or `https://` URL.
 
 ALB access logs use a dedicated S3 bucket with SSE-S3 because Elastic Load
 Balancing does not support SSE-KMS for Application Load Balancer access-log

--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -138,7 +138,11 @@ publish the runtime DNS records:
   has completed certbot and `https://<ctfd_domain>/login` works against the
   origin. After that validation, the CTFd `A` record may be switched to
   proxied with SSL/TLS mode `Full (strict)`. The DNS target is the bare
-  Elastic IP address, never an `http://` or `https://` URL.
+  Elastic IP address, never an `http://` or `https://` URL. Cloudflare
+  challenge actions must be disabled or explicitly skipped for the CTFd
+  hostname before event smoke testing; the CTFd sync scripts and automated
+  checks expect the CTFd app to answer directly instead of a Cloudflare
+  `cf-mitigated: challenge` page.
 
 ALB access logs use a dedicated S3 bucket with SSE-S3 because Elastic Load
 Balancing does not support SSE-KMS for Application Load Balancer access-log

--- a/scenario-dev/polaris/README.md
+++ b/scenario-dev/polaris/README.md
@@ -107,11 +107,13 @@ Legacy local-compose flow:
    isolation. Does not verify CTFd challenge content.
 
 3. **Verify scenario content** — pre-event content check that every CTFd
-   challenge's hint path produces the configured flag:
+   covered hint path produces the configured flag:
    ```
-   ssh ctf-range-builder 'cd /home/atomik/range/tests && python3 -m scenario_smoketest'
+   ssh ctf-range-builder 'cd /home/atomik/range/tests && python3 -m scenario_smoketest --only 1,2,3,4,5,6,31'
    ```
-   Content-level (vs. step 2's infra sweep). Full usage, flags, and the
+   Content-level (vs. step 2's infra sweep). Current executable adapter
+   coverage is challenges `1-6` and `31`; an unfiltered run intentionally exits
+   non-zero while uncovered board challenges remain. Full usage, flags, and the
    CTFd-token security model live in
    [`tests/scenario_smoketest/README.md`](tests/scenario_smoketest/README.md).
 

--- a/scenario-dev/polaris/README.md
+++ b/scenario-dev/polaris/README.md
@@ -41,7 +41,7 @@ scenario-dev/polaris/
 │   ├── dns/                        BIND sidecar (boreas-systems.ctf + boreas.local zones, AXFR enabled)
 │   ├── a0/ ... a14/                Dockerfiles + runtime configs per asset
 │   └── A0-boreas-website/ ...      content generators (server.py, build_*.py, bootstrap.sh, init SQL)
-│       A14-kali/
+│       A14-kali/                   Kali starter text, warm-up note, Claude prompt
 │
 ├── tests/                          everything test-related
 │   ├── setup.sh                    build + up + wait ready
@@ -76,9 +76,10 @@ trust these in this order:
 
 1. `build/docker-compose.yml` and the build/runtime content under `build/`
 2. `build/ctfd-challenges.json` for the core Polaris board: challenge names, categories, values, hints, and prerequisites
-3. `build/ctfd-onboarding.json` plus `build/ctfd-pages/` for CTFd-only onboarding content such as the landing page, quickstart page, and Start Here warm-up
-4. `tests/walkthroughs/` for the intended participant path through the live topology
-5. `design/` as the spec that should be kept in sync with the implementation
+3. `build/ctfd-onboarding.json` plus `build/ctfd-pages/` for CTFd onboarding content such as the landing page, quickstart page, and Start Here warm-up
+4. `build/A14-kali/START_HERE.txt` and `build/A14-kali/welcome.txt` for the local Kali copy of the first-five-minutes path and warm-up flag note
+5. `tests/walkthroughs/` for the intended participant path through the live topology
+6. `design/` as the spec that should be kept in sync with the implementation
 
 If these disagree, reconcile the docs against the actual build and walkthroughs
 first instead of assuming the older design prose is correct.

--- a/scenario-dev/polaris/briefing-deck/index.html
+++ b/scenario-dev/polaris/briefing-deck/index.html
@@ -292,8 +292,8 @@
       <div class="roe__row"><span class="roe__n">02</span><span>Sign in with your operator account.</span></div>
       <div class="roe__row"><span class="roe__n">03</span><span>Choose the <strong>POLARIS</strong> scenario.</span></div>
       <div class="roe__row"><span class="roe__n">04</span><span>Click <strong>ENTER RANGE</strong>. ~5 minutes to provision.</span></div>
-      <div class="roe__row"><span class="roe__n">05</span><span>When the range is up, your Kali console opens in-browser.</span></div>
-      <div class="roe__row"><span class="roe__n">06</span><span>Submit flags on <code>polaris.keplerops.com</code> — Mission One is live, Start Here is the warm-up.</span></div>
+      <div class="roe__row"><span class="roe__n">05</span><span>When the range is up, your Kali desktop opens in-browser.</span></div>
+      <div class="roe__row"><span class="roe__n">06</span><span>Read <code>/home/kali/START_HERE.txt</code>, then submit flags on <code>polaris.keplerops.com</code>.</span></div>
     </div>
   </section>
 
@@ -304,8 +304,8 @@
       <h1 class="brief__title">QUICK REFERENCE</h1>
     </header>
     <div class="brief__body roe">
-      <div class="roe__row"><span class="roe__n">01</span><span><strong>CTFd board</strong> — submit flags here · <code>https://polaris.keplerops.com</code></span></div>
-      <div class="roe__row"><span class="roe__n">02</span><span><strong>Mission Control</strong> — your range lives here · <code>https://dev.shifter.keplerops.com</code></span></div>
+      <div class="roe__row"><span class="roe__n">01</span><span><strong>CTFd board</strong> — challenge briefs, hints, scoreboard, flag submission · <code>https://polaris.keplerops.com</code></span></div>
+      <div class="roe__row"><span class="roe__n">02</span><span><strong>Mission Control</strong> — magic-link range launch and Kali desktop · <code>https://dev.shifter.keplerops.com</code></span></div>
       <div class="roe__row"><span class="roe__n">03</span><span><strong>Boreas company site</strong> — Mission 1 OSINT target · <code>http://boreas-systems.ctf</code> (from inside Kali only)</span></div>
       <div class="roe__row"><span class="roe__n">04</span><span><strong>Boreas intranet</strong> — Mission 2 front-office · <code>http://intranet.boreas.local</code> (from inside Kali only)</span></div>
       <div class="roe__row"><span class="roe__n">05</span><span><strong>Boreas mail</strong> — webmail / IMAP · <code>http://mail.boreas.local</code> (from inside Kali only)</span></div>
@@ -320,11 +320,12 @@
       <h1 class="brief__title">YOUR FIRST FIVE MINUTES</h1>
     </header>
     <ol class="first-clicks">
-      <li><span class="first-clicks__n">01</span><span class="first-clicks__step">Open your <strong>magic-link email</strong> → it lands on <strong>Mission Control</strong>.</span></li>
-      <li><span class="first-clicks__n">02</span><span class="first-clicks__step">Choose <strong>POLARIS</strong> → click <strong>ENTER RANGE</strong> (~5 min to provision).</span></li>
-      <li><span class="first-clicks__n">03</span><span class="first-clicks__step">Your <strong>Kali desktop</strong> opens in-browser. Find the orientation note in your home directory.</span></li>
-      <li><span class="first-clicks__n">04</span><span class="first-clicks__step">Open <code>polaris.keplerops.com</code> in a new tab → click <strong>Challenges</strong> → solve <strong>Start Here — Kali Warm-Up</strong>.</span></li>
-      <li><span class="first-clicks__n">05</span><span class="first-clicks__step">First flag on the board. Start <strong>Mission 1 — Boreas</strong>.</span></li>
+      <li><span class="first-clicks__n">01</span><span class="first-clicks__step">Keep <code>polaris.keplerops.com</code> open. This is CTFd, where flags are submitted.</span></li>
+      <li><span class="first-clicks__n">02</span><span class="first-clicks__step">Open your <strong>magic-link email</strong>. It lands on <strong>Mission Control</strong>.</span></li>
+      <li><span class="first-clicks__n">03</span><span class="first-clicks__step">Choose <strong>POLARIS</strong>, click <strong>ENTER RANGE</strong>, and wait for Kali.</span></li>
+      <li><span class="first-clicks__n">04</span><span class="first-clicks__step">On Kali, read <code>/home/kali/START_HERE.txt</code>, then <code>/home/kali/.polaris/welcome.txt</code>.</span></li>
+      <li><span class="first-clicks__n">05</span><span class="first-clicks__step">Back on CTFd, open <strong>Challenges</strong> and solve <strong>Start Here — Kali Warm-Up</strong>.</span></li>
+      <li><span class="first-clicks__n">06</span><span class="first-clicks__step">First flag on the board. Start <strong>Mission 1 — Boreas</strong>.</span></li>
     </ol>
     <div class="first-clicks__signoff">
       <span class="first-clicks__signoff-lead">GOOD HUNTING,</span>

--- a/scenario-dev/polaris/briefing-deck/script.md
+++ b/scenario-dev/polaris/briefing-deck/script.md
@@ -148,6 +148,8 @@ Speaker notes for driving the deck at kickoff.
 *Six numbered steps for how to get a range. Read fast. The next slide repeats the URL.*
 
 > Your range opens through Mission Control. Open dev.shifter.keplerops.com, sign in, pick POLARIS, click ENTER RANGE. Provisioning takes about five minutes. When it's up, your Kali desktop opens right in the browser tab.
+>
+> The first local file to read on Kali is `/home/kali/START_HERE.txt`. That file is your recovery point if you lose the thread.
 
 ---
 
@@ -155,7 +157,7 @@ Speaker notes for driving the deck at kickoff.
 
 *Quick read-through. Make the cyan distinction land: CTFd and Mission Control are on your laptop browser; everything else opens from inside Kali.*
 
-> Two URLs you hit from your laptop browser: CTFd to submit flags, Mission Control for the range. Everything else (Boreas, intranet, mail, the DC) is only reachable from inside your Kali box. Don't try to load them from your laptop; they won't resolve.
+> Two URLs you hit from your laptop browser: CTFd for challenge briefs, hints, scoreboard, and flag submission; Mission Control for the range. Everything else (Boreas, intranet, mail, the DC) is only reachable from inside your Kali box. Don't try to load those targets from your laptop; they won't resolve.
 
 ---
 
@@ -163,7 +165,7 @@ Speaker notes for driving the deck at kickoff.
 
 *This is the literal handoff. Read it. Project it. Leave it on screen while people start moving.*
 
-> Five steps. Magic-link email lands you on Mission Control. Pick POLARIS, click ENTER RANGE. Five minutes to provision. Your Kali desktop opens in-browser; there's an orientation note in your home directory, find it. Open polaris.keplerops.com in a new tab, click Challenges, solve `Start Here — Kali Warm-Up`. That's your first flag on the board. Then start Mission One.
+> Six steps. Keep polaris.keplerops.com open; that's CTFd, where you submit flags. Open your magic-link email; it lands on Mission Control. Pick POLARIS, click ENTER RANGE, and wait for Kali. On Kali, read `/home/kali/START_HERE.txt`, then `/home/kali/.polaris/welcome.txt`. Back on CTFd, click Challenges and solve `Start Here — Kali Warm-Up`. That's your first flag on the board. Then start Mission One.
 >
 > Clock starts now. Good hunting, operator.
 
@@ -175,4 +177,5 @@ The First Clicks slide is the handoff. Leave it on screen. If anyone is still st
 
 - "Magic link is in your email. Check spam if you don't see it."
 - "Two browser tabs: CTFd on one, your Kali desktop on the other."
+- "Inside Kali, read `/home/kali/START_HERE.txt` first."
 - "Ask Claude on your Kali box. Ask the room. Try things."

--- a/scenario-dev/polaris/briefing-deck/seat-handout.html
+++ b/scenario-dev/polaris/briefing-deck/seat-handout.html
@@ -203,10 +203,11 @@
     <div class="handout__cta">
       <div class="handout__cta-h">▶ FIRST CLICKS — YOUR FIRST FIVE MINUTES</div>
       <ol class="handout__steps">
+        <li>Keep <strong>polaris.keplerops.com</strong> open. This is CTFd, where flags are submitted.</li>
         <li>Open your <strong>magic-link email</strong>. It lands on <strong>Mission Control</strong>.</li>
         <li>Pick <strong>POLARIS</strong> → click <strong>ENTER RANGE</strong>. ~5 min to provision.</li>
-        <li>Your <strong>Kali desktop</strong> opens in-browser. Find the orientation note in your home directory.</li>
-        <li>Open <strong>polaris.keplerops.com</strong> in a new tab → <strong>Challenges</strong> → solve <strong>Start Here — Kali Warm-Up</strong>.</li>
+        <li>On Kali, read <strong>/home/kali/START_HERE.txt</strong>, then <strong>/home/kali/.polaris/welcome.txt</strong>.</li>
+        <li>Back on CTFd → <strong>Challenges</strong> → solve <strong>Start Here — Kali Warm-Up</strong>.</li>
         <li>First flag on the board. Start <strong>Mission 1 — Boreas</strong>.</li>
       </ol>
     </div>
@@ -218,7 +219,7 @@
         <div class="handout__row"><dt>Username</dt><dd>your registered email</dd></div>
         <div class="handout__row"><dt>Password</dt><dd>vancity</dd></div>
       </dl>
-      <div class="handout__hint">Same password for everyone. Submit flags from your laptop browser — your Kali box can't reach the board.</div>
+      <div class="handout__hint">Same password for everyone. Submit flags from your laptop browser — your Kali box can't reach CTFd.</div>
     </div>
 
     <div class="handout__section-title">Range access</div>
@@ -232,7 +233,7 @@
 
     <div class="handout__section-title">If you get stuck on the warm-up</div>
     <div class="handout__card">
-      <div class="handout__hint">There's an orientation note hidden somewhere in your home directory on the Kali box. Standard Linux tricks will find it — or ask Claude Code on the box to find hidden files in your home directory. The flag is printed inline in the note.</div>
+      <div class="handout__hint">Run <strong>cat /home/kali/START_HERE.txt</strong>, then <strong>cat /home/kali/.polaris/welcome.txt</strong>. The warm-up flag is printed inline in the note. Submit it in CTFd, not from Kali.</div>
     </div>
 
     <div class="handout__footer">FLAG FORMAT · FLAG{hex} · 4-HOUR CLOCK · GOOD HUNTING</div>

--- a/scenario-dev/polaris/briefing-deck/styles.css
+++ b/scenario-dev/polaris/briefing-deck/styles.css
@@ -725,8 +725,8 @@ code {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 1.6vh;
-  font-size: clamp(15px, 1.6vw, 22px);
+  gap: 1.2vh;
+  font-size: clamp(14px, 1.45vw, 20px);
   max-width: 1100px;
 }
 
@@ -735,7 +735,7 @@ code {
   grid-template-columns: 64px 1fr;
   align-items: baseline;
   gap: 2em;
-  padding: 1.4vh 0;
+  padding: 1.1vh 0;
   border-bottom: 1px solid var(--line);
 }
 

--- a/scenario-dev/polaris/build/A14-kali/START_HERE.txt
+++ b/scenario-dev/polaris/build/A14-kali/START_HERE.txt
@@ -34,6 +34,18 @@ Open this from Kali, not from your laptop:
 
   http://boreas-systems.ctf
 
+AFTER LIGHTS OUT
+
+If a Bunker objective tells you the local splice is open, connect from Kali:
+
+  ssh root@splice-relay
+
+No password is required. The range stages a per-range key at:
+
+  /home/kali/.ssh/splice_relay
+
+If SSH asks for a password, flag a runner.
+
 IF YOU ARE LOST
 
   - Reopen the CTFd Start Here page and Kali Quickstart.

--- a/scenario-dev/polaris/build/A14-kali/START_HERE.txt
+++ b/scenario-dev/polaris/build/A14-kali/START_HERE.txt
@@ -1,0 +1,44 @@
+==========================================
+  JOINT TASK FORCE POLARIS
+  OPERATION NORTHSTORM - START HERE
+==========================================
+
+You use two browser tabs during this event:
+
+  1. CTFd: https://polaris.keplerops.com
+     Challenge briefs, hints, scoreboard, and flag submission.
+
+  2. Mission Control: https://dev.shifter.keplerops.com
+     Range launch and this Kali desktop.
+
+This Kali box is for investigation work. It can reach Boreas targets.
+It cannot submit flags to CTFd. Submit flags from your laptop browser.
+
+FIRST FIVE MINUTES
+
+  1. Keep CTFd open on your laptop.
+  2. In Mission Control, choose POLARIS and click ENTER RANGE.
+  3. When Kali opens, you are here.
+  4. Read the warm-up note:
+
+       cat /home/kali/.polaris/welcome.txt
+
+  5. Copy the flag from that note.
+  6. Go back to CTFd > Challenges > Start Here - Kali Warm-Up.
+  7. Submit the flag.
+  8. Start Mission 1 - Boreas.
+
+GOOD FIRST TARGET
+
+Open this from Kali, not from your laptop:
+
+  http://boreas-systems.ctf
+
+IF YOU ARE LOST
+
+  - Reopen the CTFd Start Here page and Kali Quickstart.
+  - Buy Hint 1 before guessing.
+  - Ask Claude on this box: claude
+  - Flag a runner if the range desktop or networking looks broken.
+
+Good hunting.

--- a/scenario-dev/polaris/build/A14-kali/welcome.txt
+++ b/scenario-dev/polaris/build/A14-kali/welcome.txt
@@ -16,6 +16,10 @@ Your first flag:
 Switch to your CTFd tab. Submit it. That's your first token
 on the board.
 
+If you lose the thread, run:
+
+  cat /home/kali/START_HERE.txt
+
 When you're done, start with Mission 1 — Boreas. Everything
 else you need lives on CTFd from here.
 

--- a/scenario-dev/polaris/build/a14/Dockerfile
+++ b/scenario-dev/polaris/build/a14/Dockerfile
@@ -81,11 +81,13 @@ RUN touch /var/log/xrdp.log /var/log/xrdp-sesman.log && \
 RUN echo 'set -g mouse on' > /etc/tmux.conf
 
 # CTF content overlay — modbus scan helper is shared with A9-splice-landing/.
-# welcome.txt is the warm-up challenge target; lives hidden in /home/kali/.polaris/.
+# START_HERE.txt is the visible local onramp; welcome.txt is the warm-up
+# challenge target and lives hidden in /home/kali/.polaris/.
 # README, mission_brief, and flag_submit.sh were removed — they were stale
 # relative to the CTFd board and Kali has no route to CTFd anyway, so a
 # Kali-side submission helper is broken by design. CTFd is the reference.
 COPY A9-splice-landing/modbus_client.py /home/kali/tools/modbus_scan.py
+COPY A14-kali/START_HERE.txt /home/kali/START_HERE.txt
 COPY A14-kali/claude_system_prompt.txt /home/kali/.config/claude/system_prompt.txt
 COPY A14-kali/welcome.txt /home/kali/.polaris/welcome.txt
 RUN chmod +x /home/kali/tools/*.py && \

--- a/scenario-dev/polaris/build/ctfd-challenges.json
+++ b/scenario-dev/polaris/build/ctfd-challenges.json
@@ -335,9 +335,10 @@
       "id": 31, "name": "Underground Signals", "category": "Mission 5 — Bunker",
       "description": "The relay sees several industrial hosts below. Before you can work with them, you need a map.",
       "value": 100, "type": "standard",
+      "connection_info": "After Lights Out, the local splice opens from Kali to the field relay. From Kali, run `ssh root@splice-relay`. No password is required: the range stages a per-range key at `/home/kali/.ssh/splice_relay` and `~/.ssh/config` uses it automatically. Once on the relay, start with `/root/README.txt` and `/root/scan_results.txt`.",
       "flags": [{"type": "static", "content": "FLAG{2e8c0a5d7f3b1946}"}],
       "hints": [
-        {"content": "Start on A9 with /root/scan_results.txt before you bother with a slow live scan.", "cost": 25},
+        {"content": "The relay is A9. From Kali, use `ssh root@splice-relay`; if SSH asks for a password, the range key staging failed and you should flag a runner.", "cost": 25},
         {"content": "Use /usr/local/bin/modbus_client.py <host> devid and keep the model strings from all three controllers.", "cost": 50}
       ],
       "tags": ["medium", "ot", "modbus"], "state": "visible",

--- a/scenario-dev/polaris/build/ctfd-onboarding.json
+++ b/scenario-dev/polaris/build/ctfd-onboarding.json
@@ -8,11 +8,11 @@
       "id": 0,
       "name": "Start Here — Kali Warm-Up",
       "category": "Start Here",
-      "description": "Welcome, Operator. POLARIS left an orientation note on your Kali box. Find it, read it, submit the flag inside.",
+      "description": "Welcome, Operator. This warm-up proves two things: your Kali desktop is reachable and your CTFd submissions work. Read the local starter on Kali, then submit the flag from the orientation note.",
       "value": 50,
       "type": "standard",
       "state": "visible",
-      "connection_info": "The file is hidden somewhere under your home directory on the Kali box. Standard Linux tricks will find it — or ask Claude Code on the box to find it for you.",
+      "connection_info": "On the Kali box, start with `cat /home/kali/START_HERE.txt`. It points you to the orientation note used for this warm-up. Submit the flag in this CTFd browser tab, not from Kali.",
       "next": "Company Info",
       "flags": [
         {
@@ -22,11 +22,11 @@
       ],
       "hints": [
         {
-          "content": "Try `ls -la ~` on the Kali box and look for anything starting with a dot. Or ask Claude Code to find hidden files in your home directory.",
+          "content": "If you are not sure where to begin, run `cat /home/kali/START_HERE.txt` on the Kali box. It gives the first-five-minutes path and reminds you where flags are submitted.",
           "cost": 0
         },
         {
-          "content": "The file is `/home/kali/.polaris/welcome.txt`. `cat` it — the flag is printed inline.",
+          "content": "The warm-up note is `/home/kali/.polaris/welcome.txt`. Run `cat /home/kali/.polaris/welcome.txt` and submit the flag printed inside.",
           "cost": 10
         }
       ]

--- a/scenario-dev/polaris/build/ctfd-pages/getting-unstuck.md
+++ b/scenario-dev/polaris/build/ctfd-pages/getting-unstuck.md
@@ -76,6 +76,18 @@ auth_required: true
 
 Four hours. Nine missions. Getting stuck is the default state — the question is whether you get stuck productively or unproductively. This page is triage.
 
+## Lost In The First Five Minutes
+
+If you are not solving yet, reset to this exact path:
+
+<ol class="step-list">
+<li>Open <code>https://polaris.keplerops.com</code> on your laptop. This is CTFd, where flags are submitted.</li>
+<li>Open your magic-link email, land in Mission Control, choose <strong>POLARIS</strong>, and click <strong>ENTER RANGE</strong>.</li>
+<li>Wait for the Kali desktop to open in-browser. If the desktop does not open cleanly, retry the range connection once, then flag a runner.</li>
+<li>Inside Kali, run <code>cat /home/kali/START_HERE.txt</code>.</li>
+<li>Run <code>cat /home/kali/.polaris/welcome.txt</code>, copy the flag, and submit it on the <strong>Start Here — Kali Warm-Up</strong> challenge in CTFd.</li>
+</ol>
+
 ## Submitting Flags
 
 Flag format: <code>FLAG{hex_string}</code>. Submit on the challenge page in CTFd — always from your laptop browser. The Kali box has no path to the scoreboard.

--- a/scenario-dev/polaris/build/ctfd-pages/index.md
+++ b/scenario-dev/polaris/build/ctfd-pages/index.md
@@ -75,17 +75,16 @@ auth_required: true
 
 <div class="polaris-page" markdown="1">
 
-<!-- vale Google.EmDash = NO -->
 <div class="first-click">
-<h2 class="first-click__h">🎯 <a href="/challenges">Open the board and solve <em>Start Here — Kali Warm-Up</em></a></h2>
+<h2 class="first-click__h"><a href="/challenges">Begin here: your first five minutes</a></h2>
 <ol>
-<li>Click your <strong>magic-link email</strong> → <strong>Mission Control</strong> → <strong>ENTER RANGE</strong>. ~5 min to provision; your Kali desktop opens in-browser.</li>
-<li>On the Kali desktop, find the orientation note in your home directory. Read it.</li>
-<li>Back in this browser tab, <a href="/challenges">open the challenges board</a>, click <strong>Start Here — Kali Warm-Up</strong>, and submit the flag from the note.</li>
-<li>Then start <strong>Mission 1 — Boreas</strong>.</li>
+<li>Keep this CTFd tab open. This is the flag-submission portal.</li>
+<li>Open your <strong>magic-link email</strong>. It lands on <strong>Mission Control</strong>.</li>
+<li>Choose <strong>POLARIS</strong>, click <strong>ENTER RANGE</strong>, and wait for the Kali desktop to open in-browser.</li>
+<li>On Kali, read <code>/home/kali/START_HERE.txt</code>. It points you to the warm-up note.</li>
+<li>Back on CTFd, open <a href="/challenges">Challenges</a>, solve <strong>Start Here — Kali Warm-Up</strong>, then start <strong>Mission 1 — Boreas</strong>.</li>
 </ol>
 </div>
-<!-- vale Google.EmDash = YES -->
 
 <div class="brief-tag">§ 00—ORIENTATION</div>
 
@@ -105,9 +104,11 @@ By participating in this CTF you acknowledge:
 
 ## First Moves
 
-1. Solve [**Start Here—Kali Warm-Up**](/challenges) for a quick first submit.
-2. Read the [Kali Quickstart](/kali-quickstart) for hostnames, tools, and copy-paste commands.
-3. Start with Mission 1—recon the front company.
+1. Use two browser tabs: CTFd for flags, Mission Control for the Kali range.
+2. Read `/home/kali/START_HERE.txt` inside Kali.
+3. Solve [**Start Here—Kali Warm-Up**](/challenges) so you know Kali access and CTFd submission both work.
+4. Read the [Kali Quickstart](/kali-quickstart) for hostnames, tools, and copy-paste commands.
+5. Start with Mission 1—recon the front company.
 
 ## Missions
 

--- a/scenario-dev/polaris/build/ctfd-pages/kali-quickstart.md
+++ b/scenario-dev/polaris/build/ctfd-pages/kali-quickstart.md
@@ -11,6 +11,27 @@ auth_required: true
 
 This page is for operators who want the shortest path from "my range is up" to "I'm solving flags."
 
+## First Five Minutes
+
+Use two browser tabs:
+
+- **CTFd:** `https://polaris.keplerops.com` for challenge briefs, hints, and flag submission.
+- **Mission Control:** your magic-link session at `https://dev.shifter.keplerops.com` for the POLARIS range and Kali desktop.
+
+When Kali opens, read the local starter:
+
+```bash
+cat /home/kali/START_HERE.txt
+```
+
+Then read the warm-up note and submit its flag back here in CTFd:
+
+```bash
+cat /home/kali/.polaris/welcome.txt
+```
+
+The warm-up only proves that your Kali desktop is reachable and that you can submit a flag in CTFd. After that, start Mission 1.
+
 ## Mission Reference
 
 Mission briefs, objectives, and the target map live on CTFd — in these pages and in the challenge descriptions themselves. The Kali box is for doing the work, not for reading docs. Submission is always on CTFd in your laptop browser; the Kali box has no route to it.

--- a/scenario-dev/polaris/content-packages/polaris/kali-start-here/package.yaml
+++ b/scenario-dev/polaris/content-packages/polaris/kali-start-here/package.yaml
@@ -1,0 +1,3 @@
+# Visible participant starter text for /home/kali/START_HERE.txt.
+# The active A14 image copies scenario-dev/polaris/build/A14-kali/START_HERE.txt
+# directly; this package keeps the SDL content reference resolvable.

--- a/scenario-dev/polaris/design/assets/A14-kali.md
+++ b/scenario-dev/polaris/design/assets/A14-kali.md
@@ -46,11 +46,11 @@ The participant's attack box. Pre-configured with standard offensive tooling plu
 
 ```
 /home/kali/
-  README.md          -- Mission brief, getting started guide
-  mission_brief.pdf  -- Full POLARIS operation brief (narrative setup)
+  START_HERE.txt     -- Visible first-five-minutes guide and local recovery path
   tools/
     modbus_scan.py   -- Helper for OT phase
-    flag_submit.sh   -- Quick flag submission to CTFd
+  .polaris/
+    welcome.txt      -- Warm-up challenge note and first flag
   .config/
     claude/          -- AI agent configuration
 ```
@@ -89,21 +89,19 @@ None. This is the attack platform, not a target.
    - API key / runtime model config injected by Shifter at deploy time
 
 4. **Create kali user home directory**
-   - `/home/kali/README.md` — mission brief, getting started guide
-   - `/home/kali/mission_brief.pdf` — full POLARIS operation brief (narrative setup)
+   - `/home/kali/START_HERE.txt` — visible first-five-minutes guide; explains the two-tab workflow and points to the warm-up note
+   - `/home/kali/.polaris/welcome.txt` — hidden warm-up challenge note containing the first flag
    - `/home/kali/tools/modbus_scan.py` — OT helper script
-   - `/home/kali/tools/flag_submit.sh` — quick CTFd flag submission script
 
-5. **Write the mission brief PDF**
-   - POLARIS operation narrative context
-   - High-level objectives (Mission 1-5 descriptions)
-   - Getting started hints (scan the network, look at the website first)
-   - CTFd URL and how to submit flags
+5. **Keep mission reference on CTFd**
+   - POLARIS narrative, mission objectives, challenge briefs, hints, and flag submission live on CTFd.
+   - Kali local content is only the first-five-minutes guide plus tooling notes.
+   - Avoid stale local copies of the full mission brief.
 
-6. **Write the flag submission helper**
-   - Shell script that POSTs to CTFd API
-   - Usage: `flag_submit.sh FLAG{...}`
-   - Pre-configured with CTFd URL and participant API token (injected at deploy time)
+6. **Keep flag submission browser-only**
+   - CTFd is reachable from the participant's laptop browser, not from Kali.
+   - Do not ship a required Kali-side flag submission helper.
+   - Local copy must say to submit flags in CTFd at `https://polaris.keplerops.com`.
 
 7. **Write the modbus_scan.py helper**
    - Scans a subnet for Modbus devices

--- a/scenario-dev/polaris/sdl/polaris-operation-northstorm.sdl.yaml
+++ b/scenario-dev/polaris/sdl/polaris-operation-northstorm.sdl.yaml
@@ -1298,7 +1298,14 @@ content:
     source: polaris/brain-protocol-seed
     sensitive: true
 
-  # Kali participant welcome
+  # Kali participant onboarding
+  kali-start-here:
+    type: file
+    format: txt
+    target: a14-kali
+    path: /home/kali/START_HERE.txt
+    source: polaris/kali-start-here
+
   kali-welcome:
     type: file
     format: txt

--- a/scenario-dev/polaris/tests/scenario_smoketest/README.md
+++ b/scenario-dev/polaris/tests/scenario_smoketest/README.md
@@ -33,8 +33,8 @@ Run from the range host (it executes commands in runner containers via
 `docker exec`):
 
 ```sh
-# Full range sweep against a staged range
-python3 -m scenario_smoketest
+# Covered range sweep against a staged range
+python3 -m scenario_smoketest --only 1,2,3,4,5,6,31
 
 # A subset of challenges
 python3 -m scenario_smoketest --only 1,2,3
@@ -58,6 +58,12 @@ smoketests under `../smoketests/`. Coverage is intentionally incremental: the
 report makes every uncovered challenge explicit, so the gap is visible rather
 than hidden. Add an adapter by registering a callable for a challenge id — see
 `adapters/mission1_osint.py` for the pattern.
+
+Current executable range-adapter coverage is challenges `1-6` and `31`. Use
+`--only 1,2,3,4,5,6,31` for pre-event validation until more adapters are added.
+Running `python3 -m scenario_smoketest` without `--only` is useful for coverage
+gap discovery, but it intentionally exits non-zero while uncovered board
+challenges remain.
 
 ## Tests
 

--- a/scenario-dev/polaris/tests/smoketests/A14-smoketest.sh
+++ b/scenario-dev/polaris/tests/smoketests/A14-smoketest.sh
@@ -27,14 +27,20 @@ echo "--- Content files ---"
 # in 2026-04 (see scenario-dev/polaris/build/a14/Dockerfile:85): they were
 # stale relative to the CTFd board and Kali has no route to CTFd, so a
 # Kali-side submission helper is broken by design. CTFd is the reference.
-# The remaining content drops are modbus_scan.py (Mission 4 helper), the
-# Claude POLARIS system prompt, and the warm-up challenge target.
+# The remaining content drops are START_HERE.txt (visible participant
+# onramp), modbus_scan.py (Mission 4 helper), the Claude POLARIS system
+# prompt, and the warm-up challenge target.
 for f in /home/kali/tools/modbus_scan.py \
+         /home/kali/START_HERE.txt \
          /home/kali/.config/claude/system_prompt.txt \
          /home/kali/.polaris/welcome.txt; do
     [[ -f "$f" ]] && pass "$f present" || fail "$f missing"
 done
 [[ -x /home/kali/tools/modbus_scan.py ]] && pass "modbus_scan.py executable" || fail "modbus_scan.py not exec"
+grep -q 'polaris.keplerops.com' /home/kali/START_HERE.txt \
+    && pass "START_HERE names CTFd" || fail "START_HERE missing CTFd URL"
+grep -q 'cannot submit flags to CTFd' /home/kali/START_HERE.txt \
+    && pass "START_HERE explains CTFd is browser-only" || fail "START_HERE missing browser-only guidance"
 
 echo
 echo "--- Kali user and services ---"

--- a/scripts/ctfd-workshop/README.md
+++ b/scripts/ctfd-workshop/README.md
@@ -22,6 +22,11 @@ After apply:
 3. If the hostname should sit behind Cloudflare, switch the same `A` record to
    proxied after origin HTTPS works and set Cloudflare SSL/TLS mode to
    `Full (strict)`.
+   Do not leave a Managed Challenge, Bot Fight Mode, Browser Integrity Check,
+   or equivalent challenge action in front of the CTFd hostname unless the
+   event explicitly accepts that participant and API traffic may be challenged.
+   A smoke check to `https://<ctfd-hostname>/login` should return the CTFd login
+   page, not a Cloudflare `cf-mitigated: challenge` response.
 4. Complete the CTFd setup wizard in the browser.
 5. Generate an admin API token in CTFd and export it as `CTFD_TOKEN`.
 

--- a/scripts/ctfd-workshop/README.md
+++ b/scripts/ctfd-workshop/README.md
@@ -15,9 +15,15 @@ AWS_PROFILE=panw-shifter-dev-workstation terraform apply -var-file=dev.tfvars
 After apply:
 
 1. Create the external DNS `A` record for the CTFd hostname to the new Elastic IP.
+   In Cloudflare, keep the record DNS-only for the first certbot run and put
+   only the IP address in the target field, not an `http://` or `https://` URL.
 2. Use the Terraform `certbot_command` output over SSM after DNS resolves.
-3. Complete the CTFd setup wizard in the browser.
-4. Generate an admin API token in CTFd and export it as `CTFD_TOKEN`.
+   Verify `https://<ctfd-hostname>/login` reaches CTFd from outside AWS.
+3. If the hostname should sit behind Cloudflare, switch the same `A` record to
+   proxied after origin HTTPS works and set Cloudflare SSL/TLS mode to
+   `Full (strict)`.
+4. Complete the CTFd setup wizard in the browser.
+5. Generate an admin API token in CTFd and export it as `CTFD_TOKEN`.
 
 ## Polaris Onboarding Pages + Start Here Warm-Up
 


### PR DESCRIPTION
## Summary

- Add a local A14 Kali `START_HERE.txt` onramp and wire it into the A14 image build/source manifest.
- Tighten Polaris CTFd onboarding, quickstart, unstuck guidance, briefing deck, and seat handout so participants get an explicit first move.
- Clarify the Mission 5 bunker relay handoff: use `ssh root@splice-relay`, no password, with the staged per-range key at `/home/kali/.ssh/splice_relay`.
- Document Polaris CTF smoke coverage and CTFd Cloudflare setup caveats found during aws-dev bring-up.

## Why

Prior event feedback showed participants could miss the first clue, lose the basic getting-started instructions, or hit the bunker relay without knowing the intended auth path. These changes put the starter instructions in CTFd, the deck/handout, and the Kali desktop image source, while keeping the runtime bunker behavior unchanged.

## Validation

- `jq empty scenario-dev/polaris/build/ctfd-challenges.json`
- Polaris manifest validation
- `bash -n scenario-dev/polaris/tests/smoketests/A14-smoketest.sh`
- `pre-commit run --files ...` for the changed Polaris/CTFd content
- `uv run --with pytest python -m pytest -q scenario-dev/polaris/tests/test_scenario_smoketest.py -k 'mission5 or challenge_31'`
- Live CTFd sync completed and DB readback verified `Underground Signals` has the updated no-password relay guidance, two hints, and one flag row.

Fixes #907