### PR TITLE
fix(deploy): render range tfvars from secrets

### DIFF
--- a/.github/workflows/_range.yml
+++ b/.github/workflows/_range.yml
@@ -17,6 +17,15 @@ on:
         required: true
       AWS_ROLE_ARN_DEV:
         required: true
+      # Whole-file local.auto.tfvars payload per environment. The committed
+      # terraform.tfvars is an example baseline; real per-deployment range
+      # values are rendered from these secrets before plan/apply. Declared
+      # required: false because GitHub evaluates reusable-workflow secrets at
+      # dispatch time; the render step fails loud for the active environment.
+      TF_VARS_DEV_RANGE:
+        required: false
+      TF_VARS_PROD_RANGE:
+        required: false
 
 jobs:
   plan:
@@ -40,6 +49,28 @@ jobs:
           terraform_version: "1.13.3"
       - run: terraform fmt -check -recursive
         working-directory: platform/terraform
+      - name: Render local.auto.tfvars from deployment secret
+        env:
+          IS_DEV: ${{ inputs.is_dev }}
+          TF_VARS_DEV_RANGE: ${{ secrets.TF_VARS_DEV_RANGE }}
+          TF_VARS_PROD_RANGE: ${{ secrets.TF_VARS_PROD_RANGE }}
+        run: |
+          # Select strictly on inputs.is_dev. Do not use an
+          # `is_dev && DEV_SECRET || PROD_SECRET` expression here: an empty
+          # active-environment secret is falsy and can fall through to the
+          # other environment's secret instead of failing loud.
+          if [ "${IS_DEV}" = "true" ]; then
+            RANGE_SECRET_NAME="TF_VARS_DEV_RANGE"
+            TF_VARS_RANGE="${TF_VARS_DEV_RANGE}"
+          else
+            RANGE_SECRET_NAME="TF_VARS_PROD_RANGE"
+            TF_VARS_RANGE="${TF_VARS_PROD_RANGE}"
+          fi
+          if [ -z "${TF_VARS_RANGE}" ]; then
+            echo "::error::Required secret ${RANGE_SECRET_NAME} is not set. See docs/dev/deploy-secrets.md."
+            exit 1
+          fi
+          printf '%s\n' "${TF_VARS_RANGE}" > local.auto.tfvars
       - run: terraform init -backend-config=${{ inputs.environment }}.s3.tfbackend
       - run: terraform validate
       - run: terraform plan -no-color -out=tfplan && terraform show -no-color tfplan > plan.txt
@@ -82,6 +113,26 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.13.3"
+      - name: Render local.auto.tfvars from deployment secret
+        env:
+          IS_DEV: ${{ inputs.is_dev }}
+          TF_VARS_DEV_RANGE: ${{ secrets.TF_VARS_DEV_RANGE }}
+          TF_VARS_PROD_RANGE: ${{ secrets.TF_VARS_PROD_RANGE }}
+        run: |
+          # Keep the apply job's rendering logic identical to plan so the
+          # applied values cannot diverge from the reviewed plan inputs.
+          if [ "${IS_DEV}" = "true" ]; then
+            RANGE_SECRET_NAME="TF_VARS_DEV_RANGE"
+            TF_VARS_RANGE="${TF_VARS_DEV_RANGE}"
+          else
+            RANGE_SECRET_NAME="TF_VARS_PROD_RANGE"
+            TF_VARS_RANGE="${TF_VARS_PROD_RANGE}"
+          fi
+          if [ -z "${TF_VARS_RANGE}" ]; then
+            echo "::error::Required secret ${RANGE_SECRET_NAME} is not set. See docs/dev/deploy-secrets.md."
+            exit 1
+          fi
+          printf '%s\n' "${TF_VARS_RANGE}" > local.auto.tfvars
       - run: terraform init -backend-config=${{ inputs.environment }}.s3.tfbackend
       - run: terraform apply -auto-approve
       - run: terraform output -json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -407,6 +407,8 @@ jobs:
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_ROLE_ARN_DEV: ${{ secrets.AWS_ROLE_ARN_DEV }}
+      TF_VARS_DEV_RANGE: ${{ secrets.TF_VARS_DEV_RANGE }}
+      TF_VARS_PROD_RANGE: ${{ secrets.TF_VARS_PROD_RANGE }}
 
   shifter-engine:
     name: Shifter Engine

