### PR TITLE
fix: restore application-code deploy trigger for the portal

### DIFF
--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -12,6 +12,19 @@ on:
       apply_changes:
         required: true
         type: boolean
+      # Split per concern (#913). `apply_changes` is deployment
+      # permission (environment branch / manual dispatch); these two
+      # say which paths actually changed. Terraform plan/apply and the
+      # Guacamole image publish run only for platform_changes;
+      # the portal image build/deploy runs for either signal.
+      platform_changes:
+        description: Terraform/platform-infrastructure inputs changed (or manual dispatch)
+        required: true
+        type: boolean
+      portal_image_changes:
+        description: Portal image source changed (or manual dispatch)
+        required: true
+        type: boolean
     secrets:
       AWS_ROLE_ARN:
         required: true
@@ -42,6 +55,7 @@ jobs:
     needs: push-guacamole-images
     if: |
       always() &&
+      inputs.platform_changes &&
       (needs.push-guacamole-images.result == 'success' ||
        needs.push-guacamole-images.result == 'skipped')
     defaults:
@@ -112,6 +126,7 @@ jobs:
     runs-on: self-hosted
     if: |
       inputs.apply_changes &&
+      inputs.platform_changes &&
       github.event_name != 'pull_request'
     env:
       GUACD_REPO: ${{ inputs.is_dev && 'shifter-dev-guacd' || 'shifter-guacd' }}
@@ -162,6 +177,7 @@ jobs:
     if: |
       always() &&
       inputs.apply_changes &&
+      inputs.platform_changes &&
       (needs.plan.result == 'success' || needs.plan.result == 'skipped') &&
       (needs.push-guacamole-images.result == 'success' || needs.push-guacamole-images.result == 'skipped') &&
       github.event_name != 'pull_request'
@@ -359,7 +375,19 @@ jobs:
     name: Build (${{ inputs.environment }})
     runs-on: self-hosted
     needs: apply
-    if: inputs.apply_changes && github.event_name != 'pull_request'
+    # Runs for Terraform changes (after a successful apply) AND for
+    # app-only changes (#913), where plan/apply are legitimately
+    # skipped. Fail-closed: a skipped apply passes only when no
+    # Terraform change was requested, so a failed/cancelled plan or
+    # apply (or an upstream failure that skipped apply on a
+    # Terraform-relevant run) still blocks the image deploy.
+    if: |
+      always() &&
+      inputs.apply_changes &&
+      github.event_name != 'pull_request' &&
+      (inputs.platform_changes || inputs.portal_image_changes) &&
+      (needs.apply.result == 'success' ||
+       (needs.apply.result == 'skipped' && !inputs.platform_changes))
     outputs:
       image_tag: ${{ steps.sha.outputs.short }}
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
       shifter_engine: ${{ steps.filter.outputs.shifter_engine }}
       shifter_platform: ${{ steps.filter.outputs.shifter_platform }}
       shifter_app: ${{ steps.filter.outputs.shifter_app }}
+      portal_image: ${{ steps.filter.outputs.portal_image }}
       mcp: ${{ steps.filter.outputs.mcp }}
       gcp: ${{ steps.filter.outputs.gcp }}
       aws_environment: ${{ steps.env.outputs.aws_environment }}
@@ -102,6 +103,22 @@ jobs:
               - '.github/workflows/_shifter-platform.yml'
             shifter_app:
               - 'shifter/**'
+            # Portal image build/deploy trigger (#913). Mirrors the
+            # portal image's build inputs: the Docker context controls
+            # plus every tree the Dockerfile COPYs
+            # (shifter_platform, cyberscript, installation). Kept
+            # separate from the Terraform-only `shifter_platform`
+            # filter (ADR-003-R2) and from the broad Quality-only
+            # `shifter_app` filter so engine/packer-only changes do
+            # not redeploy the portal. In-app documentation under
+            # shifter/shifter_platform/documentation/** is image
+            # content, so it deploys with the image; top-level docs/**
+            # never does.
+            portal_image:
+              - 'shifter/shifter_platform/**'
+              - 'shifter/cyberscript/**'
+              - 'shifter/installation/**'
+              - 'shifter/.dockerignore'
             mcp:
               - 'mcp/**'
               - '.github/workflows/_quality.yml'
