### PR TITLE
fixed(portal): split readiness from ASG health

### DIFF
--- a/changelog.d/919.fixed.md
+++ b/changelog.d/919.fixed.md
@@ -1,0 +1,4 @@
+**Portal readiness now checks Redis when Channels is Redis-backed, while ASG
+instance replacement health uses EC2 status checks instead of ALB readiness.**
+Shared DB/cache/Redis blips can still remove a target from ALB routing, but no
+longer cause ASG instance churn.

--- a/docs/architecture/portal-health-readiness-preflight-477.md
+++ b/docs/architecture/portal-health-readiness-preflight-477.md
@@ -27,8 +27,10 @@ No new Ground Control requirement is attached.
   required to serve user traffic fail.
 - `django-health-check` is the incumbent readiness implementation. The
   installed `health_check.db`, `health_check.cache`, and
-  `health_check.storage` checks are the canonical probe set unless a later
-  issue deliberately changes the dependency contract.
+  `health_check.storage` checks are the canonical baseline probe set. Issue
+  #919 deliberately extends that contract with a conditional Channels Redis
+  probe when the resolved default channel layer is
+  `channels_redis.core.RedisChannelLayer`.
 - Host-header accommodation for load-balancer probes is allowed only as a
   narrow admission concern. Middleware may normalize or permit the probe to
   reach the health view, but it must not create the health response, status
@@ -112,6 +114,8 @@ Useful assertions include:
 
 - the old middleware short-circuit cannot satisfy `/health` or `/health/`;
 - a failing DB/cache/storage check can make `/health` non-200;
+- when Channels resolves to Redis, a failing channel-layer Redis probe can
+  make `/health` non-200;
 - host-header handling for the load-balancer probe reaches the real health
   view instead of failing early or returning synthetic success;
 - public output remains coarse when a dependency raises;
@@ -131,12 +135,14 @@ Useful assertions include:
   internet-facing health consumers.
 - Database readiness is already a startup gate in `entrypoint.sh`; runtime
   readiness still matters because dependencies can fail after boot.
-- Cache readiness means both Django cache health and Channels/Redis posture
-  must not be conceptually conflated. If only the installed cache probe is
-  exercised, do not claim websocket/channel-layer readiness beyond that.
-- Storage readiness should use the configured storage backend. Do not add a
-  parallel S3/GCS client just for health unless `django-health-check.storage`
-  cannot express the required check.
+- Cache readiness means Django cache health and Channels/Redis posture must
+  not be conceptually conflated. Since #919, channel-layer Redis readiness is
+  a separate conditional probe that is registered only when the resolved
+  `CHANNEL_LAYERS` backend is Redis.
+- Storage readiness should use the configured storage backend. The current
+  `health_check.storage` plugin exercises Django's default storage; do not
+  describe it as S3/GCS readiness unless the configured backend and probe
+  actually exercise S3/GCS.
 
 ## Anti-Patterns
 

--- a/docs/architecture/portal-health-scaling-preflight-851.md
+++ b/docs/architecture/portal-health-scaling-preflight-851.md
@@ -45,10 +45,12 @@ Adjacent contracts this preflight respects but does not pre-empt:
 
 - Portal capacity has two distinct decision surfaces: a health/readiness
   surface that gates traffic admission (the ALB target-group health probe)
-  and a scaling surface that drives ASG capacity. The current configuration
-  conflates them: both use a single binary `/health` for admission and a
-  single EC2-average `CPUUtilization` for scaling. Future work must treat
-  them as independently parameterized.
+  and a scaling surface that drives ASG capacity. Issue #919 keeps ALB target
+  routing on dependency-aware `/health` while moving ASG instance replacement
+  health to EC2 status checks, so transient shared dependency failures stop
+  causing instance churn. Autoscaling policy decisions still use the existing
+  EC2-average `CPUUtilization` alarms until a later evidence-backed issue
+  changes them.
 - The health surface stays coarse and public. Verbose dependency state and
   per-process saturation diagnostics go to logs, CloudWatch metrics, or an
   internal/admin surface, not to a public probe.
@@ -76,10 +78,11 @@ Adjacent contracts this preflight respects but does not pre-empt:
 - ASG sizing: `asg_min_size`, `asg_max_size`, `asg_desired_capacity` set
   per environment. dev: 1/1/1, prod: 2/5/2
   (`platform/terraform/environments/{dev,prod}/portal/terraform.tfvars`).
-- ASG health probe source: `health_check_type = "ELB"`,
+- ASG health probe source: `health_check_type = "EC2"`,
   `health_check_grace_period = 900` at