--- a/changelog.d/916.security.md
+++ b/changelog.d/916.security.md
@@ -1,0 +1,1 @@
+Render AWS range Terraform tfvars from per-environment GitHub secrets, document the matching local overlay model, and replace committed account-bound bucket plus deployment-specific PAN-OS AMI values with placeholders.

--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -1,12 +1,12 @@
 # Deploy secrets and repository variables
 
-The committed `terraform.tfvars` files in `platform/terraform/.../portal/`
-and `platform/terraform/gcp/environments/...` ship an `example.com`
-baseline that's intentionally broken-on-deploy. Each environment provides
-its real deployment values via GitHub secrets and repository variables;
-the deploy workflows write them into a gitignored `local.auto.tfvars`
-that Terraform auto-loads alongside the baseline (the `.local`/`.auto`
-overrides win).
+The committed `terraform.tfvars` files in `platform/terraform/environments/...`
+and `platform/terraform/gcp/environments/...` ship account-neutral baselines
+that are intentionally broken-on-deploy where real account values are
+required. Each environment provides its real deployment values via GitHub
+secrets, repository variables, or a local operator overlay; deploy workflows
+write them into a gitignored `local.auto.tfvars` that Terraform auto-loads
+alongside the baseline (the `.local`/`.auto` overrides win).
 
 This file lists values that must be configured before a fresh deploy. Set values
 under **Settings → Secrets and variables → Actions**, separated by:
@@ -96,7 +96,11 @@ to use the `aws-dev` deploy branch:
    the target account to accept the free AWS Marketplace terms for product
    code `7lgvy7mt78lgoi4lant0znp5h`.
 4. Review `TF_VARS_DEV_PORTAL` for account-specific values such as domain
-   names, alarm email, SSH allowlists, and bucket names.
+   names, alarm email, SSH allowlists, and bucket names. Review
+   `TF_VARS_DEV_RANGE` for range deployment values such as the agent S3 bucket
+   and the regional PAN-OS VM-Series AMI. Bootstrap configures the AWS role
+   secret and backend files; the deploy workflows fail loud when the active
+   portal or range tfvars secret is missing.
 5. For the first deploy in a moved or fresh account, run the `Deploy`
    workflow manually with `workflow_dispatch` on `aws-dev`. Manual dispatch
    forces the full AWS chain (Core -> Range -> Engine -> Platform). A plain
@@ -176,12 +180,40 @@ VPC-local and is required for the routed middlebox path.
 
 ## AWS range (`dev` / `prod`)
 