@@ -430,7 +447,9 @@ jobs:
     if: |
       always() &&
       needs.changes.outputs.run_aws == 'true' &&
-      (needs.changes.outputs.shifter_platform == 'true' || github.event_name == 'workflow_dispatch') &&
+      (needs.changes.outputs.shifter_platform == 'true' ||
+       needs.changes.outputs.portal_image == 'true' ||
+       github.event_name == 'workflow_dispatch') &&
       (needs.core.result == 'success' || needs.core.result == 'skipped') &&
       (needs.range.result == 'success' || needs.range.result == 'skipped') &&
       (needs.shifter-engine.result == 'success' || needs.shifter-engine.result == 'skipped') &&
@@ -440,6 +459,12 @@ jobs:
       environment: ${{ needs.changes.outputs.aws_environment }}
       is_dev: ${{ needs.changes.outputs.aws_is_dev == 'true' }}
       apply_changes: ${{ needs.changes.outputs.apply_aws == 'true' }}
+      # Split per concern (#913): Terraform plan/apply stays scoped to
+      # Terraform-relevant changes, while app-only changes drive just
+      # the portal image build/deploy. workflow_dispatch remains the
+      # deliberate full-deploy path for both concerns.
+      platform_changes: ${{ needs.changes.outputs.shifter_platform == 'true' || github.event_name == 'workflow_dispatch' }}
+      portal_image_changes: ${{ needs.changes.outputs.portal_image == 'true' || github.event_name == 'workflow_dispatch' }}
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ROLE_ARN_DEV: ${{ secrets.AWS_ROLE_ARN_DEV }}

