### PR TITLE
test: extract portal deploy script

### DIFF
--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -530,140 +530,48 @@ jobs:
             echo "Attempt $i: Waiting for cloud-init..."; sleep 10
           done
 
-          # Deploy script reads config from Parameter Store and restarts containers
-          DEPLOY_SCRIPT=$(cat << 'EOFSCRIPT'
-          set -euo pipefail
-          AWS_REGION="us-east-2"
-          PS_PREFIX="__PS_PREFIX__"
+          # Deploy script reads config from Parameter Store and restarts containers.
+          DEPLOY_SCRIPT_PATH="${GITHUB_WORKSPACE}/scripts/portal-deploy/deploy_portal.sh"
+          DEPLOY_SCRIPT_B64=$(base64 -w0 "$DEPLOY_SCRIPT_PATH")
 
-          get_param() { aws ssm get-parameter --name "$1" --with-decryption --query 'Parameter.Value' --output text --region "$AWS_REGION"; }
-          validate_bootstrap_email_list() {
-            local name="$1"
-            local value="$2"
-            if [[ -n "$value" && ! "$value" =~ ^[A-Za-z0-9._%+@,-]+$ ]]; then
-              echo "Invalid $name: expected a comma-separated email list"
-              exit 1
-            fi
-          }
-
-          IMAGE_TAG=$(get_param "$PS_PREFIX/image-tag")
-          ECR_REGISTRY=$(get_param "$PS_PREFIX/ecr-registry")
-          ECR_REPOSITORY=$(get_param "$PS_PREFIX/ecr-repository")
-          DOMAIN_NAME=$(get_param "$PS_PREFIX/domain-name")
-          S3_BUCKET=$(get_param "$PS_PREFIX/s3-bucket")
-          DB_SECRET_ARN=$(get_param "$PS_PREFIX/db-secret-arn")
-          APP_SECRET_ARN=$(get_param "$PS_PREFIX/app-secret-arn")
-          COGNITO_SECRET_ARN=$(get_param "$PS_PREFIX/cognito-secret-arn")
-          GUACAMOLE_SECRET_ARN=$(get_param "$PS_PREFIX/guacamole-secret-arn" || echo "")
-          DC_DOMAIN_PASSWORD_SECRET_ARN=$(get_param "$PS_PREFIX/dc-domain-password-secret-arn" || echo "")
-          GUACAMOLE_BASE_URL=$(get_param "$PS_PREFIX/guacamole-base-url" || echo "")
-          GUACAMOLE_API_BASE_URL=$(get_param "$PS_PREFIX/guacamole-api-base-url" || echo "")
-          ENGINE_ECS_CLUSTER_ARN=$(get_param "$PS_PREFIX/engine-ecs-cluster-arn")
-          ENGINE_TASK_DEFINITION_ARN=$(get_param "$PS_PREFIX/engine-task-definition-arn")
-          ENGINE_ECS_SECURITY_GROUP_ID=$(get_param "$PS_PREFIX/engine-ecs-security-group-id")
-          ENGINE_PRIVATE_SUBNET_IDS=$(get_param "$PS_PREFIX/engine-private-subnet-ids")
-          SQS_CMS_URL=$(get_param "$PS_PREFIX/sqs-cms-url")
-          SQS_ENGINE_URL=$(get_param "$PS_PREFIX/sqs-engine-url")
-          SQS_MC_URL=$(get_param "$PS_PREFIX/sqs-mc-url")
-          REDIS_ENDPOINT=$(get_param "$PS_PREFIX/redis-endpoint" || echo "")
-          CHANNEL_LAYER_BACKEND=$(get_param "$PS_PREFIX/channel-layer-backend" || echo "")
-          EMAIL_BACKEND=$(get_param "$PS_PREFIX/email-backend" || echo "")
-          CTF_FROM_EMAIL=$(get_param "$PS_PREFIX/ctf-from-email" || echo "")
-          PLATFORM_BOOTSTRAP_STAFF_EMAILS=$(get_param "$PS_PREFIX/platform-bootstrap-staff-emails" || echo "")
-          PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS=$(get_param "$PS_PREFIX/platform-bootstrap-superuser-emails" || echo "")
-          validate_bootstrap_email_list "PLATFORM_BOOTSTRAP_STAFF_EMAILS" "$PLATFORM_BOOTSTRAP_STAFF_EMAILS"
-          validate_bootstrap_email_list "PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS" "$PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS"
-
-          IMAGE="$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          echo "Deploying image: $IMAGE"
-
-          COMMON_ENV="-e AWS_REGION=$AWS_REGION -e AWS_S3_BUCKET_NAME=$S3_BUCKET -e DB_SECRET_ARN=$DB_SECRET_ARN"
-          COMMON_ENV="$COMMON_ENV -e APP_SECRET_ARN=$APP_SECRET_ARN -e COGNITO_SECRET_ARN=$COGNITO_SECRET_ARN"
-          [ -n "$GUACAMOLE_SECRET_ARN" ] && COMMON_ENV="$COMMON_ENV -e GUACAMOLE_SECRET_ARN=$GUACAMOLE_SECRET_ARN"
-          [ -n "$GUACAMOLE_BASE_URL" ] && COMMON_ENV="$COMMON_ENV -e GUACAMOLE_BASE_URL=$GUACAMOLE_BASE_URL"
-          [ -n "$GUACAMOLE_API_BASE_URL" ] && COMMON_ENV="$COMMON_ENV -e GUACAMOLE_API_BASE_URL=$GUACAMOLE_API_BASE_URL"
-          [ -n "$DC_DOMAIN_PASSWORD_SECRET_ARN" ] && COMMON_ENV="$COMMON_ENV -e DC_DOMAIN_PASSWORD_SECRET_ARN=$DC_DOMAIN_PASSWORD_SECRET_ARN"
-          # Add localhost to ALLOWED_HOSTS for dev (enables SSM tunnel testing)
-          # PS_PREFIX comes from Parameter Store, not user input - safe to use
-          if [[ "$PS_PREFIX" == *"/dev/"* ]]; then
-            COMMON_ENV="$COMMON_ENV -e DJANGO_ALLOWED_HOSTS=$DOMAIN_NAME,localhost,127.0.0.1"
-          else
-            COMMON_ENV="$COMMON_ENV -e DJANGO_ALLOWED_HOSTS=$DOMAIN_NAME"
-          fi
-          COMMON_ENV="$COMMON_ENV -e DJANGO_CSRF_TRUSTED_ORIGINS=https://$DOMAIN_NAME"
-          COMMON_ENV="$COMMON_ENV -e SITE_URL=https://$DOMAIN_NAME -e ENGINE_ECS_CLUSTER_ARN=$ENGINE_ECS_CLUSTER_ARN"
-          COMMON_ENV="$COMMON_ENV -e ENGINE_TASK_DEFINITION_ARN=$ENGINE_TASK_DEFINITION_ARN"
-          COMMON_ENV="$COMMON_ENV -e ENGINE_ECS_SECURITY_GROUP_ID=$ENGINE_ECS_SECURITY_GROUP_ID"
-          COMMON_ENV="$COMMON_ENV -e ENGINE_PRIVATE_SUBNET_IDS=$ENGINE_PRIVATE_SUBNET_IDS"
-          COMMON_ENV="$COMMON_ENV -e SQS_CMS_URL=$SQS_CMS_URL -e SQS_ENGINE_URL=$SQS_ENGINE_URL -e SQS_MC_URL=$SQS_MC_URL"
-          [ -n "$REDIS_ENDPOINT" ] && COMMON_ENV="$COMMON_ENV -e REDIS_HOST=$REDIS_ENDPOINT"
-          # Channel-layer backend posture (ADR-018, #849), mirrors user_data.sh.
-          [ -n "$CHANNEL_LAYER_BACKEND" ] && COMMON_ENV="$COMMON_ENV -e CHANNEL_LAYER_BACKEND=$CHANNEL_LAYER_BACKEND"
-          [ -n "$EMAIL_BACKEND" ] && COMMON_ENV="$COMMON_ENV -e EMAIL_BACKEND=$EMAIL_BACKEND"
-          [ -n "$CTF_FROM_EMAIL" ] && COMMON_ENV="$COMMON_ENV -e CTF_FROM_EMAIL=$CTF_FROM_EMAIL"
-          [ -n "$PLATFORM_BOOTSTRAP_STAFF_EMAILS" ] && COMMON_ENV="$COMMON_ENV -e PLATFORM_BOOTSTRAP_STAFF_EMAILS=$PLATFORM_BOOTSTRAP_STAFF_EMAILS"
-          [ -n "$PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS" ] && COMMON_ENV="$COMMON_ENV -e PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS=$PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS"
-
-          docker pull "$IMAGE"
-          # The DC domain password secret is Terraform-managed (created and
-          # seeded by the engine-provisioner module), so it always carries an
-          # AWSCURRENT value — no pre-deploy populate check needed, same as the
-          # DB / app / Cognito secret ARNs above.
-          docker stop portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
-          docker rm portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
-          eval docker run -d --name portal --restart unless-stopped -p 8000:8000 $COMMON_ENV "$IMAGE"
-          WORKER_HEALTH_BASE="--health-interval 30s --health-timeout 5s --health-start-period 90s --health-retries 2"
-          WORKER_CMS_HEALTH="--health-cmd='find /tmp/worker-cms-heartbeat -mmin -2 | grep -q .'"
-          WORKER_ENGINE_HEALTH="--health-cmd='find /tmp/worker-engine-heartbeat -mmin -2 | grep -q .'"
-          WORKER_MC_HEALTH="--health-cmd='find /tmp/worker-mc-heartbeat -mmin -2 | grep -q .'"
-          CTF_SCHEDULER_HEALTH="--health-cmd='find /tmp/ctf-scheduler-heartbeat -mmin -2 | grep -q .'"
-          eval docker run -d --name worker-cms --restart unless-stopped $WORKER_HEALTH_BASE "$WORKER_CMS_HEALTH" $COMMON_ENV "$IMAGE" python manage.py run_worker --queue cms
-          eval docker run -d --name worker-engine --restart unless-stopped $WORKER_HEALTH_BASE "$WORKER_ENGINE_HEALTH" $COMMON_ENV "$IMAGE" python manage.py run_worker --queue engine
-          eval docker run -d --name worker-mc --restart unless-stopped $WORKER_HEALTH_BASE "$WORKER_MC_HEALTH" $COMMON_ENV "$IMAGE" python manage.py run_worker --queue mc
-          eval docker run -d --name ctf-scheduler --restart unless-stopped $WORKER_HEALTH_BASE "$CTF_SCHEDULER_HEALTH" $COMMON_ENV "$IMAGE" python manage.py run_ctf_scheduler
-          docker ps
-
-          # Worker-container health supervisor (#953) — byte-identical to the
-          # user_data.sh fresh-boot install; artifacts are single-sourced under
-          # modules/portal/ec2/worker-health/ and injected base64-encoded.
-          echo "Installing worker-container health supervisor..."
-          echo "__WH_MONITOR_B64__" | base64 -d > /usr/local/bin/shifter-worker-health.sh
-          chmod 0755 /usr/local/bin/shifter-worker-health.sh
-          echo "__WH_SERVICE_B64__" | base64 -d > /etc/systemd/system/shifter-worker-health.service
-          echo "__WH_TIMER_B64__" | base64 -d > /etc/systemd/system/shifter-worker-health.timer
-          # Per-environment metric dimension so dev and prod alarms stay independent.
-          echo "WH_NAME_PREFIX=__WH_NAME_PREFIX__" > /etc/shifter-worker-health.env
-          systemctl daemon-reload
-          systemctl enable --now shifter-worker-health.timer
-
-          echo "Deployment complete!"
-          EOFSCRIPT
-          )
-
-          # Substitute PS_PREFIX
-          DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__PS_PREFIX__/${PS_PREFIX}}"
-
-          # Substitute worker-health artifact payloads (#953). base64 so the
-          # single-source files survive jq/SSM transport without quoting issues;
-          # both AWS deploy paths then install byte-identical files.
-          WH_DIR="platform/terraform/modules/portal/ec2/worker-health"
+          # Worker-container health supervisor (#953) artifacts stay single-sourced
+          # under modules/portal/ec2/worker-health and are injected base64-encoded
+          # so both AWS deploy paths install byte-identical files.
+          WH_DIR="${GITHUB_WORKSPACE}/platform/terraform/modules/portal/ec2/worker-health"
           WH_MONITOR_B64=$(base64 -w0 "$WH_DIR/shifter-worker-health.sh")
           WH_SERVICE_B64=$(base64 -w0 "$WH_DIR/shifter-worker-health.service")
           WH_TIMER_B64=$(base64 -w0 "$WH_DIR/shifter-worker-health.timer")