-Range Terraform (under `platform/terraform/environments/<env>/range/`) is
-applied locally by operators today, not by GitHub Actions, so there is no
-CI secret to render — the operator writes the deployment-specific values
-into a gitignored `local.auto.tfvars` alongside `terraform.tfvars`. The
-committed `terraform.tfvars` ships an empty `victim_allowed_cidrs` baseline
-so the repo never carries a deployment's allowlist (PLAT-220 / #775).
+Consumed by `.github/workflows/_range.yml`. The committed
+`platform/terraform/environments/<env>/range/terraform.tfvars` is an
+account-neutral baseline. The workflow's `Render local.auto.tfvars from
+deployment secret` step is present in both the `plan` and `apply` jobs; it
+selects the active environment strictly from `inputs.is_dev`, writes the
+matching whole-file secret into `local.auto.tfvars`, and fails loud
+(`::error::`) when the active secret is empty.
+
+| Name | Kind | Required | Notes |
+|---|---|---|---|
+| `TF_VARS_DEV_RANGE` | secret | yes (dev) | Whole-file `local.auto.tfvars` payload for the dev range root, rendered verbatim over the committed baseline before `terraform plan` / `apply`. |
+| `TF_VARS_PROD_RANGE` | secret | yes (prod) | As above, for the prod range root. |
+
+At minimum, each `TF_VARS_<ENV>_RANGE` payload must set the deployment-specific
+values stripped from the committed baseline:
+
+- `agent_s3_bucket` — the account-specific user-storage bucket read by range
+  instance roles
+- `vm_series_ami_id` — the regional PAN-OS Marketplace AMI to use. This is
+  deployment configuration, not a credential; keep it in the overlay so the
+  shared repo does not prescribe a marketplace version/region for every
+  deployment.
+
+Local operators use the same model: write those values to a gitignored
+`local.auto.tfvars` alongside the range `terraform.tfvars`. In this repo's
+worktree workflow, `scripts/setup-worktree.sh` symlinks existing
+`local.auto.tfvars` overlays from the main checkout into worktrees so local
+plans do not lose the per-account values when branches change.
+
+The committed `terraform.tfvars` also ships an empty `victim_allowed_cidrs`
+baseline so the repo never carries a deployment's allowlist (PLAT-220 / #775).
+This completes the `_core.yml` / `_range.yml` deploy-tfvars audit from #784:
+the AWS core tfvars remain generic repository-name defaults, while account-bound
+and deployment-specific range values are supplied by secret or local overlay.
 
 For the PLAT-220 range egress allowlist:
 
@@ -189,7 +221,7 @@ For the PLAT-220 range egress allowlist:
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------- |
 | `platform/terraform/environments/{dev,prod}/range/terraform.tfvars`                  | committed; empty `victim_allowed_cidrs` baseline      |
 | `platform/terraform/environments/{dev,prod}/range/local.auto.tfvars.example`         | committed; shape reference                            |
-| `platform/terraform/environments/{dev,prod}/range/local.auto.tfvars`                 | gitignored; operator writes `victim_allowed_cidrs`    |
+| `platform/terraform/environments/{dev,prod}/range/local.auto.tfvars`                 | gitignored; operator writes account values and `victim_allowed_cidrs` |
 
 Source for the PANW Cortex XSIAM/XDR allowlist:
 <https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Administrator-Guide/Resources-Required-to-Enable-Access>.
@@ -244,6 +276,21 @@ user_storage_bucket   = "shifter-dev-user-storage-<your-account-id>"
 EOF
 
 cd platform/terraform/environments/dev/portal
+terraform init -backend-config=dev.s3.tfbackend
+terraform plan
+```
+
+```sh
+# AWS dev range
+cat > platform/terraform/environments/dev/range/local.auto.tfvars <<EOF
+agent_s3_bucket = "shifter-dev-user-storage-<your-account-id>"
+vm_series_ami_id = "ami-xxxxxxxxxxxxxxxxx"
+victim_allowed_cidrs = [
+  "<your-required-egress-cidr>/32",
+]
+EOF
+
+cd platform/terraform/environments/dev/range
 terraform init -backend-config=dev.s3.tfbackend
 terraform plan
 ```

--- a/platform/terraform/environments/dev/range/local.auto.tfvars.example
+++ b/platform/terraform/environments/dev/range/local.auto.tfvars.example
@@ -19,3 +19,6 @@ victim_allowed_cidrs = [
   # "8.8.8.8/32",
   # "203.0.113.0/24",
 ]
+
+agent_s3_bucket = "shifter-dev-user-storage-<your-account-id>"
+vm_series_ami_id = "ami-xxxxxxxxxxxxxxxxx"

--- a/platform/terraform/environments/dev/range/terraform.tfvars
+++ b/platform/terraform/environments/dev/range/terraform.tfvars
@@ -28,22 +28,17 @@ enable_flow_logs = true
 # Range Instance IAM
 # ------------------------------------------------------------------------------
 