-  `platform/terraform/modules/portal/ec2/main.tf:514-515`. Termination
-  decisions chain off the ALB target-group health check.
+  `platform/terraform/modules/portal/ec2/main.tf`. Termination decisions use
+  EC2 instance status checks; the ASG still attaches instances to the ALB
+  target group so `/health` remains the traffic-routing readiness signal.
 - Scaling policies: `aws_autoscaling_policy.scale_up` /
   `scale_down`, simple `ChangeInCapacity` of +/-1 with a 300 s cooldown
   (`platform/terraform/modules/portal/ec2/main.tf:553-571`). No
@@ -93,14 +96,13 @@ Adjacent contracts this preflight respects but does not pre-empt:
   HTTP, matcher `200`, `interval = 30`, `healthy_threshold = 2`,
   `unhealthy_threshold = 3`, `timeout = 5`. Stickiness conditional on
   `var.enable_stickiness`.
-- App middleware: `HealthCheckMiddleware` at
-  `shifter/shifter_platform/config/middleware.py:36-51`
-  short-circuits `/health` and `/health/` to a plain-text `OK` response,
-  bypassing `django-health-check`. The DB/cache/storage probes from
-  `django-health-check` are installed
-  (`shifter/shifter_platform/config/settings.py`) but never reached on
-  these paths. The same `/health` path is reused as the container-level
-  `HEALTHCHECK` in `shifter/shifter_platform/Dockerfile:62`.
+- App health: `/health` and `/health/` reach the coarse
+  `django-health-check` wrapper in `shifter/shifter_platform/config/health.py`.
+  The registered probes include DB/cache/default-storage checks plus the #919
+  conditional channel-layer Redis probe when `CHANNEL_LAYERS` resolves to
+  `channels_redis.core.RedisChannelLayer`. The same `/health` path is reused
+  as the container-level `HEALTHCHECK` in
+  `shifter/shifter_platform/Dockerfile:62`.
 - This behavior is fully tracked by #477 and
   `portal-health-readiness-preflight-477.md`; it is not redesigned here.
 