-          DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__WH_MONITOR_B64__/$WH_MONITOR_B64}"
-          DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__WH_SERVICE_B64__/$WH_SERVICE_B64}"
-          DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__WH_TIMER_B64__/$WH_TIMER_B64}"
           # name_prefix is "<environment>-portal"; matches the Terraform alarm dimension.
           WH_NAME_PREFIX="$ENV-portal"
-          DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__WH_NAME_PREFIX__/$WH_NAME_PREFIX}"
+
+          DEPLOY_ARGS=$(jq -cn \
+            --arg awsRegion "$AWS_REGION" \
+            --arg psPrefix "$PS_PREFIX" \
+            --arg whMonitorB64 "$WH_MONITOR_B64" \
+            --arg whServiceB64 "$WH_SERVICE_B64" \
+            --arg whTimerB64 "$WH_TIMER_B64" \
+            --arg whNamePrefix "$WH_NAME_PREFIX" \
+            '[
+              "--aws-region", $awsRegion,
+              "--ps-prefix", $psPrefix,
+              "--worker-health-monitor-b64", $whMonitorB64,
+              "--worker-health-service-b64", $whServiceB64,
+              "--worker-health-timer-b64", $whTimerB64,
+              "--worker-health-name-prefix", $whNamePrefix
+            ]')
 
           # Run deploy via SSM using temp file to avoid quoting issues
           PARAMS_FILE=$(mktemp)
