### PR TITLE
ci: gate shifter_platform deploy on Shifter Engine success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -433,7 +433,7 @@ jobs:
       (needs.changes.outputs.shifter_platform == 'true' || github.event_name == 'workflow_dispatch') &&
       (needs.core.result == 'success' || needs.core.result == 'skipped') &&
       (needs.range.result == 'success' || needs.range.result == 'skipped') &&
-      needs.shifter-engine.result != 'cancelled' &&
+      (needs.shifter-engine.result == 'success' || needs.shifter-engine.result == 'skipped') &&
       (needs.quality.result == 'success' || needs.quality.result == 'skipped')
     uses: ./.github/workflows/_shifter-platform.yml
     with:

--- a/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
@@ -59,14 +59,20 @@ Quality (must pass first)
     ▼
   Core (ECR)
     │
-    ├──────────────┬─────────────────┐
-    ▼              ▼                 ▼
-  Range    Shifter Engine    Portal Plan
-                   │                 │
-                   └────────┬────────┘
-                            ▼
-                      Portal Deploy
+    ├──────────────┐
+    ▼              ▼
+  Range    Shifter Engine
+    │              │
+    └──────────────┘
+            │
+            ▼
+  Shifter Platform Plan/Deploy
 ```
+
+Downstream AWS jobs use explicit `needs.<job>.result` gates. A skipped upstream
+is acceptable when its path filter did not select it, but a failed or cancelled
+upstream must stop dependent infrastructure work. In particular, Shifter Platform
+must not plan or apply on top of a failed Shifter Engine deploy.
 
 ## Change Detection
 
@@ -77,7 +83,8 @@ The orchestrator uses path filters to run only relevant jobs:
 | `core` | ECR module, environment root, deploy workflow |
 | `range` | Range Terraform, engine state module |
 | `shifter_engine` | Shifter Engine code, ECR module |
-| `shifter_platform` | Shifter Django code, portal/Guacamole Terraform |
+| `shifter_platform` | Portal/Guacamole Terraform and platform deploy workflow |
+| `shifter_app` | Shifter Django application source, routed to Quality without launching a platform Terraform plan |
 | `gcp` | GCP Terraform, GCP Kubernetes assets, GCP scripts, GCP cloud adapters |
 
 ## Quality Gate
@@ -144,7 +151,7 @@ After Terraform apply, AWS platform deployment:
 
 1. Build Docker image
 2. Push to ECR with tags: `latest`, `{git-sha}`
-3. Find target EC2 instance(s) via tags
+3. Find target EC2 instances via tags
 4. SSM send-command to pull and run new container
 
 **Single Instance Mode**: Deploys to `{env}-portal-ec2` tagged instance.


### PR DESCRIPTION
## Summary

Fixes a CI orchestration bug in `.github/workflows/deploy.yml`: the `shifter_platform` job gated its `shifter-engine` upstream on `result != 'cancelled'`, which lets a `failure` result satisfy the condition, so Platform planned/applied on top of a failed Shifter Engine deploy. The fix gates `shifter-engine` the same way as the sibling `core`, `range`, and `quality` upstreams — `result == 'success' || result == 'skipped'` — so a failed Engine deploy now halts the pipeline. This is a CI-workflow + docs change: no application source, no migration, and no changelog fragment is required (CI-only and docs-only diffs are both fragment-exempt).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #781

## ADR Impact

- ADR-021
- ADR-003

## Changes

- deploy.yml: gate the `shifter_platform` job on `needs.shifter-engine.result == 'success' || == 'skipped'` instead of `!= 'cancelled'`, matching the core/range/quality idiom in the same `if:` block
- ci-cd.md: correct the AWS deploy dependency diagram and document that a failed/cancelled upstream must stop dependent infra work (Platform must not plan/apply on top of a failed Engine deploy); plus a Vale plural cleanup
- Verified: actionlint on deploy.yml, `adr_guard --all --level ci`, Vale, and full `pre-commit run --all-files` all pass

## Test Plan

- Unit tests / integration tests: N/A — CI-workflow + docs change with no application-code surface
- Verified locally: actionlint, `python3 scripts/adr_guard/adr_guard.py --all --level ci`, Vale, and `pre-commit run --all-files`

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — CI-configuration change with no unit-testable surface in this repo)

## Checklist

- Changelog fragment: N/A — CI-only + docs-only change (both fragment-exempt)
- [x] Architectural docs updated (ci-cd.md dependency diagram + gating note)
- [x] No CI enforcement weakened; `deploy.yml` moves toward ADR-003-R3 fail-loud intent