--- a/changelog.d/913.fixed.md
+++ b/changelog.d/913.fixed.md
@@ -1,0 +1,1 @@
+Pushes to AWS environment branches that change only portal application code (`shifter/shifter_platform/**`, `cyberscript`, `installation`) now build the portal image, update the SSM image-tag parameter, and converge the running fleet again. Terraform plan/apply still runs only for Terraform-relevant changes, and docs-only pushes still deploy nothing.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -58,7 +58,7 @@
       },
       {
         "id": "ADR-003-R2",
-        "description": "AWS platform Terraform plan routing must stay scoped to Terraform-consumed files, while platform application changes still trigger Quality through a separate app-source filter. AWS platform Terraform plan commands must wait for the state lock before failing.",
+        "description": "AWS platform Terraform plan routing must stay scoped to Terraform-consumed files, while platform application changes still trigger Quality through a separate app-source filter. AWS platform Terraform plan commands must wait for the state lock before failing. Portal application changes must keep reaching the portal image build/deploy path through the dedicated portal_image filter wired into the shifter_platform job trigger and the platform build job's portal_image_changes input, without widening the Terraform-scoped plan trigger.",
         "checks": ["deploy-workflow-plan-scope"]
       },
       {

--- a/docs/architecture/portal-app-deploy-trigger-preflight-913.md
+++ b/docs/architecture/portal-app-deploy-trigger-preflight-913.md
@@ -1,0 +1,177 @@
+# Portal App Deploy Trigger Preflight (#913)
+
+Status: pre-implementation guidance
+
+Date: 2026-06-11
+
+Issue: GitHub #913, "deploy: restore an application-code deploy trigger for
+the portal".
+
+This issue is requirement-free. The GitHub issue title, body, and acceptance
+criteria are the shipping contract. This note is intentionally not an
+implementation plan.
+
+## Scope Boundary
+
+Treat this as AWS deploy-routing work, not a portal runtime feature. The defect
+is that an AWS environment-branch push can change code that is baked into the
+portal image while the deploy workflow reports success without building or
+converging that image.
+
+Keep these concepts separate:
+
+1. Terraform platform changes: inputs that require the portal Terraform plan and
+   apply path.
+2. Portal image changes: source files copied into
+   `shifter/shifter_platform/Dockerfile` from the `./shifter` Docker context.
+3. Quality-only source changes: repository source that should run Quality but
+   should not deploy the AWS portal.
+4. Deployment intent: branch/event routing that decides whether an AWS deploy is
+   allowed at all.
+
+Do not put `shifter/**` back into the `shifter_platform` filter. That would
+recreate the Terraform-plan spam #913 is trying to avoid.
+
+## Architecture Decisions
+
+- Preserve `shifter_platform` as the Terraform/platform-infrastructure signal.
+  It should continue to cover portal/Guacamole Terraform, environment portal
+  roots, and the reusable platform workflow itself.
+- Introduce or repurpose a separate portal-image signal for build/deploy. It
+  must not be confused with the existing broad `shifter_app` Quality signal
+  unless the implementation deliberately narrows or renames that signal.
+- Split reusable workflow inputs by concern. `apply_changes` is deployment
+  permission for environment branches/manual dispatch; it is not enough to tell
+  `_shifter-platform.yml` whether Terraform should run or whether only the
+  portal image should deploy.
+- The portal image build and deploy path must still wait for failed upstream
+  AWS jobs and must not run after a failed portal Terraform apply when Terraform
+  changes are present. App-only deploys may pass through skipped plan/apply
+  jobs, but not failed or cancelled ones.
+- Workflow dispatch remains a deliberate full deploy path. Automatic pushes
+  should be driven by explicit path signals, not broad "any Shifter source"
+  matching.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #913 |
+| --- | --- | --- |
+| AWS branch/event routing | `.github/workflows/deploy.yml` `changes` job and `run_aws` / `apply_aws` outputs | Keep deploy permission centralized in the orchestrator. Do not add branch parsing inside reusable jobs. |
+| Path filtering | `dorny/paths-filter` block in `.github/workflows/deploy.yml` | Add or refine named filters there; do not duplicate changed-file parsing in shell. |
+| Terraform platform plan/apply | `.github/workflows/_shifter-platform.yml` `plan`, `push-guacamole-images`, and `apply` jobs | Keep Terraform plan/apply gated on Terraform-relevant changes or manual dispatch, not app-only changes. |
+| Portal image build | `.github/workflows/_shifter-platform.yml` `build` job and `shifter/shifter_platform/Dockerfile` | Reuse the existing Buildx/ECR tag flow and short-SHA output. Do not create a parallel image publisher. |
+| Portal convergence | `.github/workflows/_shifter-platform.yml` `deploy` job | Reuse the existing SSM single-instance path, ASG instance-refresh path, SSM `/image-tag` contract, and fail-loud deploy checks. |
+| Image input surface | `shifter/shifter_platform/Dockerfile` and `shifter/.dockerignore` | The image copies `shifter_platform`, `cyberscript`, and `installation`; exclude local envs, caches, venvs, and node modules through the existing dockerignore. |
+| Architecture guardrails | `scripts/adr_guard/adr_guard.py`, `scripts/adr_guard/tests/test_adr_guard.py`, `docs/adr/index.yaml`, `shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md` | Existing ADR-003-R2 only protects plan scope and Quality routing; update it intentionally if the new deploy signal changes the contract. |
+| Operator docs | `shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md`, `shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/cicd.md` | Update stale path-filter docs after behavior changes; the platform-infrastructure doc currently still says `shifter_platform` includes `shifter/**`. |
+
+## Cross-Cutting Layers
+
+Security layers the intended design must satisfy:
+
+- GitHub auth/OIDC surface: keep AWS credentialing through
+  `aws-actions/configure-aws-credentials` with the existing caller permissions
+  (`contents: read`, `id-token: write`, `pull-requests: write` where plan
+  comments require it). Do not introduce long-lived AWS keys, PATs, or broader
+  token scopes for path routing.
+- Secret-handling surface: app-only deploy still writes a non-secret SSM
+  `/image-tag` value and may update optional bootstrap email SecureString
+  parameters through the existing deploy job. Do not log rendered tfvars,
+  SecureString values, Secrets Manager values, queue URLs, or container env
+  dumps while adding diagnostics.
+- Env-binding shape: use typed `workflow_call` boolean inputs for separate
+  concerns, for example `platform_changes` and `portal_image_changes`. Avoid
+  untyped magic env vars or shell-derived booleans with duplicated branch logic.
+- Config and policy validators: workflow edits must pass `actionlint`; guardrail
+  edits must update ADR docs and tests; architecture changes must pass
+  `python3 scripts/adr_guard/adr_guard.py --all --level ci`.
+- OS/process exposure: path booleans, image tags, repository names, instance
+  ids, ASG names, and command ids are acceptable in logs. Do not put secret
+  bodies or rendered tfvars content into argv, GitHub step summaries, SSM command
+  diagnostics, or PR comments.
+- Error and observability surface: keep GitHub Actions annotations and the
+  existing SSM/ASG deploy failure handling. A green run must mean the selected
+  deploy path actually built the image, updated `/image-tag`, and converged the
+  single instance or ASG.
+
+Maintainability incumbents the implementation must build on:
+
+- `deploy.yml` as the single place that turns branch/event/path information into
+  reusable workflow inputs.
+- `_shifter-platform.yml` as the single AWS portal image build/deploy workflow.
+- `shifter/shifter_platform/Dockerfile` as the source of truth for which source
+  directories affect the portal image.
+- ADR-003-R2 / `deploy-workflow-plan-scope` as the guardrail that prevents
+  app-only changes from launching Terraform plans.
+- ADR-003-R3 / `deploy-verification-fail-loud` as the guardrail that prevents a
+  selected deploy path from silently doing nothing.
+
+Extensibility seam:
+
+The needed seam is a typed reusable-workflow input pair:
+
+- `platform_changes`: run portal Terraform plan/apply and prerequisite
+  Guacamole image publication when the platform infrastructure contract changed
+  or the run is a deliberate full manual dispatch.
+- `portal_image_changes`: build/push/deploy the portal image when files copied
+  into the portal image changed or the run is a deliberate full manual dispatch.
+
+This keeps the next reasonable variation, such as "dependency-only portal image
+deploy" or "portal docs are image content", as a path-filter update rather than
+a rewrite of job dependencies or Terraform gates.
+
+## Whole-Repo Scope
+
+In scope for the implementation:
+
+- `.github/workflows/deploy.yml`
+- `.github/workflows/_shifter-platform.yml`
+- `scripts/adr_guard/adr_guard.py` and
+  `scripts/adr_guard/tests/test_adr_guard.py` if ADR-003-R2 needs to recognize
+  the new deploy signal
+- `docs/adr/index.yaml` and
+  `shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md`
+  if the guardrail contract changes
+- `shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md` and
+  `shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/cicd.md`
+  after workflow behavior changes
+
+Usually out of scope:
+
+- Terraform module redesign, ECR repository changes, IAM trust changes, SSM
+  parameter naming changes, Django settings, entrypoint secret hydration,
+  Guacamole runtime behavior, GCP deploy routing, and engine deploy behavior.
+
+## Gotchas And Anti-Patterns
+
+- Do not gate portal deploys directly on the current broad `shifter_app:
+  shifter/**` signal without deciding whether engine, packer, installation,
+  cyberscript, and in-app docs changes should deploy the AWS portal.
+- Do not make app-only changes run portal Terraform `plan` or `apply`. The fix
+  is to split plan/apply from image build/deploy, not to undo the May path-filter
+  split.
+- Do not let app-only deploys bypass failed upstream jobs. Skipped upstream jobs
+  are acceptable only when their path filter did not select them.
+- Do not let a skipped `apply` block app-only deploys purely because `build`
+  has `needs: apply`; use the existing `needs.<job>.result` pattern so skipped
+  and successful are distinguished from failed/cancelled.
+- Do not update `/image-tag` without building and pushing the same short-SHA
+  tag first.
+- Do not treat all docs as equivalent without a conscious decision. Top-level
+  `docs/**` should not trigger a portal deploy; in-app documentation under
+  `shifter/shifter_platform/documentation/**` is copied into the portal image,
+  so excluding it means those docs will not deploy automatically.
+- Do not weaken `deploy-workflow-plan-scope`, `deploy-verification-fail-loud`,
+  `actionlint`, Terraform validation, or Quality routing to make the workflow
+  pass.
+
+## Non-Goals
+
+- No implementation in this preflight note.
+- No new deploy framework, workflow parser, exception hierarchy, schema registry,
+  logging framework, monitoring stack, or persistence model.
+- No change to portal runtime configuration, app validation, auth surfaces,
+  secret stores, Terraform state, ECR repositories, SSM parameter names, or AWS
+  IAM policies unless the implementation uncovers an existing permissions bug.
+- No attempt to solve GCP fast-path behavior or engine deploy asymmetry; #913 is
+  limited to restoring the AWS portal application-code deploy trigger.

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -2283,6 +2283,10 @@ _PLAN_SCOPE_CHECK = "deploy-workflow-plan-scope"
 _PLAN_SCOPE_RULE = "ADR-003-R2"
 _SHIFTER_APP_OUTPUT = "shifter_app: ${{ steps.filter.outputs.shifter_app }}"
 _SHIFTER_APP_QUALITY_CONDITION = "needs.changes.outputs.shifter_app == 'true'"
+_PORTAL_IMAGE_OUTPUT = "portal_image: ${{ steps.filter.outputs.portal_image }}"
+_PORTAL_IMAGE_DEPLOY_CONDITION = "needs.changes.outputs.portal_image == 'true'"
+_PORTAL_IMAGE_REQUIRED_GLOB = "shifter/shifter_platform/**"
+_PORTAL_IMAGE_BUILD_INPUT = "inputs.portal_image_changes"
 
 
 def _deploy_plan_scope_relevant(files: list[str] | None) -> bool:
@@ -2416,6 +2420,59 @@ def _check_deploy_workflow_plan_routing(deploy_text: str) -> list[Violation]:
     return violations
 
 
+def _check_deploy_workflow_portal_image_routing(deploy_text: str) -> list[Violation]:
+    """Require the portal-image deploy trigger restored by #913.
+
+    Application-code changes must reach the portal build/deploy path through
+    a dedicated `portal_image` filter, without widening the Terraform-scoped
+    `shifter_platform` plan trigger.
+    """
+    portal_block = _paths_filter_block(deploy_text, "portal_image")
+    changes_block = _workflow_job_block(deploy_text, "changes")
+    platform_job_block = _workflow_job_block(deploy_text, "shifter_platform")
+    if not portal_block or not _active_line_contains(changes_block, _PORTAL_IMAGE_OUTPUT):
+        return [
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                "Portal application changes must retain a `portal_image` filter/output "
+                "so app-only pushes still build and deploy the portal image (#913); "
+                "missing the filter or changes-job output",
+            )
+        ]
+    if not _block_contains_glob(portal_block, _PORTAL_IMAGE_REQUIRED_GLOB):
+        return [
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                f"`portal_image` must include `{_PORTAL_IMAGE_REQUIRED_GLOB}` so portal "
+                "application changes trigger the image build/deploy path",
+            )
+        ]
+    if not _active_line_contains(platform_job_block, _PORTAL_IMAGE_DEPLOY_CONDITION):
+        return [
+            _plan_scope_violation(
+                _DEPLOY_WORKFLOW_PATH,
+                "The `shifter_platform` job must include "
+                f"`{_PORTAL_IMAGE_DEPLOY_CONDITION}` so application-code pushes still "
+                "invoke the portal build/deploy workflow",
+            )
+        ]
+    return []
+
+
+def _check_platform_build_portal_image_gate(platform_text: str) -> list[Violation]:
+    """Require the platform build job to gate on the portal-image input (#913)."""
+    build_block = _workflow_job_block(platform_text, "build")
+    if not build_block or not _active_line_contains(build_block, _PORTAL_IMAGE_BUILD_INPUT):
+        return [
+            _plan_scope_violation(
+                _PLATFORM_WORKFLOW_PATH,
+                f"The `build` job must gate on `{_PORTAL_IMAGE_BUILD_INPUT}` so app-only "
+                "changes build and deploy the portal image without running Terraform",
+            )
+        ]
+    return []
+
+
 def _check_platform_plan_lock_timeout(platform_text: str) -> list[Violation]:
     violations: list[Violation] = []
     for lineno, line in enumerate(platform_text.splitlines(), start=1):