-# Per-account suffix on the user-storage bucket. The dev account is
-# 788327019743 (verified via `aws sts get-caller-identity` 2026-05-05).
-# The earlier `e3462f0c` suffix was from a previous dev account; the
-# `dev-range-range-instance` IAM role's `s3-agent-read` policy was
-# pointing at a bucket the current account doesn't own, so any range
-# instance trying to fetch from S3 via the instance profile got 403.
-# Found while debugging the polaris-vm bake (the bake exemplar uses a
-# dedicated `polaris-bake-instance` role to side-step this; production
-# range path needs the value here to be right).
-agent_s3_bucket = "shifter-dev-user-storage-788327019743"
+# Per-deployment value rendered from TF_VARS_DEV_RANGE into local.auto.tfvars.
+# Keep the committed baseline account-neutral; apply jobs fail loud when the
+# deployment overlay is absent.
+agent_s3_bucket = "REPLACE_AGENT_S3_BUCKET"
 
 # ------------------------------------------------------------------------------
 # VM-Series NGFW (optional)
 # ------------------------------------------------------------------------------
 
-vm_series_ami_id        = "ami-065e27477b191614c" # PAN-OS 11.2.8
+# Regional PAN-OS Marketplace AMI rendered from the deployment overlay.
+vm_series_ami_id        = "REPLACE_VM_SERIES_AMI_ID"
 vm_series_instance_type = "m5.xlarge"
 
 # ------------------------------------------------------------------------------

--- a/platform/terraform/environments/prod/range/local.auto.tfvars.example
+++ b/platform/terraform/environments/prod/range/local.auto.tfvars.example
@@ -19,3 +19,6 @@ victim_allowed_cidrs = [
   # "8.8.8.8/32",
   # "203.0.113.0/24",
 ]
+
+agent_s3_bucket = "shifter-user-storage-<your-account-id-or-suffix>"
+vm_series_ami_id = "ami-xxxxxxxxxxxxxxxxx"

--- a/platform/terraform/environments/prod/range/terraform.tfvars
+++ b/platform/terraform/environments/prod/range/terraform.tfvars
@@ -28,13 +28,17 @@ enable_flow_logs = true
 # Range Instance IAM
 # ------------------------------------------------------------------------------
 
-agent_s3_bucket = "shifter-user-storage-7a3f9c2e"
+# Per-deployment value rendered from TF_VARS_PROD_RANGE into local.auto.tfvars.
+# Keep the committed baseline account-neutral; apply jobs fail loud when the
+# deployment overlay is absent.
+agent_s3_bucket = "REPLACE_AGENT_S3_BUCKET"
 
 # ------------------------------------------------------------------------------
 # VM-Series NGFW (optional)
 # ------------------------------------------------------------------------------
 
-vm_series_ami_id        = "ami-065e27477b191614c" # PAN-OS 11.2.8
+# Regional PAN-OS Marketplace AMI rendered from the deployment overlay.
+vm_series_ami_id        = "REPLACE_VM_SERIES_AMI_ID"
 vm_series_instance_type = "m5.xlarge"
 
 # ------------------------------------------------------------------------------

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -66,20 +66,26 @@ runners are provisioned and registered.
    parameters required by portal Terraform. The Kali build requires the target
    account to accept the free AWS Marketplace terms for product code
    `7lgvy7mt78lgoi4lant0znp5h`.
-5. For the first deploy in the moved account, run the `Deploy` GitHub Actions
+5. Configure the deployment tfvars secrets documented in
+   `docs/dev/deploy-secrets.md`, including `TF_VARS_DEV_PORTAL` and
+   `TF_VARS_DEV_RANGE`. Bootstrap configures the AWS role secret and backend
+   files; deploy-time portal/range values live in those tfvars secrets for
+   GitHub Actions, or in gitignored `local.auto.tfvars` files for local
+   Terraform runs.
+6. For the first deploy in the moved account, run the `Deploy` GitHub Actions
    workflow manually with `workflow_dispatch` on `aws-dev`. Manual dispatch
    forces the full AWS chain (Core -> Range -> Engine -> Platform). A plain
    branch push still obeys path filters, so it can skip Core or image
    publishing when the pushed commit only touched bootstrap/backend files.
    After the first full run succeeds, normal filtered `aws-dev` pushes are
    appropriate.