-          cat > "$PARAMS_FILE" << EOF
-          {
-            "commands": [$(echo "$DEPLOY_SCRIPT" | jq -Rs .)]
-          }
-          EOF
+          jq -n \
+            --arg deployScriptB64 "$DEPLOY_SCRIPT_B64" \
+            --argjson deployArgs "$DEPLOY_ARGS" \
+            '{
+              commands: [
+                ("printf %s " + ($deployScriptB64 | @sh) + " | base64 -d > /tmp/shifter-deploy-portal.sh"),
+                "chmod 0755 /tmp/shifter-deploy-portal.sh",
+                ((["/tmp/shifter-deploy-portal.sh"] + $deployArgs) | @sh)
+              ]
+            }' > "$PARAMS_FILE"
 
           COMMAND_ID=$(aws ssm send-command \
             --document-name "AWS-RunShellScript" \

--- a/changelog.d/925.fixed.md
+++ b/changelog.d/925.fixed.md
@@ -1,0 +1,1 @@
+**AWS single-instance portal deploy logic is now a tracked, tested script.** The reusable platform workflow sends `scripts/portal-deploy/deploy_portal.sh` through SSM instead of carrying the instance deploy body as an inline heredoc, with subprocess tests covering its argument validation and repeatable worker-health installation.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -80,6 +80,7 @@
       ".github/workflows/_shifter-engine.yml",
       ".github/workflows/_shifter-platform.yml",
       "scripts/portal_deploy/portal_deploy.py",
+      "scripts/portal-deploy/deploy_portal.sh",
       "platform/terraform/environments/dev/portal/outputs.tf",
       "platform/terraform/environments/prod/portal/outputs.tf"
     ]