@@ -2453,7 +2510,9 @@ def check_deploy_workflow_plan_scope(repo_root: Path, files: list[str] | None) -
             )
         )
     else:
-        violations.extend(_check_deploy_workflow_plan_routing(deploy_path.read_text(encoding="utf-8")))
+        deploy_text = deploy_path.read_text(encoding="utf-8")
+        violations.extend(_check_deploy_workflow_plan_routing(deploy_text))
+        violations.extend(_check_deploy_workflow_portal_image_routing(deploy_text))
 
     if not platform_path.exists():
         violations.append(
@@ -2463,7 +2522,9 @@ def check_deploy_workflow_plan_scope(repo_root: Path, files: list[str] | None) -
             )
         )
     else:
-        violations.extend(_check_platform_plan_lock_timeout(platform_path.read_text(encoding="utf-8")))
+        platform_text = platform_path.read_text(encoding="utf-8")
+        violations.extend(_check_platform_plan_lock_timeout(platform_text))
+        violations.extend(_check_platform_build_portal_image_gate(platform_text))
 
     return violations
 

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -122,17 +122,29 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
         *,
         platform_globs: list[str] | None = None,
         app_globs: list[str] | None = None,
+        portal_image_globs: list[str] | None = None,
         quality_condition: str = "needs.changes.outputs.shifter_app == 'true'",
