### PR TITLE
infra: scale dev portal for event load

### DIFF
--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -249,6 +249,48 @@ terraform init -backend-config=dev.s3.tfbackend
 terraform plan
 ```
 
+For event-sized AWS dev runs, keep the GitHub Actions variable
+`AWS_PORTAL_ENABLE_AUTOSCALING=true` in sync with the portal tfvars. That
+variable controls whether the deploy job uses the ASG refresh path instead of
+the single-instance SSM path. The deployment-owned `TF_VARS_DEV_PORTAL` payload
+should also carry the event sizing values from the committed baseline when you
+want the live account to use the ASG, warm pool, Redis channel layer, and larger
+Guacamole/Postgres capacity:
+
+```hcl
+enable_autoscaling     = true
+asg_min_size           = 2
+asg_max_size           = 8
+asg_desired_capacity   = 2
+asg_warm_pool_min_size = 2
+asg_warm_pool_state    = "Stopped"
+enable_redis           = true
+
+db_instance_class        = "db.m6i.xlarge"
+db_allocated_storage     = 100
+db_max_allocated_storage = 500
+db_backup_retention_days = 7
+
+redis_node_type = "cache.m6g.xlarge"
+
+guacd_cpu                      = 2048
+guacd_memory                   = 4096
+guacamole_client_cpu           = 2048
+guacamole_client_memory        = 4096
+guacd_desired_count            = 6
+guacamole_client_desired_count = 4
+
+guacamole_db_instance_class        = "db.m6i.xlarge"
+guacamole_db_allocated_storage     = 100
+guacamole_db_max_allocated_storage = 500
+guacamole_db_multi_az              = true
+
+guacamole_enable_autoscaling       = true
+guacamole_autoscaling_min_capacity = 4
+guacamole_autoscaling_max_capacity = 10
+guacamole_autoscaling_cpu_target   = 60
+```
+
 ```sh
 # GCP gcp-dev
 cat > platform/terraform/gcp/environments/gcp-dev/local.auto.tfvars <<EOF