--- a/scripts/portal-deploy/deploy_portal.sh
+++ b/scripts/portal-deploy/deploy_portal.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AWS_REGION="${AWS_REGION:-us-east-2}"
+PS_PREFIX=""
+WORKER_HEALTH_MONITOR_B64=""
+WORKER_HEALTH_SERVICE_B64=""
+WORKER_HEALTH_TIMER_B64=""
+WORKER_HEALTH_NAME_PREFIX=""
+WORKER_HEALTH_BIN_PATH="/usr/local/bin/shifter-worker-health.sh"
+WORKER_HEALTH_SERVICE_PATH="/etc/systemd/system/shifter-worker-health.service"
+WORKER_HEALTH_TIMER_PATH="/etc/systemd/system/shifter-worker-health.timer"
+WORKER_HEALTH_ENV_PATH="/etc/shifter-worker-health.env"
+DOCKER_ENV=()
+
+usage() {
+  cat <<'EOF'
+Usage: deploy_portal.sh --ps-prefix PREFIX --worker-health-monitor-b64 B64 --worker-health-service-b64 B64 --worker-health-timer-b64 B64 --worker-health-name-prefix PREFIX [options]
+
+Required:
+  --ps-prefix PREFIX
+  --worker-health-monitor-b64 B64
+  --worker-health-service-b64 B64
+  --worker-health-timer-b64 B64
+  --worker-health-name-prefix PREFIX
+
+Options:
+  --aws-region REGION
+  --worker-health-bin-path PATH
+  --worker-health-service-path PATH
+  --worker-health-timer-path PATH
+  --worker-health-env-path PATH
+  --help
+EOF
+}
+
+die_usage() {
+  echo "deploy_portal.sh: $*" >&2
+  usage >&2
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" ]]; then
+    die_usage "${option} requires a value"
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --help)
+        usage
+        exit 0
+        ;;
+      --aws-region)
+        require_value "$1" "${2:-}"
+        AWS_REGION="$2"
+        shift 2
+        ;;
+      --ps-prefix)
+        require_value "$1" "${2:-}"
+        PS_PREFIX="$2"
+        shift 2
+        ;;
+      --worker-health-monitor-b64)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_MONITOR_B64="$2"
+        shift 2
+        ;;
+      --worker-health-service-b64)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_SERVICE_B64="$2"
+        shift 2
+        ;;
+      --worker-health-timer-b64)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_TIMER_B64="$2"
+        shift 2
+        ;;
+      --worker-health-name-prefix)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_NAME_PREFIX="$2"
+        shift 2
+        ;;
+      --worker-health-bin-path)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_BIN_PATH="$2"
+        shift 2
+        ;;
+      --worker-health-service-path)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_SERVICE_PATH="$2"
+        shift 2
+        ;;
+      --worker-health-timer-path)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_TIMER_PATH="$2"
+        shift 2
+        ;;
+      --worker-health-env-path)
+        require_value "$1" "${2:-}"
+        WORKER_HEALTH_ENV_PATH="$2"
+        shift 2
+        ;;
+      *)
+        die_usage "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$PS_PREFIX" ]] || die_usage "--ps-prefix is required"
+  [[ -n "$WORKER_HEALTH_MONITOR_B64" ]] || die_usage "--worker-health-monitor-b64 is required"
+  [[ -n "$WORKER_HEALTH_SERVICE_B64" ]] || die_usage "--worker-health-service-b64 is required"
+  [[ -n "$WORKER_HEALTH_TIMER_B64" ]] || die_usage "--worker-health-timer-b64 is required"
+  [[ -n "$WORKER_HEALTH_NAME_PREFIX" ]] || die_usage "--worker-health-name-prefix is required"
+}
+
+get_param() {
+  aws ssm get-parameter \
+    --name "$1" \
+    --with-decryption \
+    --query 'Parameter.Value' \
+    --output text \
+    --region "$AWS_REGION"
+}
+
+get_optional_param() {
+  get_param "$1" 2>/dev/null || true
+}
+
+validate_bootstrap_email_list() {
+  local name="$1"
+  local value="$2"
+  if [[ -n "$value" && ! "$value" =~ ^[A-Za-z0-9._%+@,-]+$ ]]; then
+    echo "Invalid ${name}: expected a comma-separated email list" >&2
+    exit 1
+  fi
+}
+
+append_env() {
+  local name="$1"
+  local value="$2"
+  DOCKER_ENV+=("-e" "${name}=${value}")
+}
+
+append_env_if_set() {
+  local name="$1"
+  local value="$2"
+  if [[ -n "$value" ]]; then
+    append_env "$name" "$value"
+  fi
+}
+
+install_b64_file() {
+  local payload_b64="$1"
+  local path="$2"
+  local mode="$3"
+
+  mkdir -p "$(dirname "$path")"
+  printf '%s' "$payload_b64" | base64 -d > "$path"
+  chmod "$mode" "$path"
+}
+
+install_worker_health() {
+  echo "Installing worker-container health supervisor..."
+  install_b64_file "$WORKER_HEALTH_MONITOR_B64" "$WORKER_HEALTH_BIN_PATH" "0755"
+  install_b64_file "$WORKER_HEALTH_SERVICE_B64" "$WORKER_HEALTH_SERVICE_PATH" "0644"
+  install_b64_file "$WORKER_HEALTH_TIMER_B64" "$WORKER_HEALTH_TIMER_PATH" "0644"
+  mkdir -p "$(dirname "$WORKER_HEALTH_ENV_PATH")"
+  printf 'WH_NAME_PREFIX=%s\n' "$WORKER_HEALTH_NAME_PREFIX" > "$WORKER_HEALTH_ENV_PATH"
+  systemctl daemon-reload
+  systemctl enable --now shifter-worker-health.timer
+}
+
+run_containers() {
+  local image="$1"
+  shift
+  local -a common_env=("$@")
+  local -a worker_health_base=(
+    --health-interval 30s
+    --health-timeout 5s
+    --health-start-period 90s
+    --health-retries 2
+  )
+
+  docker pull "$image"
+  docker stop portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
+  docker rm portal worker-cms worker-engine worker-mc ctf-scheduler 2>/dev/null || true
+  docker run -d --name portal --restart unless-stopped -p 8000:8000 "${common_env[@]}" "$image"
+  docker run -d --name worker-cms --restart unless-stopped "${worker_health_base[@]}" \
+    "--health-cmd=find /tmp/worker-cms-heartbeat -mmin -2 | grep -q ." \
+    "${common_env[@]}" "$image" python manage.py run_worker --queue cms
+  docker run -d --name worker-engine --restart unless-stopped "${worker_health_base[@]}" \
+    "--health-cmd=find /tmp/worker-engine-heartbeat -mmin -2 | grep -q ." \
+    "${common_env[@]}" "$image" python manage.py run_worker --queue engine
+  docker run -d --name worker-mc --restart unless-stopped "${worker_health_base[@]}" \
+    "--health-cmd=find /tmp/worker-mc-heartbeat -mmin -2 | grep -q ." \
+    "${common_env[@]}" "$image" python manage.py run_worker --queue mc
+  docker run -d --name ctf-scheduler --restart unless-stopped "${worker_health_base[@]}" \
+    "--health-cmd=find /tmp/ctf-scheduler-heartbeat -mmin -2 | grep -q ." \
+    "${common_env[@]}" "$image" python manage.py run_ctf_scheduler
+  docker ps
+}
+
+main() {
+  parse_args "$@"
+
+  local image_tag
+  local ecr_registry
+  local ecr_repository
+  local domain_name
+  local s3_bucket
+  local db_secret_arn
+  local app_secret_arn
+  local cognito_secret_arn
+  local guacamole_secret_arn
+  local dc_domain_password_secret_arn
+  local guacamole_base_url
+  local guacamole_api_base_url
+  local engine_ecs_cluster_arn
+  local engine_task_definition_arn
+  local engine_ecs_security_group_id
+  local engine_private_subnet_ids
+  local sqs_cms_url
+  local sqs_engine_url
+  local sqs_mc_url
+  local redis_endpoint
+  local channel_layer_backend
+  local email_backend
+  local ctf_from_email
+  local platform_bootstrap_staff_emails
+  local platform_bootstrap_superuser_emails
+
+  image_tag=$(get_param "$PS_PREFIX/image-tag")
+  ecr_registry=$(get_param "$PS_PREFIX/ecr-registry")
+  ecr_repository=$(get_param "$PS_PREFIX/ecr-repository")
+  domain_name=$(get_param "$PS_PREFIX/domain-name")
+  s3_bucket=$(get_param "$PS_PREFIX/s3-bucket")
+  db_secret_arn=$(get_param "$PS_PREFIX/db-secret-arn")
+  app_secret_arn=$(get_param "$PS_PREFIX/app-secret-arn")
+  cognito_secret_arn=$(get_param "$PS_PREFIX/cognito-secret-arn")
+  guacamole_secret_arn=$(get_optional_param "$PS_PREFIX/guacamole-secret-arn")
+  dc_domain_password_secret_arn=$(get_optional_param "$PS_PREFIX/dc-domain-password-secret-arn")
+  guacamole_base_url=$(get_optional_param "$PS_PREFIX/guacamole-base-url")
+  guacamole_api_base_url=$(get_optional_param "$PS_PREFIX/guacamole-api-base-url")
+  engine_ecs_cluster_arn=$(get_param "$PS_PREFIX/engine-ecs-cluster-arn")
+  engine_task_definition_arn=$(get_param "$PS_PREFIX/engine-task-definition-arn")
+  engine_ecs_security_group_id=$(get_param "$PS_PREFIX/engine-ecs-security-group-id")
+  engine_private_subnet_ids=$(get_param "$PS_PREFIX/engine-private-subnet-ids")
+  sqs_cms_url=$(get_param "$PS_PREFIX/sqs-cms-url")
+  sqs_engine_url=$(get_param "$PS_PREFIX/sqs-engine-url")
+  sqs_mc_url=$(get_param "$PS_PREFIX/sqs-mc-url")
+  redis_endpoint=$(get_optional_param "$PS_PREFIX/redis-endpoint")
+  channel_layer_backend=$(get_optional_param "$PS_PREFIX/channel-layer-backend")
+  email_backend=$(get_optional_param "$PS_PREFIX/email-backend")
+  ctf_from_email=$(get_optional_param "$PS_PREFIX/ctf-from-email")
+  platform_bootstrap_staff_emails=$(get_optional_param "$PS_PREFIX/platform-bootstrap-staff-emails")
+  platform_bootstrap_superuser_emails=$(get_optional_param "$PS_PREFIX/platform-bootstrap-superuser-emails")
+  validate_bootstrap_email_list "PLATFORM_BOOTSTRAP_STAFF_EMAILS" "$platform_bootstrap_staff_emails"
+  validate_bootstrap_email_list "PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS" "$platform_bootstrap_superuser_emails"
+
+  local image="${ecr_registry}/${ecr_repository}:${image_tag}"
+  echo "Deploying image: $image"
+
+  DOCKER_ENV=()
+  append_env AWS_REGION "$AWS_REGION"
+  append_env AWS_S3_BUCKET_NAME "$s3_bucket"
+  append_env DB_SECRET_ARN "$db_secret_arn"
+  append_env APP_SECRET_ARN "$app_secret_arn"
+  append_env COGNITO_SECRET_ARN "$cognito_secret_arn"
+  append_env_if_set GUACAMOLE_SECRET_ARN "$guacamole_secret_arn"
+  append_env_if_set GUACAMOLE_BASE_URL "$guacamole_base_url"
+  append_env_if_set GUACAMOLE_API_BASE_URL "$guacamole_api_base_url"
+  append_env_if_set DC_DOMAIN_PASSWORD_SECRET_ARN "$dc_domain_password_secret_arn"
+
+  if [[ "$PS_PREFIX" == *"/dev/"* ]]; then
+    append_env DJANGO_ALLOWED_HOSTS "${domain_name},localhost,127.0.0.1"
+  else
+    append_env DJANGO_ALLOWED_HOSTS "$domain_name"
+  fi
+  append_env DJANGO_CSRF_TRUSTED_ORIGINS "https://${domain_name}"
+  append_env SITE_URL "https://${domain_name}"
+  append_env ENGINE_ECS_CLUSTER_ARN "$engine_ecs_cluster_arn"
+  append_env ENGINE_TASK_DEFINITION_ARN "$engine_task_definition_arn"
+  append_env ENGINE_ECS_SECURITY_GROUP_ID "$engine_ecs_security_group_id"
+  append_env ENGINE_PRIVATE_SUBNET_IDS "$engine_private_subnet_ids"
+  append_env SQS_CMS_URL "$sqs_cms_url"
+  append_env SQS_ENGINE_URL "$sqs_engine_url"
+  append_env SQS_MC_URL "$sqs_mc_url"
+  append_env_if_set REDIS_HOST "$redis_endpoint"
+  append_env_if_set CHANNEL_LAYER_BACKEND "$channel_layer_backend"
+  append_env_if_set EMAIL_BACKEND "$email_backend"
+  append_env_if_set CTF_FROM_EMAIL "$ctf_from_email"
+  append_env_if_set PLATFORM_BOOTSTRAP_STAFF_EMAILS "$platform_bootstrap_staff_emails"
+  append_env_if_set PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS "$platform_bootstrap_superuser_emails"
+
+  run_containers "$image" "${DOCKER_ENV[@]}"
+  install_worker_health
+  echo "Deployment complete!"
+}
+
+main "$@"