+        include_portal_image_filter: bool = True,
+        portal_image_output: str = "portal_image: ${{ steps.filter.outputs.portal_image }}",
+        platform_job_condition: str = "needs.changes.outputs.portal_image == 'true'",
     ) -> str:
         platform_globs = platform_globs or ["platform/terraform/modules/portal/**"]
         app_globs = app_globs or ["shifter/**"]
+        portal_image_globs = portal_image_globs or ["shifter/shifter_platform/**"]
         platform_lines = "".join(f"              - '{glob}'\n" for glob in platform_globs)
         app_lines = "".join(f"              - '{glob}'\n" for glob in app_globs)
+        portal_image_filter = ""
+        if include_portal_image_filter:
+            portal_image_lines = "".join(
+                f"              - '{glob}'\n" for glob in portal_image_globs
+            )
+            portal_image_filter = f"            portal_image:\n{portal_image_lines}"
         return (
             "jobs:\n"
             "  changes:\n"
             "    outputs:\n"
             "      shifter_app: ${{ steps.filter.outputs.shifter_app }}\n"
+            f"      {portal_image_output}\n"
             "    steps:\n"
             "      - id: filter\n"
             "        with:\n"
@@ -141,17 +153,28 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
             f"{platform_lines}"
             "            shifter_app:\n"
             f"{app_lines}"
+            f"{portal_image_filter}"
             "  quality:\n"
             "    if: |\n"
             f"      {quality_condition}\n"
+            "  shifter_platform:\n"
+            "    if: |\n"
+            f"      {platform_job_condition}\n"
         )
 