--- a/platform/terraform/modules/portal/ec2/main.tf
+++ b/platform/terraform/modules/portal/ec2/main.tf
@@ -598,7 +598,7 @@ resource "aws_autoscaling_group" "this" {
   name_prefix               = "${var.name_prefix}-asg-"
   vpc_zone_identifier       = var.subnet_ids
   target_group_arns         = [var.target_group_arn]
-  health_check_type         = "ELB"
+  health_check_type         = "EC2"
   health_check_grace_period = 900
 
   min_size         = var.asg_min_size

--- a/shifter/shifter_platform/config/apps.py
+++ b/shifter/shifter_platform/config/apps.py
@@ -1,0 +1,14 @@
+"""Django app hooks for cross-cutting portal configuration."""
+
+from __future__ import annotations
+
+from django.apps import AppConfig
+
+
+class PortalConfig(AppConfig):
+    name = "config"
+
+    def ready(self) -> None:
+        from config.health_checks import register_channel_layer_redis_health_check
+
+        register_channel_layer_redis_health_check()

--- a/shifter/shifter_platform/config/apps.py
+++ b/shifter/shifter_platform/config/apps.py
@@ -6,6 +6,8 @@ from django.apps import AppConfig
 
 
 class PortalConfig(AppConfig):
+    """Register config-level startup hooks for the portal runtime."""
+
     name = "config"
 
     def ready(self) -> None:

--- a/shifter/shifter_platform/config/health_checks.py
+++ b/shifter/shifter_platform/config/health_checks.py
@@ -1,0 +1,78 @@
+"""Additional portal health-check plugins.
+
+The public ``/health`` endpoint is the ALB readiness surface. Keep new probes
+inside the existing django-health-check registry so the endpoint preserves one
+coarse response contract while reflecting the configured runtime dependencies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.conf import settings
+from health_check.backends import HealthCheck as HealthCheckPluginBase
+from health_check.exceptions import ServiceUnavailable
+from health_check.plugins import plugin_dir
+
+from shared.log_sanitize import safe_log_value
+
+__all__ = [
+    "ChannelLayerRedisHealthCheck",
+    "channel_layer_uses_redis",
+    "register_channel_layer_redis_health_check",
+]
+
+_logger = logging.getLogger(__name__)
+_REDIS_CHANNEL_LAYER = "channels_redis.core.RedisChannelLayer"
+_PROBE_TIMEOUT_SECONDS = 2.0
+
+
+def channel_layer_uses_redis() -> bool:
+    """Return whether the resolved default Channels backend is Redis."""
+    channel_layers = getattr(settings, "CHANNEL_LAYERS", {})
+    default_layer = channel_layers.get("default", {})
+    return default_layer.get("BACKEND") == _REDIS_CHANNEL_LAYER
+
+
+class ChannelLayerRedisHealthCheck(HealthCheckPluginBase):
+    """Probe the configured Redis-backed Channels layer."""
+
+    def check_status(self) -> None:
+        try:
+            self._probe()
+        except Exception as exc:
+            _logger.warning("channel-layer Redis readiness failed: %s", safe_log_value(exc.__class__.__name__))
+            self.add_error(ServiceUnavailable("Channel layer Redis unavailable"))
+
+    def _probe(self) -> None:
+        async_to_sync(_probe_configured_channel_layer)()
+
+
+def register_channel_layer_redis_health_check() -> None:
+    """Register Redis readiness only when the default channel layer is Redis."""
+    if not channel_layer_uses_redis():
+        return
+    if any(plugin is ChannelLayerRedisHealthCheck for plugin, _options in plugin_dir._registry):
+        return
+    plugin_dir.register(ChannelLayerRedisHealthCheck)
+
+
+async def _probe_configured_channel_layer() -> None:
+    layer = get_channel_layer()
+    if layer is None:
+        raise ServiceUnavailable("Default channel layer is unavailable")
+    await asyncio.wait_for(_round_trip(layer), timeout=_PROBE_TIMEOUT_SECONDS)
+
+
+async def _round_trip(layer: Any) -> None:
+    channel = await layer.new_channel("health.check")
+    message = {"type": "health.check", "id": uuid.uuid4().hex}
+    await layer.send(channel, message)
+    received = await layer.receive(channel)
+    if received != message:
+        raise ServiceUnavailable("Default channel layer returned an unexpected health-check response")

--- a/shifter/shifter_platform/config/health_checks.py
+++ b/shifter/shifter_platform/config/health_checks.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from typing import Any
+from typing import Protocol
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -30,6 +30,17 @@ __all__ = [
 _logger = logging.getLogger(__name__)
 _REDIS_CHANNEL_LAYER = "channels_redis.core.RedisChannelLayer"
 _PROBE_TIMEOUT_SECONDS = 2.0
+HealthCheckMessage = dict[str, str]
+
+
+class ChannelLayerProbe(Protocol):
+    """Minimal Channels layer protocol needed by the Redis readiness probe."""
+
+    async def new_channel(self, prefix: str = "specific") -> str: ...
+
+    async def send(self, channel: str, message: HealthCheckMessage) -> None: ...
+
+    async def receive(self, channel: str) -> HealthCheckMessage: ...
 
 
 def channel_layer_uses_redis() -> bool:
@@ -63,13 +74,15 @@ def register_channel_layer_redis_health_check() -> None:
 
 
 async def _probe_configured_channel_layer() -> None:
+    """Run a bounded round trip against the configured default channel layer."""
     layer = get_channel_layer()
     if layer is None:
         raise ServiceUnavailable("Default channel layer is unavailable")
     await asyncio.wait_for(_round_trip(layer), timeout=_PROBE_TIMEOUT_SECONDS)
 
 
-async def _round_trip(layer: Any) -> None:
+async def _round_trip(layer: ChannelLayerProbe) -> None:
+    """Send and receive a unique health-check message through ``layer``."""
     channel = await layer.new_channel("health.check")
     message = {"type": "health.check", "id": uuid.uuid4().hex}
     await layer.send(channel, message)

--- a/shifter/shifter_platform/config/settings.py
+++ b/shifter/shifter_platform/config/settings.py
@@ -113,6 +113,7 @@ INSTALLED_APPS = [
     "health_check.db",
     "health_check.cache",
     "health_check.storage",
+    "config.apps.PortalConfig",
     "rest_framework",
     "mission_control.apps.MissionControlConfig",
     "risk_register.apps.RiskRegisterConfig",

--- a/shifter/shifter_platform/tests/mission_control/test_health.py
+++ b/shifter/shifter_platform/tests/mission_control/test_health.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 import pytest
 from django.test import Client
 from health_check.exceptions import ServiceUnavailable
+from health_check.plugins import plugin_dir
 
 # A non-secret sentinel used as the forced failure reason in probe-patches.
 # Tests use it as a positive control: if the public response surfaces *this*
@@ -106,6 +107,16 @@ def _force_probe_failure(target: str):
     return patch(target, side_effect=ServiceUnavailable(_FORCED_FAILURE_REASON))
 
 
+@pytest.fixture
+def health_check_registry():
+    """Restore the global django-health-check plugin registry after tests."""
+    original_registry = list(plugin_dir._registry)
+    try:
+        yield plugin_dir._registry
+    finally:
+        plugin_dir._registry = original_registry
+
+
 def test_health_returns_non_200_when_db_probe_fails():
     with _force_probe_failure("health_check.db.backends.DatabaseBackend.check_status"):
         status, _ = _get_health("/health/")
@@ -122,6 +133,54 @@ def test_health_returns_non_200_when_storage_probe_fails():
     with _force_probe_failure("health_check.storage.backends.DefaultFileStorageHealthCheck.check_status"):
         status, _ = _get_health("/health/")
     assert status != 200, "storage probe failure must surface as a non-200 /health"
+
+
+def test_in_memory_channel_layer_does_not_register_redis_probe(settings, health_check_registry):
+    from config.health_checks import ChannelLayerRedisHealthCheck, register_channel_layer_redis_health_check
+
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+    health_check_registry.clear()
+
+    register_channel_layer_redis_health_check()
+
+    assert all(plugin is not ChannelLayerRedisHealthCheck for plugin, _ in health_check_registry)
+
+
+def test_redis_channel_layer_registers_redis_probe(settings, health_check_registry):
+    from config.health_checks import ChannelLayerRedisHealthCheck, register_channel_layer_redis_health_check
+
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels_redis.core.RedisChannelLayer"}}
+    health_check_registry.clear()
+
+    register_channel_layer_redis_health_check()
+
+    assert any(plugin is ChannelLayerRedisHealthCheck for plugin, _ in health_check_registry)
+
+
+def test_redis_health_check_uses_installed_health_check_plugin_base():
+    from health_check.backends import HealthCheck
+
+    from config.health_checks import ChannelLayerRedisHealthCheck
+
+    assert issubclass(ChannelLayerRedisHealthCheck, HealthCheck)
+
+
+def test_health_returns_non_200_when_channel_layer_redis_probe_fails(settings, health_check_registry):
+    from config.health_checks import ChannelLayerRedisHealthCheck, register_channel_layer_redis_health_check
+
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels_redis.core.RedisChannelLayer"}}
+    health_check_registry.clear()
+    register_channel_layer_redis_health_check()
+
+    with patch.object(ChannelLayerRedisHealthCheck, "_probe", side_effect=ServiceUnavailable(_FORCED_FAILURE_REASON)):
+        status, body = _get_health("/health/", HTTP_ACCEPT="application/json")
+
+    assert status != 200, "Redis channel-layer probe failure must surface as a non-200 /health"
+    assert "ChannelLayerRedisHealthCheck" in body, body
+    assert '"unavailable"' in body, body
+    lowered = body.lower()
+    for marker in _FORBIDDEN_LEAK_MARKERS:
+        assert marker not in lowered, f"public /health body leaked sensitive marker {marker!r}: {body!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/shifter/shifter_platform/tests/mission_control/test_health.py
+++ b/shifter/shifter_platform/tests/mission_control/test_health.py
@@ -10,7 +10,7 @@ bucket names, secret IDs, or private hostnames.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from django.test import Client
@@ -157,12 +157,35 @@ def test_redis_channel_layer_registers_redis_probe(settings, health_check_regist
     assert any(plugin is ChannelLayerRedisHealthCheck for plugin, _ in health_check_registry)
 
 
+def test_redis_channel_layer_registration_is_idempotent(settings, health_check_registry):
+    from config.health_checks import ChannelLayerRedisHealthCheck, register_channel_layer_redis_health_check
+
+    settings.CHANNEL_LAYERS = {"default": {"BACKEND": "channels_redis.core.RedisChannelLayer"}}
+    health_check_registry.clear()
+
+    register_channel_layer_redis_health_check()
+    register_channel_layer_redis_health_check()
+
+    assert [plugin for plugin, _ in health_check_registry].count(ChannelLayerRedisHealthCheck) == 1
+
+
 def test_redis_health_check_uses_installed_health_check_plugin_base():
     from health_check.backends import HealthCheck
 
     from config.health_checks import ChannelLayerRedisHealthCheck
 
     assert issubclass(ChannelLayerRedisHealthCheck, HealthCheck)
+
+
+def test_redis_health_check_probe_uses_sync_bridge():
+    from config.health_checks import ChannelLayerRedisHealthCheck, _probe_configured_channel_layer
+
+    runner = Mock()
+    with patch("config.health_checks.async_to_sync", return_value=runner) as async_to_sync:
+        ChannelLayerRedisHealthCheck()._probe()
+
+    async_to_sync.assert_called_once_with(_probe_configured_channel_layer)
+    runner.assert_called_once_with()
 
 
 def test_health_returns_non_200_when_channel_layer_redis_probe_fails(settings, health_check_registry):
@@ -181,6 +204,66 @@ def test_health_returns_non_200_when_channel_layer_redis_probe_fails(settings, h
     lowered = body.lower()
     for marker in _FORBIDDEN_LEAK_MARKERS:
         assert marker not in lowered, f"public /health body leaked sensitive marker {marker!r}: {body!r}"
+
+
+@pytest.mark.asyncio
+async def test_channel_layer_probe_round_trip_uses_configured_layer():
+    from config.health_checks import _round_trip
+
+    class FakeChannelLayer:
+        def __init__(self):
+            self.channel_prefix = None
+            self.sent_channel = None
+            self.sent_message = None
+
+        async def new_channel(self, prefix: str = "specific") -> str:
+            self.channel_prefix = prefix
+            return "health.check.test!channel"
+
+        async def send(self, channel: str, message: dict[str, str]) -> None:
+            self.sent_channel = channel
+            self.sent_message = message
+
+        async def receive(self, channel: str) -> dict[str, str]:
+            assert channel == self.sent_channel
+            assert self.sent_message is not None
+            return self.sent_message
+
+    layer = FakeChannelLayer()
+
+    await _round_trip(layer)
+
+    assert layer.channel_prefix == "health.check"
+    assert layer.sent_channel == "health.check.test!channel"
+    assert layer.sent_message is not None
+    assert layer.sent_message["type"] == "health.check"
+    assert layer.sent_message["id"]
+
+
+@pytest.mark.asyncio
+async def test_channel_layer_probe_fails_when_default_layer_is_missing():
+    from config.health_checks import _probe_configured_channel_layer
+
+    with patch("config.health_checks.get_channel_layer", return_value=None), pytest.raises(ServiceUnavailable):
+        await _probe_configured_channel_layer()
+
+
+@pytest.mark.asyncio
+async def test_channel_layer_probe_fails_on_unexpected_round_trip_response():
+    from config.health_checks import _round_trip
+
+    class MismatchedChannelLayer:
+        async def new_channel(self, prefix: str = "specific") -> str:
+            return "health.check.test!channel"
+
+        async def send(self, channel: str, message: dict[str, str]) -> None:
+            return None
+
+        async def receive(self, channel: str) -> dict[str, str]:
+            return {"type": "health.check", "id": "different"}
+
+    with pytest.raises(ServiceUnavailable):
+        await _round_trip(MismatchedChannelLayer())
 
 
 # ---------------------------------------------------------------------------

--- a/shifter/shifter_platform/tests/platform/test_portal_readiness_health_sources.py
+++ b/shifter/shifter_platform/tests/platform/test_portal_readiness_health_sources.py
@@ -1,0 +1,16 @@
+"""Portal readiness and instance replacement health-source invariants (#919)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+EC2_MAIN_TF = REPO_ROOT / "platform" / "terraform" / "modules" / "portal" / "ec2" / "main.tf"
+
+
+def test_portal_asg_uses_ec2_health_while_alb_target_group_handles_readiness() -> None:
+    text = EC2_MAIN_TF.read_text(encoding="utf-8")
+
+    assert 'health_check_type         = "EC2"' in text
+    assert "target_group_arns         = [var.target_group_arn]" in text
+    assert 'health_check_type         = "ELB"' not in text


### PR DESCRIPTION
## Summary

Split portal dependency readiness from AWS ASG instance replacement health. The ALB target group continues to use dependency-aware `/health` for routing, Redis-backed Channels now contributes a conditional readiness probe, and ASG replacement health uses EC2 status checks so shared dependency blips stop causing instance churn.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #919

## ADR Impact

- ADR-021
- ADR-018

## Changes

- Added a conditional django-health-check plugin that probes the configured Channels layer only when `CHANNEL_LAYERS` resolves to Redis.
- Registered the Redis readiness plugin through Django app startup while preserving the coarse public `/health` response envelope.
- Changed the portal ASG from ELB health checks to EC2 health checks while keeping ALB target-group attachment for readiness routing.
- Added health and Terraform structural tests for Redis readiness registration/failure and ASG health-source separation.
- Updated portal health/scaling architecture notes and added the #919 changelog fragment.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local validation: `uv run pytest tests/mission_control/test_health.py tests/platform`; `uv run ruff check .`; `uv run ruff format --check .`; `uv run lint-imports --config ../../.importlinter`; `tflint --recursive --config /home/atomik/src/shifter2/.tflint.hcl`; `python3 scripts/adr_guard/adr_guard.py --all --level ci`; `pre-commit run --all-files`.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/919.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