--- a/platform/terraform/environments/dev/portal/main.tf
+++ b/platform/terraform/environments/dev/portal/main.tf
@@ -481,16 +481,18 @@ module "ec2" {
   ecs_execution_role_arn     = module.engine_provisioner.ecs_execution_role_arn
 
   # Autoscaling configuration
-  enable_autoscaling   = var.enable_autoscaling
-  subnet_ids           = module.vpc.private_subnet_ids
-  target_group_arn     = module.alb.target_group_arn
-  asg_min_size         = var.asg_min_size
-  asg_max_size         = var.asg_max_size
-  asg_desired_capacity = var.asg_desired_capacity
-  redis_endpoint       = var.enable_redis ? module.redis.redis_endpoint : ""
-  scale_up_threshold   = var.scale_up_threshold
-  scale_down_threshold = var.scale_down_threshold
-  log_retention_days   = var.log_retention_days
+  enable_autoscaling     = var.enable_autoscaling
+  subnet_ids             = module.vpc.private_subnet_ids
+  target_group_arn       = module.alb.target_group_arn
+  asg_min_size           = var.asg_min_size
+  asg_max_size           = var.asg_max_size
+  asg_desired_capacity   = var.asg_desired_capacity
+  asg_warm_pool_min_size = var.asg_warm_pool_min_size
+  asg_warm_pool_state    = var.asg_warm_pool_state
+  redis_endpoint         = var.enable_redis ? module.redis.redis_endpoint : ""
+  scale_up_threshold     = var.scale_up_threshold
+  scale_down_threshold   = var.scale_down_threshold
+  log_retention_days     = var.log_retention_days
 
   # Messaging (SQS queues for message consumers)
   sqs_queue_arns  = values(module.messaging.sqs_queue_arns)

--- a/platform/terraform/environments/dev/portal/terraform.tfvars
+++ b/platform/terraform/environments/dev/portal/terraform.tfvars
@@ -34,11 +34,11 @@ enable_nat_gateway = true
 db_name                  = "shifter"
 db_username              = "shifter_admin"
 db_engine_version        = "16"
-db_instance_class        = "db.m5.large"
-db_allocated_storage     = 20
-db_max_allocated_storage = 50
+db_instance_class        = "db.m6i.xlarge"
+db_allocated_storage     = 100
+db_max_allocated_storage = 500
 db_multi_az              = true
-db_backup_retention_days = 1
+db_backup_retention_days = 7
 db_deletion_protection   = false
 db_skip_final_snapshot   = true
 db_apply_immediately     = true
@@ -49,8 +49,8 @@ db_apply_immediately     = true
 
 # Standard AL2023 AMI (NOT ECS-optimized) - us-east-2
 ec2_ami_id           = "ami-00e428798e77d38d9"
-ec2_instance_type    = "m5.xlarge"
-ec2_root_volume_size = 30
+ec2_instance_type    = "m6i.xlarge"
+ec2_root_volume_size = 50
 
 # Standalone CTFd host in the portal VPC
 enable_ctfd                 = true
@@ -115,24 +115,25 @@ kali_instance_type   = "t3.large"
 # Autoscaling
 # ------------------------------------------------------------------------------
 
-enable_autoscaling   = false
-asg_min_size         = 1
-asg_max_size         = 1
-asg_desired_capacity = 1
-scale_up_threshold   = 70
-scale_down_threshold = 30
+enable_autoscaling     = true
+asg_min_size           = 2
+asg_max_size           = 8
+asg_desired_capacity   = 2
+asg_warm_pool_min_size = 2
+asg_warm_pool_state    = "Stopped"
+scale_up_threshold     = 70
+scale_down_threshold   = 30
 
 # Channel-layer backend (ADR-018, #849), decoupled from autoscaling above.
-# Dev keeps the in-memory channel layer (Redis provisioned but unused). Flip to
-# true to run the portal on Redis for event-representative websocket behavior;
-# no change to enable_autoscaling is required.
-enable_redis = false
+# Event-representative dev runs the portal on Redis so websocket behavior is
+# shared across the ASG instead of being pinned to per-instance memory.
+enable_redis = true
 
 # ------------------------------------------------------------------------------
 # Redis
 # ------------------------------------------------------------------------------
 
-redis_node_type          = "cache.m6g.large"
+redis_node_type          = "cache.m6g.xlarge"
 redis_engine_version     = "7.1"
 redis_enable_replication = true
 
@@ -187,29 +188,29 @@ dc_domain_name = "internal.shifter"
 
 guacd_image_tag                = "1.5.5"
 guacamole_client_image_tag     = "1.5.5"
-guacd_cpu                      = 1024
-guacd_memory                   = 2048
-guacamole_client_cpu           = 1024
-guacamole_client_memory        = 2048
-guacd_desired_count            = 4
-guacamole_client_desired_count = 3
+guacd_cpu                      = 2048
+guacd_memory                   = 4096
+guacamole_client_cpu           = 2048
+guacamole_client_memory        = 4096
+guacd_desired_count            = 6
+guacamole_client_desired_count = 4
 
 # Database
-guacamole_db_instance_class        = "db.m5.xlarge"
-guacamole_db_allocated_storage     = 20
-guacamole_db_max_allocated_storage = 50
+guacamole_db_instance_class        = "db.m6i.xlarge"
+guacamole_db_allocated_storage     = 100
+guacamole_db_max_allocated_storage = 500
 guacamole_db_engine_version        = "16"
-guacamole_db_multi_az              = false
+guacamole_db_multi_az              = true
 guacamole_db_backup_retention_days = 7
 guacamole_db_deletion_protection   = false
 guacamole_db_skip_final_snapshot   = true
 guacamole_db_apply_immediately     = true
 
-# Autoscaling (disabled for initial testing)
-guacamole_enable_autoscaling       = false
-guacamole_autoscaling_min_capacity = 1
-guacamole_autoscaling_max_capacity = 4
-guacamole_autoscaling_cpu_target   = 70
+# Autoscaling
+guacamole_enable_autoscaling       = true
+guacamole_autoscaling_min_capacity = 4
+guacamole_autoscaling_max_capacity = 10
+guacamole_autoscaling_cpu_target   = 60
 
 # Secrets
 guacamole_secrets_recovery_window_days = 0

--- a/platform/terraform/environments/dev/portal/variables.tf
+++ b/platform/terraform/environments/dev/portal/variables.tf
@@ -293,6 +293,21 @@ variable "asg_desired_capacity" {
   type        = number
 }
 
+variable "asg_warm_pool_min_size" {
+  description = "Minimum number of pre-initialized portal instances to keep in the ASG warm pool. Set 0 to disable."
+  type        = number
+}
+
+variable "asg_warm_pool_state" {
+  description = "Warm pool instance state. Valid values are Stopped, Running, or Hibernated."
+  type        = string
+
+  validation {
+    condition     = contains(["Stopped", "Running", "Hibernated"], var.asg_warm_pool_state)
+    error_message = "asg_warm_pool_state must be one of: Stopped, Running, Hibernated."
+  }
+}
+
 variable "scale_up_threshold" {
   description = "CPU percentage threshold to trigger scale up"
   type        = number

--- a/platform/terraform/modules/portal/ec2/main.tf
+++ b/platform/terraform/modules/portal/ec2/main.tf
@@ -555,6 +555,19 @@ resource "aws_autoscaling_group" "this" {
     }
   }
 
+  dynamic "warm_pool" {
+    for_each = var.asg_warm_pool_min_size > 0 ? [1] : []
+
+    content {
+      min_size   = var.asg_warm_pool_min_size
+      pool_state = var.asg_warm_pool_state
+
+      instance_reuse_policy {
+        reuse_on_scale_in = true
+      }
+    }
+  }
+
   dynamic "tag" {
     for_each = merge(local.common_tags, {
       Name = "${var.name_prefix}-ec2"

--- a/platform/terraform/modules/portal/ec2/variables.tf
+++ b/platform/terraform/modules/portal/ec2/variables.tf
@@ -149,6 +149,23 @@ variable "asg_desired_capacity" {
   type        = number
 }
 
+variable "asg_warm_pool_min_size" {
+  description = "Minimum number of pre-initialized instances to keep in the ASG warm pool. Set 0 to disable the warm pool."
+  type        = number
+  default     = 0
+}
+
+variable "asg_warm_pool_state" {
+  description = "Warm pool instance state. Valid values are Stopped, Running, or Hibernated."
+  type        = string
+  default     = "Stopped"
+
+  validation {
+    condition     = contains(["Stopped", "Running", "Hibernated"], var.asg_warm_pool_state)
+    error_message = "asg_warm_pool_state must be one of: Stopped, Running, Hibernated."
+  }
+}
+
 variable "redis_endpoint" {
   description = "Redis endpoint for Django Channels"
   type        = string


### PR DESCRIPTION
## Summary

- Enable event-representative dev portal ASG settings: two live instances, scale room to eight, and two prepared warm-pool instances in `Stopped` state.
- Wire Redis as the dev portal channel layer and size the Redis replication group up to `cache.m6g.xlarge`.
- Increase portal Postgres and Guacamole Postgres to `db.m6i.xlarge` with 100 GB initial / 500 GB max storage and enable Guacamole Multi-AZ.
- Increase Guacamole ECS task CPU/memory/counts and enable Guacamole service autoscaling.
- Document that `AWS_PORTAL_ENABLE_AUTOSCALING=true` must stay aligned with the `TF_VARS_DEV_PORTAL` payload so the deploy job uses ASG refresh instead of single-instance SSM.

## Deployment note

This PR only changes repo configuration. It does not directly mutate the aws-dev account. For the live deployment, the GitHub Actions `TF_VARS_DEV_PORTAL` payload needs to include the same sizing values if it currently overrides them, and the repository/environment variable `AWS_PORTAL_ENABLE_AUTOSCALING` must be `true`.

## Validation

- `terraform fmt -recursive platform/terraform/modules/portal/ec2 platform/terraform/environments/dev/portal`
- `terraform -chdir=platform/terraform/modules/portal/ec2 validate -no-color`
- `terraform -chdir=platform/terraform/environments/dev/portal validate -no-color`
- `tflint --recursive --config /home/atomik/src/shifter/.tflint.hcl`
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- pre-commit hooks during commit, including Terraform fmt/validate, tflint, checkov, Secrets Manager KMS grant check, and ADR guard fast

Terraform validate reports existing provider deprecation warnings in Guacamole service discovery and `data.aws_region.current.name`; no validation errors.