-    def _platform_text(self, plan_args: str = "-no-color -lock-timeout=5m -out=tfplan") -> str:
+    def _platform_text(
+        self,
+        plan_args: str = "-no-color -lock-timeout=5m -out=tfplan",
+        build_condition: str = "inputs.portal_image_changes",
+    ) -> str:
         return (
             "jobs:\n"
             "  plan:\n"
             "    steps:\n"
             f"      - run: terraform plan {plan_args}\n"
+            "  build:\n"
+            "    if: |\n"
+            f"      {build_condition}\n"
         )
 
     def test_flags_python_glob_in_platform_plan_scope(self) -> None:
@@ -208,12 +231,19 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
                 repo_root,
                 "jobs:\n"
                 "  changes:\n"
+                "    outputs:\n"
+                "      portal_image: ${{ steps.filter.outputs.portal_image }}\n"
                 "    steps:\n"
                 "      - id: filter\n"
                 "        with:\n"
                 "          filters: |\n"
                 "            shifter_platform:\n"
-                "              - 'platform/terraform/modules/portal/**'\n",
+                "              - 'platform/terraform/modules/portal/**'\n"
+                "            portal_image:\n"
+                "              - 'shifter/shifter_platform/**'\n"
+                "  shifter_platform:\n"
+                "    if: |\n"
+                "      needs.changes.outputs.portal_image == 'true'\n",
                 self._platform_text(),
             )
 