--- a/scripts/portal_deploy/tests/test_deploy_portal_script.py
+++ b/scripts/portal_deploy/tests/test_deploy_portal_script.py
@@ -1,0 +1,358 @@
+import base64
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "portal-deploy" / "deploy_portal.sh"
+
+
+def _b64(value: str) -> str:
+    return base64.b64encode(value.encode("utf-8")).decode("ascii")
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class DeployPortalScriptTests(unittest.TestCase):
+    def _install_stubs(
+        self,
+        root: Path,
+        *,
+        invalid_bootstrap_emails: bool = False,
+        missing_optional_params: bool = False,
+    ) -> dict[str, str]:
+        bin_dir = root / "bin"
+        bin_dir.mkdir()
+        call_log = root / "calls.log"
+
+        _write_executable(
+            bin_dir / "aws",
+            """
+            #!/usr/bin/env bash
+            set -euo pipefail
+            {
+              printf 'aws'
+              for arg in "$@"; do printf ' %s' "$arg"; done
+              printf '\\n'
+            } >> "$CALL_LOG"
+
+            if [[ "$1" == "ssm" && "$2" == "get-parameter" ]]; then
+              name=""
+              while [[ $# -gt 0 ]]; do
+                case "$1" in
+                  --name)
+                    name="$2"
+                    shift 2
+                    ;;
+                  *)
+                    shift
+                    ;;
+                esac
+              done
+
+              case "$name" in
+                */image-tag) printf 'abc123\\n' ;;
+                */ecr-registry) printf '123456789012.dkr.ecr.us-east-2.amazonaws.com\\n' ;;
+                */ecr-repository) printf 'shifter-dev-portal\\n' ;;
+                */domain-name) printf 'portal.dev.example.test\\n' ;;
+                */s3-bucket) printf 'shifter-dev-bucket\\n' ;;
+                */db-secret-arn) printf 'arn:aws:secretsmanager:db\\n' ;;
+                */app-secret-arn) printf 'arn:aws:secretsmanager:app\\n' ;;
+                */cognito-secret-arn) printf 'arn:aws:secretsmanager:cognito\\n' ;;
+                */guacamole-secret-arn)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'arn:aws:secretsmanager:guacamole\\n'
+                  fi
+                  ;;
+                */dc-domain-password-secret-arn)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'arn:aws:secretsmanager:dc\\n'
+                  fi
+                  ;;
+                */guacamole-base-url)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'https://guac.example.test/guacamole\\n'
+                  fi
+                  ;;
+                */guacamole-api-base-url)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'http://guacamole-client:8080/guacamole\\n'
+                  fi
+                  ;;
+                */engine-ecs-cluster-arn) printf 'arn:aws:ecs:cluster/engine\\n' ;;
+                */engine-task-definition-arn) printf 'arn:aws:ecs:task-definition/engine:1\\n' ;;
+                */engine-ecs-security-group-id) printf 'sg-123\\n' ;;
+                */engine-private-subnet-ids) printf 'subnet-a,subnet-b\\n' ;;
+                */sqs-cms-url) printf 'https://sqs.example.test/cms\\n' ;;
+                */sqs-engine-url) printf 'https://sqs.example.test/engine\\n' ;;
+                */sqs-mc-url) printf 'https://sqs.example.test/mc\\n' ;;
+                */redis-endpoint)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'redis.example.test\\n'
+                  fi
+                  ;;
+                */channel-layer-backend)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'redis\\n'
+                  fi
+                  ;;
+                */email-backend)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'django.core.mail.backends.smtp.EmailBackend\\n'
+                  fi
+                  ;;
+                */ctf-from-email)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'ctf@example.test\\n'
+                  fi
+                  ;;
+                */platform-bootstrap-staff-emails)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  elif [[ "${INVALID_BOOTSTRAP_EMAILS:-}" == "1" ]]; then
+                    printf 'staff example.test\\n'
+                  else
+                    printf 'staff@example.test,ops@example.test\\n'
+                  fi
+                  ;;
+                */platform-bootstrap-superuser-emails)
+                  if [[ "${MISSING_OPTIONAL_PARAMS:-}" == "1" ]]; then
+                    printf '\\n'
+                  else
+                    printf 'admin@example.test\\n'
+                  fi
+                  ;;
+                *) printf '\\n' ;;
+              esac
+              exit 0
+            fi
+
+            printf 'unexpected aws call: %s\\n' "$*" >&2
+            exit 1
+            """,
+        )
+        _write_executable(
+            bin_dir / "docker",
+            """
+            #!/usr/bin/env bash
+            set -euo pipefail
+            {
+              printf 'docker'
+              for arg in "$@"; do printf ' %s' "$arg"; done
+              printf '\\n'
+            } >> "$CALL_LOG"
+
+            if [[ "${1:-}" == "stop" || "${1:-}" == "rm" ]]; then
+              exit 1
+            fi
+            exit 0
+            """,
+        )
+        _write_executable(
+            bin_dir / "systemctl",
+            """
+            #!/usr/bin/env bash
+            set -euo pipefail
+            {
+              printf 'systemctl'
+              for arg in "$@"; do printf ' %s' "$arg"; done
+              printf '\\n'
+            } >> "$CALL_LOG"
+            exit 0
+            """,
+        )
+
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["CALL_LOG"] = str(call_log)
+        if invalid_bootstrap_emails:
+            env["INVALID_BOOTSTRAP_EMAILS"] = "1"
+        if missing_optional_params:
+            env["MISSING_OPTIONAL_PARAMS"] = "1"
+        return env
+
+    def _script_args(self, root: Path, *, ps_prefix: str = "/shifter/dev/portal") -> list[str]:
+        return [
+            str(SCRIPT_PATH),
+            "--aws-region",
+            "us-east-2",
+            "--ps-prefix",
+            ps_prefix,
+            "--worker-health-monitor-b64",
+            _b64("monitor-v1\n"),
+            "--worker-health-service-b64",
+            _b64("[Service]\nExecStart=/usr/local/bin/shifter-worker-health.sh\n"),
+            "--worker-health-timer-b64",
+            _b64("[Timer]\nOnCalendar=*:*:00\n"),
+            "--worker-health-name-prefix",
+            "dev-portal",
+            "--worker-health-bin-path",
+            str(root / "usr" / "local" / "bin" / "shifter-worker-health.sh"),
+            "--worker-health-service-path",
+            str(root / "etc" / "systemd" / "system" / "shifter-worker-health.service"),
+            "--worker-health-timer-path",
+            str(root / "etc" / "systemd" / "system" / "shifter-worker-health.timer"),
+            "--worker-health-env-path",
+            str(root / "etc" / "shifter-worker-health.env"),
+        ]
+
+    def test_missing_required_argument_fails_before_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = self._install_stubs(root)
+
+            result = subprocess.run(
+                [str(SCRIPT_PATH)],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("--ps-prefix is required", result.stderr)
+            self.assertFalse((root / "calls.log").exists())
+
+    def test_rejects_unknown_argument(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = self._install_stubs(root)
+
+            result = subprocess.run(
+                [str(SCRIPT_PATH), "--bogus"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("unknown argument: --bogus", result.stderr)
+            self.assertFalse((root / "calls.log").exists())
+
+    def test_rejects_invalid_bootstrap_email_before_docker_calls(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = self._install_stubs(root, invalid_bootstrap_emails=True)
+
+            result = subprocess.run(
+                self._script_args(root),
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("Invalid PLATFORM_BOOTSTRAP_STAFF_EMAILS", result.stderr)
+            log = (root / "calls.log").read_text(encoding="utf-8")
+            self.assertNotIn("docker pull", log)
+
+    def test_deploy_rewrites_worker_health_artifacts_and_tolerates_repeated_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = self._install_stubs(root)
+            args = self._script_args(root)
+
+            first = subprocess.run(args, check=False, capture_output=True, text=True, env=env)
+            second = subprocess.run(args, check=False, capture_output=True, text=True, env=env)
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(
+                (root / "usr" / "local" / "bin" / "shifter-worker-health.sh").read_text(
+                    encoding="utf-8"
+                ),
+                "monitor-v1\n",
+            )
+            self.assertEqual(
+                (root / "etc" / "shifter-worker-health.env").read_text(encoding="utf-8"),
+                "WH_NAME_PREFIX=dev-portal\n",
+            )
+            log = (root / "calls.log").read_text(encoding="utf-8")
+            self.assertEqual(log.count("docker run -d --name portal"), 2)
+            for name in ("worker-cms", "worker-engine", "worker-mc", "ctf-scheduler"):
+                self.assertIn(f"docker run -d --name {name}", log)
+            self.assertIn("run_worker --queue cms", log)
+            self.assertIn("run_worker --queue engine", log)
+            self.assertIn("run_worker --queue mc", log)
+            self.assertIn("python manage.py run_ctf_scheduler", log)
+            self.assertIn("docker stop portal worker-cms worker-engine worker-mc ctf-scheduler", log)
+            self.assertIn(
+                "DJANGO_ALLOWED_HOSTS=portal.dev.example.test,localhost,127.0.0.1",
+                log,
+            )
+            self.assertIn("systemctl enable --now shifter-worker-health.timer", log)
+
+    def test_missing_optional_params_are_not_emitted_as_empty_env_vars(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = self._install_stubs(root, missing_optional_params=True)
+
+            result = subprocess.run(
+                self._script_args(root),
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            log = (root / "calls.log").read_text(encoding="utf-8")
+            for name in (
+                "GUACAMOLE_SECRET_ARN",
+                "GUACAMOLE_BASE_URL",
+                "GUACAMOLE_API_BASE_URL",
+                "DC_DOMAIN_PASSWORD_SECRET_ARN",
+                "REDIS_HOST",
+                "CHANNEL_LAYER_BACKEND",
+                "EMAIL_BACKEND",
+                "CTF_FROM_EMAIL",
+                "PLATFORM_BOOTSTRAP_STAFF_EMAILS",
+                "PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS",
+            ):
+                self.assertNotIn(f"{name}=", log)
+
+    def test_non_dev_allowed_hosts_excludes_localhost_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = self._install_stubs(root)
+
+            result = subprocess.run(
+                self._script_args(root, ps_prefix="/shifter/prod/portal"),
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            log = (root / "calls.log").read_text(encoding="utf-8")
+            self.assertRegex(log, r"DJANGO_ALLOWED_HOSTS=portal\.dev\.example\.test(?!,)")
+            self.assertNotIn(
+                "DJANGO_ALLOWED_HOSTS=portal.dev.example.test,localhost,127.0.0.1",
+                log,
+            )

--- a/shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py
+++ b/shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py
@@ -13,6 +13,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[4]
 AWS_USER_DATA = REPO_ROOT / "platform" / "terraform" / "modules" / "portal" / "ec2" / "user_data.sh"
 AWS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_shifter-platform.yml"
+AWS_REDEPLOY_SCRIPT = REPO_ROOT / "scripts" / "portal-deploy" / "deploy_portal.sh"
 BASE_MANIFEST_DIR = REPO_ROOT / "platform" / "k8s" / "gcp" / "base"
 CHART_DIR = REPO_ROOT / "platform" / "charts" / "shifter"
 COMPOSE_FILE = REPO_ROOT / "shifter" / "shifter_platform" / "docker-compose.yml"
@@ -70,27 +71,32 @@ def test_local_compose_starts_ctf_scheduler_service() -> None:
     assert "ctf-scheduler-heartbeat" in " ".join(service["healthcheck"]["test"])
 
 
-@pytest.mark.parametrize("path", [AWS_USER_DATA, AWS_WORKFLOW])
+@pytest.mark.parametrize("path", [AWS_USER_DATA, AWS_REDEPLOY_SCRIPT])
 def test_aws_deploy_paths_start_ctf_scheduler_container(path: Path) -> None:
     deployment_text = path.read_text(encoding="utf-8")
 
     assert f"docker stop portal worker-cms worker-engine worker-mc {SCHEDULER_NAME}" in deployment_text
     assert f"docker rm portal worker-cms worker-engine worker-mc {SCHEDULER_NAME}" in deployment_text
-    assert (
-        'WORKER_HEALTH_BASE="--health-interval 30s --health-timeout 5s --health-start-period 90s --health-retries 2"'
-    ) in deployment_text
+    assert "health-interval 30s" in deployment_text
+    assert "health-timeout 5s" in deployment_text
+    assert "health-start-period 90s" in deployment_text
+    assert "health-retries 2" in deployment_text
     for heartbeat in (
         "worker-cms-heartbeat",
         "worker-engine-heartbeat",
         "worker-mc-heartbeat",
         "ctf-scheduler-heartbeat",
     ):
-        assert f"--health-cmd='find /tmp/{heartbeat} -mmin -2 | grep -q .'" in deployment_text
+        assert f"/tmp/{heartbeat} -mmin -2 | grep -q ." in deployment_text  # noqa: S108
     assert f"docker run -d --name {SCHEDULER_NAME} --restart unless-stopped" in deployment_text
-    assert (
-        f'docker run -d --name {SCHEDULER_NAME} --restart unless-stopped $WORKER_HEALTH_BASE "$CTF_SCHEDULER_HEALTH"'
-    ) in deployment_text
     assert " ".join(SCHEDULER_COMMAND) in deployment_text
+
+
+def test_aws_workflow_invokes_tracked_single_instance_deploy_script() -> None:
+    workflow_text = AWS_WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/portal-deploy/deploy_portal.sh" in workflow_text
+    assert "base64 -d > /tmp/shifter-deploy-portal.sh" in workflow_text
+    assert "--worker-health-name-prefix" in workflow_text
 
 
 @pytest.mark.parametrize(

--- a/shifter/shifter_platform/tests/platform/test_worker_health_supervision.py
+++ b/shifter/shifter_platform/tests/platform/test_worker_health_supervision.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 EC2_MODULE = REPO_ROOT / "platform" / "terraform" / "modules" / "portal" / "ec2"
 AWS_USER_DATA = EC2_MODULE / "user_data.sh"
 AWS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_shifter-platform.yml"
+AWS_REDEPLOY_SCRIPT = REPO_ROOT / "scripts" / "portal-deploy" / "deploy_portal.sh"
 WORKER_HEALTH_DIR = EC2_MODULE / "worker-health"
 MONITOR_SCRIPT = WORKER_HEALTH_DIR / "shifter-worker-health.sh"
 MONITOR_SERVICE = WORKER_HEALTH_DIR / "shifter-worker-health.service"
@@ -90,7 +91,7 @@ def test_systemd_timer_fires_on_the_health_interval() -> None:
     assert "WantedBy=timers.target" in text
 
 
-@pytest.mark.parametrize("path", [AWS_USER_DATA, AWS_WORKFLOW])
+@pytest.mark.parametrize("path", [AWS_USER_DATA, AWS_REDEPLOY_SCRIPT])
 def test_both_aws_deploy_paths_install_the_monitor(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
     assert MONITOR_HOST_PATH in text
@@ -105,6 +106,17 @@ def test_both_aws_deploy_paths_install_the_monitor(path: Path) -> None:
     # supervisor run would read WH_NAME_PREFIX unset and emit metrics under
     # NamePrefix=unknown, silently collapsing dev/prod and defeating alarm scoping.
     assert text.index("WH_NAME_PREFIX=") < text.index(f"systemctl enable --now {TIMER_UNIT}")
+
+
+def test_workflow_invokes_tracked_redeploy_script() -> None:
+    text = AWS_WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/portal-deploy/deploy_portal.sh" in text
+    assert "base64 -d > /tmp/shifter-deploy-portal.sh" in text
+    assert "--worker-health-monitor-b64" in text
+    assert "--worker-health-service-b64" in text
+    assert "--worker-health-timer-b64" in text
+    assert "--worker-health-name-prefix" in text
+    assert "aws ssm send-command" in text
 
 
 def test_ec2_module_grants_putmetricdata_least_privilege() -> None:


### PR DESCRIPTION
## Summary

Extracts the AWS single-instance portal SSM deploy body into a tracked shell script and wires the workflow to ship that script through SSM, with subprocess tests covering argument validation, optional env handling, idempotent worker-health installation, and container startup invariants.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #925

## ADR Impact

- ADR-021
- ADR-003

## Changes

- Add `scripts/portal-deploy/deploy_portal.sh` with strict CLI parsing, Parameter Store reads, array-based Docker runs, and worker-health installation.
- Replace the inline `_shifter-platform.yml` deploy heredoc with SSM transport that base64-ships and invokes the tracked script.
- Add subprocess tests for the shell script plus update platform structural tests to point at the extracted runtime script.
- Add a changelog fragment and register the new deploy script in ADR evidence for the portal deploy surface.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

- `pre-commit run --all-files`
- `PYTHONPATH=. uv run --with pytest pytest scripts/portal_deploy/tests/test_deploy_portal_script.py scripts/portal_deploy/tests/test_portal_deploy.py`
- `cd shifter/shifter_platform && uv run pytest tests/platform/test_worker_health_supervision.py tests/platform/test_ctf_scheduler_startup.py`
- `uvx --from shellcheck-py shellcheck scripts/portal-deploy/deploy_portal.sh`
- `actionlint`
- `python3 scripts/adr_guard/adr_guard.py --all --level ci`

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: issue #925 acceptance ← scripts/portal_deploy/tests/test_deploy_portal_script.py, issue #925 acceptance ← shifter/shifter_platform/tests/platform/test_worker_health_supervision.py, issue #925 acceptance ← shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/925.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