-6. During that first platform apply, publish DNS records for ACM and SES
+7. During that first platform apply, publish DNS records for ACM and SES
    validation in the authoritative DNS zone. ACM records come from the root
    Terraform output `acm_validation_records`. SES records come from
    `aws ses get-identity-verification-attributes` for the `_amazonses` TXT
    value and `aws ses get-identity-dkim-attributes` for the three DKIM CNAME
    tokens. In Cloudflare, keep ACM and DKIM CNAMEs DNS-only.
-7. After platform apply creates runtime endpoints, publish routing records:
+8. After platform apply creates runtime endpoints, publish routing records:
    `domain_name` and `chat.<domain_name>` CNAME to the root Terraform output
    `alb_dns_name`; `ctfd_domain` A-records to `ctfd_elastic_ip`.
 

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -91,6 +91,21 @@ ensure_symlink \
     "$WORKTREE_ROOT/shifter/engine/provisioner/.venv" \
     "shifter/engine/provisioner/.venv"
 
+# Gitignored Terraform deployment overlays. Keep per-account values in the
+# main checkout and symlink them into worktrees so local plans remain usable
+# without committing deployment-specific tfvars.
+for tfvars_overlay in \
+    "platform/terraform/environments/dev/portal/local.auto.tfvars" \
+    "platform/terraform/environments/dev/range/local.auto.tfvars" \
+    "platform/terraform/environments/prod/portal/local.auto.tfvars" \
+    "platform/terraform/environments/prod/range/local.auto.tfvars"
+do
+    ensure_symlink \
+        "$MAIN_REPO/$tfvars_overlay" \
+        "$WORKTREE_ROOT/$tfvars_overlay" \
+        "$tfvars_overlay"
+done
+
 # Node modules (for stylelint, prettier, etc.)
 if [[ -f "$WORKTREE_ROOT/package.json" ]]; then
     if [[ -d "$WORKTREE_ROOT/node_modules" ]]; then


### PR DESCRIPTION
## Summary

- What changed: extended the AWS range reusable workflow to render `local.auto.tfvars` from `TF_VARS_DEV_RANGE` / `TF_VARS_PROD_RANGE`; replaced committed range bucket and PAN-OS AMI values with placeholders; documented the GitHub secret and local overlay model; updated worktree setup to symlink local Terraform overlays.
- Why: fixes #916 by keeping account-identifying and deployment-specific range values out of committed range tfvars while preserving fail-loud deploy behavior.

Closes #916

## ADR Impact

- [x] No ADR impact
- [ ] Existing ADRs updated
- [ ] New ADR added
- [ ] Temporary exception added to `docs/adr/exceptions.yaml`

ADRs touched: none

Exceptions added or renewed: none

## Guardrail Changes

- [ ] No guardrail files changed
- [x] Guardrail files changed and matching docs were updated

Guardrail files changed: `.github/workflows/_range.yml`, `.github/workflows/deploy.yml`

## Verification

- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- [x] Relevant stack-native checks passed (`actionlint`, `tflint`, Terraform fmt) where applicable
- [x] Relevant tests: pre-commit ran bootstrap pytest, Terraform validate, checkov, shellcheck, and ADR fast guard during commit
- [x] Docs updated where behavior or enforcement changed

Additional local checks run:

```sh
actionlint
terraform fmt -check -recursive platform/terraform
tflint --recursive --config /home/atomik/src/shifter/.tflint.hcl
bash -n scripts/setup-worktree.sh
git grep -n "ami-065e27477b191614c\|shifter-dev-user-storage-788327019743\|shifter-user-storage-7a3f9c2e" -- platform/terraform/environments ":!platform/terraform/environments/*/range/local.auto.tfvars" || true
```