@@ -248,6 +278,97 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
             self.assertEqual(len(violations), 1)
             self.assertIn("Quality", violations[0].message)
 
+    def test_flags_missing_portal_image_filter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(include_portal_image_filter=False),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-003-R2")
+            self.assertIn("portal_image", violations[0].message)
+
+    def test_flags_portal_image_filter_without_platform_source_glob(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(portal_image_globs=["shifter/cyberscript/**"]),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("shifter/shifter_platform/**", violations[0].message)
+
+    def test_flags_missing_portal_image_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(
+                    portal_image_output="# portal_image: ${{ steps.filter.outputs.portal_image }}"
+                ),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("output", violations[0].message)
+
+    def test_flags_platform_job_without_portal_image_trigger(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(
+                    platform_job_condition="needs.changes.outputs.shifter_platform == 'true'"
+                ),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("needs.changes.outputs.portal_image == 'true'", violations[0].message)
+
+    def test_flags_commented_portal_image_trigger(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(
+                    platform_job_condition="# needs.changes.outputs.portal_image == 'true'"
+                ),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("needs.changes.outputs.portal_image == 'true'", violations[0].message)
+
+    def test_flags_platform_build_without_portal_image_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(),
+                self._platform_text(build_condition="inputs.apply_changes"),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("inputs.portal_image_changes", violations[0].message)
+
     def test_flags_missing_required_workflow_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
@@ -267,6 +388,7 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
                 "  changes:\n"
                 "    outputs:\n"
                 "      # shifter_app: ${{ steps.filter.outputs.shifter_app }}\n"
+                "      portal_image: ${{ steps.filter.outputs.portal_image }}\n"
                 "    steps:\n"
                 "      - id: filter\n"
                 "        with:\n"
@@ -275,9 +397,14 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
                 "              - 'platform/terraform/modules/portal/**'\n"
                 "            shifter_app:\n"
                 "              - 'shifter/**'\n"
+                "            portal_image:\n"
+                "              - 'shifter/shifter_platform/**'\n"
                 "  quality:\n"
                 "    if: |\n"
                 "      # needs.changes.outputs.shifter_app == 'true'\n"
+                "  shifter_platform:\n"
+                "    if: |\n"
+                "      needs.changes.outputs.portal_image == 'true'\n"
             )
             self._write_workflows(repo_root, deploy, self._platform_text())
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -101,10 +101,16 @@ The first slice intentionally stays small:
   change filter in `.github/workflows/deploy.yml` must stay scoped to
   Terraform-consumed platform files, with application source changes routed
   through the separate `shifter_app` filter so Quality still runs without
-  launching a platform Terraform plan. The check also requires every
-  `terraform plan` command in `_shifter-platform.yml` to include
-  `-lock-timeout=5m`, so legitimate concurrent platform plans wait on the
-  backend state lock instead of failing immediately. On apply workflows,
+  launching a platform Terraform plan. Portal application changes must also
+  keep reaching the portal image build/deploy path (#913): the check requires
+  a `portal_image` filter covering `shifter/shifter_platform/**`, exposed as
+  a `changes`-job output, included in the `shifter_platform` job's trigger
+  condition, and consumed by the platform `build` job through the
+  `portal_image_changes` input — so an app-only push to an environment branch
+  builds and converges the portal image without running Terraform. The check
+  also requires every `terraform plan` command in `_shifter-platform.yml` to
+  include `-lock-timeout=5m`, so legitimate concurrent platform plans wait on
+  the backend state lock instead of failing immediately. On apply workflows,
   `_shifter-platform.yml` pushes the Guacamole ECR images before the
   platform Terraform plan because the Guacamole module resolves current
   image digests with `aws_ecr_image` data sources during plan. This ordering

--- a/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
@@ -85,6 +85,7 @@ The orchestrator uses path filters to run only relevant jobs:
 | `shifter_engine` | Shifter Engine code, ECR module |
 | `shifter_platform` | Portal/Guacamole Terraform and platform deploy workflow |
 | `shifter_app` | Shifter Django application source, routed to Quality without launching a platform Terraform plan |
+| `portal_image` | Portal image build inputs (`shifter/shifter_platform/**`, `cyberscript`, `installation`, `.dockerignore`); triggers the portal image build/deploy on environment branches without running Terraform |
 | `gcp` | GCP Terraform, GCP Kubernetes assets, GCP scripts, GCP cloud adapters |
 
 ## Quality Gate

--- a/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/cicd.md
+++ b/shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/cicd.md
@@ -37,7 +37,8 @@ Jobs run only when relevant files change. `deploy.yml` detects changes and trigg
 | **core** | `platform/terraform/modules/ecr/**`, `platform/terraform/environments/*/*.tf` |
 | **range** | `platform/terraform/modules/range/**`, `platform/terraform/environments/*/range/**` |
 | **shifter_engine** | `shifter/engine/provisioner/**`, `platform/terraform/modules/pulumi-provisioner/**` |
-| **shifter_platform** | `platform/terraform/modules/portal/**`, `shifter/**` |
+| **shifter_platform** | `platform/terraform/modules/portal/**`, `platform/terraform/modules/guacamole/**`, `platform/terraform/environments/*/portal/**` (Terraform only) |
+| **portal_image** | `shifter/shifter_platform/**`, `shifter/cyberscript/**`, `shifter/installation/**` (portal image build/deploy, no Terraform) |
 
 ## Environment Targeting
 


### PR DESCRIPTION
## Summary

Restores the portal's application-code deploy trigger (#911 review finding DP-3). Since commit 854e3dc22 scoped the `shifter_platform` filter to Terraform paths, an aws-dev push changing only portal application code built nothing and deployed nothing while reporting green. A new `portal_image` paths-filter (mirroring the portal Dockerfile's COPY surface) now drives the image build/deploy through typed `platform_changes`/`portal_image_changes` inputs on `_shifter-platform.yml`: Terraform plan/apply and the Guacamole publish stay scoped to Terraform changes, while app-only pushes run build + SSM image-tag update + fleet convergence. Gating is fail-closed: a skipped `apply` passes only when no Terraform change was requested; failed/cancelled upstream jobs still block. The ADR-003-R2 guard now enforces the trigger wiring so it cannot be silently removed again.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #913

## ADR Impact

- ADR-003 (amended)

## Changes

- deploy.yml: add `portal_image` filter (`shifter/shifter_platform/**`, `cyberscript`, `installation`, `.dockerignore`) + changes-job output; extend the `shifter_platform` job trigger; pass `platform_changes`/`portal_image_changes` into the reusable workflow
- _shifter-platform.yml: new required boolean inputs; gate `push-guacamole-images`/`plan`/`apply` on `platform_changes`; rewrite `build` gate to run on either signal with fail-closed skipped-apply handling; `deploy` unchanged (still requires a successful build)
- adr_guard: extend `deploy-workflow-plan-scope` (ADR-003-R2) with portal-image routing assertions on both workflows; 6 new unit tests plus fixture updates
- docs: update ADR registry description, adr-enforcement.md, dev/ci-cd.md filter table, and fix stale platform_infrastructure/cicd.md claim that `shifter_platform` includes `shifter/**`
- add changelog fragment and the #913 architecture preflight note

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Validated locally: 189 adr_guard unit tests, `adr_guard.py --all --level ci`, repo-wide actionlint, and two full pre-commit all-files runs. Acceptance behavior is enforced by the extended ADR-003-R2 guard; the behavioral workflow-gating suite is owned by open #921.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #913 ← .github/workflows/deploy.yml, #913 ← .github/workflows/_shifter-platform.yml, #913 ← scripts/adr_guard/adr_guard.py
- TESTS: #913 ← scripts/adr_guard/tests/test_adr_guard.py (DeployWorkflowPlanScopeTests, 6 new cases + real-repo check)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/913.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
