### PR TITLE
fix: harden terraform deploy applies

### DIFF
--- a/.github/workflows/_core.yml
+++ b/.github/workflows/_core.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: platform/terraform
       - run: terraform init -backend-config=${{ inputs.environment }}.s3.tfbackend
       - run: terraform validate
-      - run: terraform plan -no-color -out=tfplan && terraform show -no-color tfplan > plan.txt
+      - run: terraform plan -no-color -lock-timeout=5m -out=tfplan && terraform show -no-color tfplan > plan.txt
       - name: Comment PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -83,5 +83,6 @@ jobs:
         with:
           terraform_version: "1.13.3"
       - run: terraform init -backend-config=${{ inputs.environment }}.s3.tfbackend
-      - run: terraform apply -auto-approve
+      - run: terraform plan -no-color -lock-timeout=5m -out=tfplan && terraform show -no-color tfplan
+      - run: terraform apply -lock-timeout=5m tfplan
       - run: terraform output -json

--- a/.github/workflows/_range.yml
+++ b/.github/workflows/_range.yml
@@ -73,7 +73,7 @@ jobs:
           printf '%s\n' "${TF_VARS_RANGE}" > local.auto.tfvars
       - run: terraform init -backend-config=${{ inputs.environment }}.s3.tfbackend
       - run: terraform validate
-      - run: terraform plan -no-color -out=tfplan && terraform show -no-color tfplan > plan.txt
+      - run: terraform plan -no-color -lock-timeout=5m -out=tfplan && terraform show -no-color tfplan > plan.txt
       - name: Comment PR
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -134,5 +134,6 @@ jobs:
           fi
           printf '%s\n' "${TF_VARS_RANGE}" > local.auto.tfvars
       - run: terraform init -backend-config=${{ inputs.environment }}.s3.tfbackend
-      - run: terraform apply -auto-approve
+      - run: terraform plan -no-color -lock-timeout=5m -out=tfplan && terraform show -no-color tfplan
+      - run: terraform apply -lock-timeout=5m tfplan
       - run: terraform output -json

--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -226,65 +226,65 @@ jobs:
         env:
           ENV: ${{ inputs.environment }}
         run: |
-          # Check if Service Discovery service needs replacement
-          echo "Running terraform plan to check for Service Discovery changes..."
+          echo "Creating saved Terraform plan for Service Discovery check and apply..."
           terraform plan -detailed-exitcode -lock-timeout=5m -out=tfplan 2>&1 || PLAN_EXIT=$?
-
-          echo "Plan exit code: ${PLAN_EXIT:-0}"
-
-          # Exit code 2 means there are changes
-          if [ "${PLAN_EXIT:-0}" = "2" ]; then
-            # Check if service discovery service is being deleted/replaced
-            echo "Checking plan for Service Discovery changes..."
-            if terraform show -json tfplan | jq -e '.resource_changes[]? | select(.address | contains("service_discovery_service")) | select(.change.actions | index("delete"))' > /dev/null 2>&1; then
-              echo "Service Discovery service deletion detected - scaling down ECS services first"
-
-              # Find the Guacamole ECS cluster using AWS CLI directly (pattern: {env}-portal-guacamole)
-              CLUSTER_NAME="${ENV}-portal-guacamole"
-              echo "Looking for Guacamole cluster: $CLUSTER_NAME"
-
-              # Verify cluster exists
-              if aws ecs describe-clusters --clusters "$CLUSTER_NAME" --query "clusters[0].status" --output text 2>/dev/null | grep -q "ACTIVE"; then
-                echo "Found active Guacamole cluster: $CLUSTER_NAME"
-
-                # Scale down guacd service to deregister from Service Discovery
-                GUACD_SERVICE="${ENV}-portal-guacd"
-                echo "Scaling down guacd service: $GUACD_SERVICE"
-
-                if aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$GUACD_SERVICE" --query "services[0].status" --output text 2>/dev/null | grep -q "ACTIVE"; then
-                  echo "Scaling guacd service to 0..."
-                  aws ecs update-service --cluster "$CLUSTER_NAME" --service "$GUACD_SERVICE" --desired-count 0 --no-cli-pager
-
-                  # Wait for tasks to drain (max 2 minutes)
-                  # shellcheck disable=SC2034
-                  for i in $(seq 1 24); do
-                    RUNNING=$(aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$GUACD_SERVICE" --query "services[0].runningCount" --output text 2>/dev/null || echo "0")
-                    if [ "$RUNNING" = "0" ]; then
-                      echo "All guacd tasks stopped"
-                      break
-                    fi
-                    echo "Waiting for tasks to stop... ($RUNNING running)"
-                    sleep 5
-                  done
-
-                  # Give Service Discovery time to deregister
-                  echo "Waiting for Service Discovery to deregister instances..."
-                  sleep 15
-                else
-                  echo "guacd service not found or not active"
-                fi
-              else
-                echo "Guacamole cluster not found or not active"
-              fi
-            else
-              echo "No Service Discovery deletion in plan"
-            fi
-          else
-            echo "No changes detected or plan succeeded without changes"
+          if [ "${PLAN_EXIT:-0}" != "0" ] && [ "${PLAN_EXIT:-0}" != "2" ]; then
+            echo "::error::Terraform plan failed with exit code ${PLAN_EXIT}"
+            exit "${PLAN_EXIT}"
           fi
 
-          rm -f tfplan
-      - run: terraform apply -auto-approve
+          if [ ! -f tfplan ]; then
+            echo "::error::Terraform did not create the expected saved plan tfplan"
+            exit 1
+          fi
+
+          terraform show -no-color tfplan
+
+          echo "Checking saved Terraform plan for Service Discovery changes..."
+          if terraform show -json tfplan | jq -e '.resource_changes[]? | select(.address | contains("service_discovery_service")) | select(.change.actions | index("delete"))' > /dev/null 2>&1; then
+            echo "Service Discovery service deletion detected - scaling down ECS services first"
+
+            # Find the Guacamole ECS cluster using AWS CLI directly (pattern: {env}-portal-guacamole)
+            CLUSTER_NAME="${ENV}-portal-guacamole"
+            echo "Looking for Guacamole cluster: $CLUSTER_NAME"
+
+            # Verify cluster exists
+            if aws ecs describe-clusters --clusters "$CLUSTER_NAME" --query "clusters[0].status" --output text 2>/dev/null | grep -q "ACTIVE"; then
+              echo "Found active Guacamole cluster: $CLUSTER_NAME"
+
+              # Scale down guacd service to deregister from Service Discovery
+              GUACD_SERVICE="${ENV}-portal-guacd"
+              echo "Scaling down guacd service: $GUACD_SERVICE"
+
+              if aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$GUACD_SERVICE" --query "services[0].status" --output text 2>/dev/null | grep -q "ACTIVE"; then
+                echo "Scaling guacd service to 0..."
+                aws ecs update-service --cluster "$CLUSTER_NAME" --service "$GUACD_SERVICE" --desired-count 0 --no-cli-pager
+
+                # Wait for tasks to drain (max 2 minutes)
+                # shellcheck disable=SC2034
+                for i in $(seq 1 24); do
+                  RUNNING=$(aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$GUACD_SERVICE" --query "services[0].runningCount" --output text 2>/dev/null || echo "0")
+                  if [ "$RUNNING" = "0" ]; then
+                    echo "All guacd tasks stopped"
+                    break
+                  fi
+                  echo "Waiting for tasks to stop... ($RUNNING running)"
+                  sleep 5
+                done
+
+                # Give Service Discovery time to deregister
+                echo "Waiting for Service Discovery to deregister instances..."
+                sleep 15
+              else
+                echo "guacd service not found or not active"
+              fi
+            else
+              echo "Guacamole cluster not found or not active"
+            fi
+          else
+            echo "No Service Discovery deletion in saved plan"
+          fi
+      - run: terraform apply -lock-timeout=5m tfplan
       - name: Verify RDS pending modifications applied (dev only)
         # Dev opts into apply_immediately=true so any post-apply
         # PendingModifiedValues means the deploy is incomplete. Prod

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,12 +27,10 @@ on:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  # Cancel an in-flight run when a newer push to the same ref arrives. Old
-  # behaviour (cancel-in-progress: false) queued every new push behind the
-  # previous run's full duration — fine if the older run was apply-bound to
-  # a different SHA, but for env-branch pushes the newer SHA always
-  # supersedes the old one (env branches never go backwards).
-  cancel-in-progress: true
+  # PR runs may be superseded safely, but env-branch deploys can be mid-apply.
+  # Queue branch/manual deploy runs so Terraform is not killed after mutating
+  # remote state or while holding the backend lock.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ============================================================================

--- a/changelog.d/917.fixed.md
+++ b/changelog.d/917.fixed.md
@@ -1,0 +1,1 @@
+**AWS deploy workflows now queue Terraform applies and execute local saved plans.** Env-branch deploys no longer cancel an in-flight apply, core/range/platform Terraform operations wait on the backend lock, and apply jobs create and consume the exact local `tfplan` they apply instead of running a fresh unplanned apply.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -58,7 +58,7 @@
       },
       {
         "id": "ADR-003-R2",
-        "description": "AWS platform Terraform plan routing must stay scoped to Terraform-consumed files, while platform application changes still trigger Quality through a separate app-source filter. AWS platform Terraform plan commands must wait for the state lock before failing. Portal application changes must keep reaching the portal image build/deploy path through the dedicated portal_image filter wired into the shifter_platform job trigger and the platform build job's portal_image_changes input, without widening the Terraform-scoped plan trigger.",
+        "description": "AWS Terraform plan routing must stay scoped to Terraform-consumed files, while platform application changes still trigger Quality through a separate app-source filter. AWS deploy runs that can apply infrastructure must queue instead of cancelling an in-flight apply. Core, range, and platform Terraform plan and apply commands must wait for the backend state lock. Their apply jobs must create a local saved tfplan and apply that exact file instead of uploading raw binary plans as artifacts or running a fresh unplanned apply; platform Service Discovery replacement handling must inspect that same saved plan before apply. Portal application changes must keep reaching the portal image build/deploy path through the dedicated portal_image filter wired into the shifter_platform job trigger and the platform build job's portal_image_changes input, without widening the Terraform-scoped plan trigger.",
         "checks": ["deploy-workflow-plan-scope"]
       },
       {
@@ -77,6 +77,8 @@
     "evidence": [
       ".github/workflows/_quality.yml",
       ".github/workflows/deploy.yml",
+      ".github/workflows/_core.yml",
+      ".github/workflows/_range.yml",
       ".github/workflows/_shifter-engine.yml",
       ".github/workflows/_shifter-platform.yml",
       "scripts/portal_deploy/portal_deploy.py",

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -2277,10 +2277,13 @@ def check_no_tracked_generated_artifacts(
 
 
 _DEPLOY_WORKFLOW_PATH = ".github/workflows/deploy.yml"
+_CORE_WORKFLOW_PATH = ".github/workflows/_core.yml"
+_RANGE_WORKFLOW_PATH = ".github/workflows/_range.yml"
 _PLATFORM_WORKFLOW_PATH = ".github/workflows/_shifter-platform.yml"
 _ADR_GUARD_SCRIPT_PATH = "scripts/adr_guard/adr_guard.py"
 _PLAN_SCOPE_CHECK = "deploy-workflow-plan-scope"
 _PLAN_SCOPE_RULE = "ADR-003-R2"
+_TERRAFORM_PLAN_FILE = "tfplan"
 _SHIFTER_APP_OUTPUT = "shifter_app: ${{ steps.filter.outputs.shifter_app }}"
 _SHIFTER_APP_QUALITY_CONDITION = "needs.changes.outputs.shifter_app == 'true'"
 _PORTAL_IMAGE_OUTPUT = "portal_image: ${{ steps.filter.outputs.portal_image }}"
@@ -2297,8 +2300,18 @@ _PORTAL_PROD_OUTPUTS_PATH = "platform/terraform/environments/prod/portal/outputs
 def _deploy_plan_scope_relevant(files: list[str] | None) -> bool:
     if files is None:
         return True
-    relevant = {_DEPLOY_WORKFLOW_PATH, _PLATFORM_WORKFLOW_PATH, _ADR_GUARD_SCRIPT_PATH}
+    relevant = {
+        _DEPLOY_WORKFLOW_PATH,
+        _CORE_WORKFLOW_PATH,
+        _RANGE_WORKFLOW_PATH,
+        _PLATFORM_WORKFLOW_PATH,
+        _ADR_GUARD_SCRIPT_PATH,
+    }
     return any(path in relevant for path in files)
+
+
+def _should_check_plan_scope_file(files: list[str] | None, path: str) -> bool:
+    return files is None or path in files or _ADR_GUARD_SCRIPT_PATH in files
 
 
 def _paths_filter_block(deploy_text: str, filter_name: str) -> list[str]:
@@ -2366,7 +2379,79 @@ def _terraform_plan_has_lock_timeout(stripped_line: str) -> bool:
         tokens = shlex.split(command, comments=True)
     except ValueError:
         tokens = command.split()
-    return "-lock-timeout=5m" in tokens
+    for index, token in enumerate(tokens[:-1]):
+        if token != "terraform" or tokens[index + 1] != "plan":
+            continue
+        plan_tokens: list[str] = []
+        for plan_token in tokens[index + 2 :]:
+            if plan_token in {"&&", "||", ";", "|"}:
+                break
+            plan_tokens.append(plan_token)
+        return "-lock-timeout=5m" in plan_tokens
+    return False
+
+
+def _terraform_plan_writes_saved_plan(stripped_line: str) -> bool:
+    if stripped_line.startswith("- run:"):
+        command = stripped_line.split(":", 1)[1].strip()
+    else:
+        command = stripped_line
+    try:
+        tokens = shlex.split(command, comments=True)
+    except ValueError:
+        tokens = command.split()
+    for index, token in enumerate(tokens[:-1]):
+        if token != "terraform" or tokens[index + 1] != "plan":
+            continue
+        plan_tokens: list[str] = []
+        for plan_token in tokens[index + 2 :]:
+            if plan_token in {"&&", "||", ";", "|"}:
+                break
+            plan_tokens.append(plan_token)
+        if f"-out={_TERRAFORM_PLAN_FILE}" in plan_tokens:
+            return True
+        return any(
+            plan_token == "-out"
+            and next_index + 1 < len(plan_tokens)
+            and plan_tokens[next_index + 1] == _TERRAFORM_PLAN_FILE
+            for next_index, plan_token in enumerate(plan_tokens)
+        )
+    return False
+
+
+def _terraform_apply_uses_saved_plan(stripped_line: str) -> bool:
+    if stripped_line.startswith("- run:"):
+        command = stripped_line.split(":", 1)[1].strip()
+    else:
+        command = stripped_line
+    try:
+        tokens = shlex.split(command, comments=True)
+    except ValueError:
+        tokens = command.split()
+    for index, token in enumerate(tokens[:-1]):
+        if token != "terraform" or tokens[index + 1] != "apply":
+            continue
+        apply_tokens = tokens[index + 2 :]
+        return (
+            "-lock-timeout=5m" in apply_tokens
+            and _TERRAFORM_PLAN_FILE in apply_tokens
+            and "-auto-approve" not in apply_tokens
+        )
+    return False
+
+
+def _line_removes_tfplan(stripped_line: str) -> bool:
+    if _TERRAFORM_PLAN_FILE not in stripped_line:
+        return False
+    if stripped_line.startswith("- run:"):
+        command = stripped_line.split(":", 1)[1].strip()
+    else:
+        command = stripped_line
+    try:
+        tokens = shlex.split(command, comments=True)
+    except ValueError:
+        tokens = command.split()
+    return "rm" in tokens and _TERRAFORM_PLAN_FILE in tokens
 
 
 def _plan_scope_violation(path: str, message: str) -> Violation:
@@ -2478,9 +2563,46 @@ def _check_platform_build_portal_image_gate(platform_text: str) -> list[Violatio
     return []
 
 
-def _check_platform_plan_lock_timeout(platform_text: str) -> list[Violation]:
+def _check_deploy_concurrency_queues_apply_runs(deploy_text: str) -> list[Violation]:
+    """Require deploy runs that can apply infrastructure to queue, not cancel.
+
+    PR cancellation is still allowed because PR runs do not execute environment
+    branch applies. A global `true` cancellation policy can kill Terraform
+    mid-apply on `aws-dev` / `gcp-dev` pushes.
+    """
+    cancel_value: str | None = None
+    for line in deploy_text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or not stripped.startswith("cancel-in-progress:"):
+            continue
+        cancel_value = stripped.split(":", 1)[1].strip()
+        break
+
+    if cancel_value is None:
+        return []
+
+    normalized = cancel_value.strip()
+    if normalized in {"false", "${{ false }}"}:
+        return []
+    if (
+        "github.event_name == 'pull_request'" in normalized
+        or 'github.event_name == "pull_request"' in normalized
+    ):
+        return []
+
+    return [
+        _plan_scope_violation(
+            _DEPLOY_WORKFLOW_PATH,
+            "Deploy workflow concurrency must queue env-branch apply runs instead "
+            "of cancelling an in-flight Terraform apply; restrict cancellation to "
+            "pull_request runs or set `cancel-in-progress: false`",
+        )
+    ]
+
+
+def _check_terraform_plan_lock_timeout(workflow_text: str, path: str) -> list[Violation]:
     violations: list[Violation] = []
-    for lineno, line in enumerate(platform_text.splitlines(), start=1):
+    for lineno, line in enumerate(workflow_text.splitlines(), start=1):
         stripped = line.strip()
         if "terraform plan" not in stripped:
             continue
@@ -2490,11 +2612,121 @@ def _check_platform_plan_lock_timeout(platform_text: str) -> list[Violation]:
             continue
         violations.append(
             _plan_scope_violation(
-                f"{_PLATFORM_WORKFLOW_PATH}:{lineno}",
-                "AWS platform Terraform plan commands must include `-lock-timeout=5m` "
+                f"{path}:{lineno}",
+                "AWS Terraform plan commands must include `-lock-timeout=5m` "
                 "so legitimate concurrent plans wait for the state lock instead of failing",
             )
         )
+    return violations
+
+
+def _check_saved_plan_apply_contract(workflow_text: str, path: str) -> list[Violation]:
+    """Require the apply job to create and consume a local saved Terraform plan."""
+    violations: list[Violation] = []
+    plan_block = _workflow_job_block(workflow_text, "plan")
+    apply_block = _workflow_job_block(workflow_text, "apply")
+
+    if not plan_block:
+        return [
+            _plan_scope_violation(
+                path,
+                "Terraform workflow is missing a `plan` job; ADR-003-R2 cannot verify "
+                "saved-plan apply integrity",
+            )
+        ]
+    if not apply_block:
+        return [
+            _plan_scope_violation(
+                path,
+                "Terraform workflow is missing an `apply` job; ADR-003-R2 cannot verify "
+                "saved-plan apply integrity",
+            )
+        ]
+
+    apply_plan_idx: int | None = None
+    apply_command_idx: int | None = None
+    for index, line in enumerate(apply_block):
+        stripped = line.strip()
+        if stripped.startswith(("#", "echo ")):
+            continue
+        if apply_plan_idx is None and "terraform plan" in stripped:
+            apply_plan_idx = index
+        if apply_command_idx is None and "terraform apply" in stripped:
+            apply_command_idx = index
+
+    if apply_plan_idx is None:
+        violations.append(
+            _plan_scope_violation(
+                path,
+                "The Terraform `apply` job must create a local saved Terraform plan "
+                "(`terraform plan -lock-timeout=5m -out=tfplan`) immediately before "
+                "applying, avoiding raw binary plan artifacts while ensuring apply "
+                "executes a reviewed saved plan",
+            )
+        )
+    elif not _terraform_plan_writes_saved_plan(apply_block[apply_plan_idx]):
+        violations.append(
+            _plan_scope_violation(
+                path,
+                "The Terraform `apply` job's local plan command must write `-out=tfplan` "
+                "so the subsequent apply consumes a saved plan file",
+            )
+        )
+
+    if apply_command_idx is None:
+        violations.append(
+            _plan_scope_violation(
+                path,
+                "The Terraform `apply` job must run `terraform apply -lock-timeout=5m "
+                "tfplan` after creating the saved plan",
+            )
+        )
+    elif apply_plan_idx is not None and apply_plan_idx > apply_command_idx:
+        violations.append(
+            _plan_scope_violation(
+                path,
+                "The Terraform `apply` job must create the saved `tfplan` before "
+                "running `terraform apply`",
+            )
+        )
+
+    for index, line in enumerate(apply_block):
+        stripped = line.strip()
+        if stripped.startswith(("#", "echo ")):
+            continue
+        if (
+            apply_plan_idx is not None
+            and apply_command_idx is not None
+            and apply_plan_idx < index < apply_command_idx
+            and _line_removes_tfplan(stripped)
+        ):
+            violations.append(
+                _plan_scope_violation(
+                    path,
+                    "The Terraform `apply` job must not remove `tfplan` before applying; "
+                    "Service Discovery checks and Terraform apply must consume the same "
+                    "saved plan file",
+                )
+            )
+        if "terraform apply" not in stripped:
+            continue
+        if _terraform_apply_uses_saved_plan(stripped):
+            continue
+        violations.append(
+            _plan_scope_violation(
+                path,
+                "Terraform apply commands must apply the saved Terraform plan with "
+                "`terraform apply -lock-timeout=5m tfplan`, not run a fresh "
+                "`terraform apply -auto-approve`",
+            )
+        )
+    return violations
+
+
+def _check_terraform_workflow_integrity(workflow_text: str, path: str) -> list[Violation]:
+    violations: list[Violation] = []
+    violations.extend(_check_terraform_plan_lock_timeout(workflow_text, path))
+    violations.extend(_check_saved_plan_apply_contract(workflow_text, path))
     return violations
 
 
@@ -2505,30 +2737,57 @@ def check_deploy_workflow_plan_scope(repo_root: Path, files: list[str] | None) -
 
     violations: list[Violation] = []
     deploy_path = repo_root / _DEPLOY_WORKFLOW_PATH
+    core_path = repo_root / _CORE_WORKFLOW_PATH
+    range_path = repo_root / _RANGE_WORKFLOW_PATH
     platform_path = repo_root / _PLATFORM_WORKFLOW_PATH
 
-    if not deploy_path.exists():
+    check_deploy_and_platform = files is None or any(
+        path in {_DEPLOY_WORKFLOW_PATH, _PLATFORM_WORKFLOW_PATH, _ADR_GUARD_SCRIPT_PATH}
+        for path in files
+    )
+
+    if check_deploy_and_platform and not deploy_path.exists():
         violations.append(
             _plan_scope_violation(
                 _DEPLOY_WORKFLOW_PATH,
                 "Required workflow is missing; ADR-003-R2 cannot verify platform plan routing",
             )
         )
-    else:
+    elif check_deploy_and_platform:
         deploy_text = deploy_path.read_text(encoding="utf-8")
+        violations.extend(_check_deploy_concurrency_queues_apply_runs(deploy_text))
         violations.extend(_check_deploy_workflow_plan_routing(deploy_text))
         violations.extend(_check_deploy_workflow_portal_image_routing(deploy_text))
 
-    if not platform_path.exists():
+    for path, workflow_path in (
+        (_CORE_WORKFLOW_PATH, core_path),
+        (_RANGE_WORKFLOW_PATH, range_path),
+    ):
+        if not _should_check_plan_scope_file(files, path):
+            continue
+        if not workflow_path.exists():
+            violations.append(
+                _plan_scope_violation(
+                    path,
+                    "Required workflow is missing; ADR-003-R2 cannot verify Terraform "
+                    "lock-timeout and saved-plan apply integrity",
+                )
+            )
+            continue
+        violations.extend(
+            _check_terraform_workflow_integrity(workflow_path.read_text(encoding="utf-8"), path)
+        )
+
+    if check_deploy_and_platform and not platform_path.exists():
         violations.append(
             _plan_scope_violation(
                 _PLATFORM_WORKFLOW_PATH,
                 "Required workflow is missing; ADR-003-R2 cannot verify platform Terraform plan commands",
             )
         )
-    else:
+    elif check_deploy_and_platform:
         platform_text = platform_path.read_text(encoding="utf-8")
-        violations.extend(_check_platform_plan_lock_timeout(platform_text))
+        violations.extend(_check_terraform_workflow_integrity(platform_text, _PLATFORM_WORKFLOW_PATH))
         violations.extend(_check_platform_build_portal_image_gate(platform_text))
 
     return violations

--- a/scripts/adr_guard/tests/test_adr_guard.py
+++ b/scripts/adr_guard/tests/test_adr_guard.py
@@ -111,11 +111,24 @@ class AdrGuardTests(unittest.TestCase):
 class DeployWorkflowPlanScopeTests(unittest.TestCase):
     """Tests for the AWS platform plan trigger and lock-timeout guardrail."""
 
-    def _write_workflows(self, repo_root: Path, deploy: str, platform: str) -> None:
+    def _write_workflows(
+        self,
+        repo_root: Path,
+        deploy: str,
+        platform: str,
+        core: str | None = None,
+        range_workflow: str | None = None,
+    ) -> None:
         workflow_dir = repo_root / ".github" / "workflows"
         workflow_dir.mkdir(parents=True)
         (workflow_dir / "deploy.yml").write_text(deploy, encoding="utf-8")
         (workflow_dir / "_shifter-platform.yml").write_text(platform, encoding="utf-8")
+        (workflow_dir / "_core.yml").write_text(
+            core or self._terraform_workflow_text("core"), encoding="utf-8"
+        )
+        (workflow_dir / "_range.yml").write_text(
+            range_workflow or self._terraform_workflow_text("range"), encoding="utf-8"
+        )
 
     def _deploy_text(
         self,
@@ -127,6 +140,7 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
         include_portal_image_filter: bool = True,
         portal_image_output: str = "portal_image: ${{ steps.filter.outputs.portal_image }}",
         platform_job_condition: str = "needs.changes.outputs.portal_image == 'true'",
+        cancel_in_progress: str = "${{ github.event_name == 'pull_request' }}",
     ) -> str:
         platform_globs = platform_globs or ["platform/terraform/modules/portal/**"]
         app_globs = app_globs or ["shifter/**"]
@@ -140,6 +154,9 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
             )
             portal_image_filter = f"            portal_image:\n{portal_image_lines}"
         return (
+            "concurrency:\n"
+            "  group: deploy-${{ github.ref }}\n"
+            f"  cancel-in-progress: {cancel_in_progress}\n"
             "jobs:\n"
             "  changes:\n"
             "    outputs:\n"
@@ -166,16 +183,147 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
         self,
         plan_args: str = "-no-color -lock-timeout=5m -out=tfplan",
         build_condition: str = "inputs.portal_image_changes",
+        apply_plan_command: str | None = "terraform plan -lock-timeout=5m -out=tfplan",
+        before_apply_command: str | None = None,
+        apply_command: str = "terraform apply -lock-timeout=5m tfplan",
     ) -> str:
+        apply_plan_step = f"      - run: {apply_plan_command}\n" if apply_plan_command else ""
+        before_apply_step = f"      - run: {before_apply_command}\n" if before_apply_command else ""
         return (
             "jobs:\n"
             "  plan:\n"
             "    steps:\n"
             f"      - run: terraform plan {plan_args}\n"
+            "  apply:\n"
+            "    steps:\n"
+            f"{apply_plan_step}"
+            f"{before_apply_step}"
+            f"      - run: {apply_command}\n"
             "  build:\n"
             "    if: |\n"
             f"      {build_condition}\n"
         )
+
+    def _terraform_workflow_text(
+        self,
+        component: str,
+        *,
+        plan_args: str = "-no-color -lock-timeout=5m -out=tfplan",
+        apply_plan_command: str | None = "terraform plan -lock-timeout=5m -out=tfplan",
+        apply_command: str = "terraform apply -lock-timeout=5m tfplan",
+    ) -> str:
+        apply_plan_step = f"      - run: {apply_plan_command}\n" if apply_plan_command else ""
+        return (
+            "jobs:\n"
+            "  plan:\n"
+            "    steps:\n"
+            f"      - run: terraform plan {plan_args}\n"
+            "  apply:\n"
+            "    steps:\n"
+            f"{apply_plan_step}"
+            f"      - run: {apply_command}\n"
+        )
+
+    def test_flags_deploy_workflow_that_cancels_env_branch_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(cancel_in_progress="true"),
+                self._platform_text(),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-003-R2")
+            self.assertIn("queue", violations[0].message)
+
+    def test_flags_core_and_range_plan_without_lock_timeout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(),
+                self._platform_text(),
+                core=self._terraform_workflow_text("core", plan_args="-no-color -out=tfplan"),
+                range_workflow=self._terraform_workflow_text(
+                    "range", plan_args="-no-color -out=tfplan"
+                ),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            flagged = {violation.path.split(":", 1)[0] for violation in violations}
+            self.assertIn(".github/workflows/_core.yml", flagged)
+            self.assertIn(".github/workflows/_range.yml", flagged)
+            self.assertTrue(all(violation.rule_id == "ADR-003-R2" for violation in violations))
+
+    def test_flags_core_apply_without_local_saved_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(),
+                self._platform_text(),
+                core=self._terraform_workflow_text(
+                    "core",
+                    apply_plan_command=None,
+                    apply_command="terraform apply -auto-approve",
+                ),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            core_violations = [
+                violation
+                for violation in violations
+                if violation.path.startswith(".github/workflows/_core.yml")
+            ]
+            self.assertGreaterEqual(len(core_violations), 1)
+            self.assertTrue(
+                all(violation.rule_id == "ADR-003-R2" for violation in core_violations)
+            )
+            self.assertTrue(
+                any(
+                    "local saved Terraform plan" in violation.message
+                    for violation in core_violations
+                )
+            )
+
+    def test_flags_apply_without_local_saved_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(),
+                self._platform_text(
+                    apply_plan_command=None,
+                    apply_command="terraform apply -auto-approve",
+                ),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            messages = "\n".join(violation.message for violation in violations)
+            self.assertIn("local saved Terraform plan", messages)
+            self.assertIn("saved Terraform plan", messages)
+
+    def test_flags_apply_job_that_removes_saved_plan_before_applying(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            self._write_workflows(
+                repo_root,
+                self._deploy_text(),
+                self._platform_text(
+                    before_apply_command="rm -f tfplan",
+                ),
+            )
+
+            violations = ADR_GUARD.check_deploy_workflow_plan_scope(repo_root, None)
+
+            self.assertEqual(len(violations), 1)
+            self.assertIn("must not remove `tfplan`", violations[0].message)
 
     def test_flags_python_glob_in_platform_plan_scope(self) -> None:
         cases = ("shifter/**", "shifter/shifter_platform/**", "shifter/**/*.py")
@@ -212,9 +360,10 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
     def test_targeted_mode_runs_for_relevant_workflow_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo_root = Path(tmp)
+            app_glob = "shifter/**"
             self._write_workflows(
                 repo_root,
-                self._deploy_text(platform_globs=["shifter/**"]),
+                self._deploy_text(platform_globs=[app_glob]),
                 self._platform_text(),
             )
 
@@ -223,6 +372,8 @@ class DeployWorkflowPlanScopeTests(unittest.TestCase):
             )
 
             self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0].rule_id, "ADR-003-R2")
+            self.assertIn(app_glob, violations[0].message)
 
     def test_flags_missing_app_quality_scope_after_platform_scope_split(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -97,7 +97,7 @@ The first slice intentionally stays small:
   (`_gcp-dev.yml`) so retention and IAM policy bootstrap logic remains valid.
 
 - `deploy-workflow-plan-scope`
-  Enforces ADR-003-R2 for the AWS platform workflow. The `shifter_platform`
+  Enforces ADR-003-R2 for the AWS deploy workflows. The `shifter_platform`
   change filter in `.github/workflows/deploy.yml` must stay scoped to
   Terraform-consumed platform files, with application source changes routed
   through the separate `shifter_app` filter so Quality still runs without
@@ -108,14 +108,18 @@ The first slice intentionally stays small:
   condition, and consumed by the platform `build` job through the
   `portal_image_changes` input — so an app-only push to an environment branch
   builds and converges the portal image without running Terraform. The check
-  also requires every `terraform plan` command in `_shifter-platform.yml` to
-  include `-lock-timeout=5m`, so legitimate concurrent platform plans wait on
-  the backend state lock instead of failing immediately. On apply workflows,
-  `_shifter-platform.yml` pushes the Guacamole ECR images before the
-  platform Terraform plan because the Guacamole module resolves current
-  image digests with `aws_ecr_image` data sources during plan. This ordering
-  is required for fresh AWS accounts where the repositories exist but the
-  tags have not been published yet.
+  requires deploy concurrency to queue branch/manual runs rather than cancel
+  in-flight applies; PR cancellation may remain enabled. It also requires every
+  core, range, and platform `terraform plan` / saved-plan `terraform apply`
+  command to include `-lock-timeout=5m`, and requires each apply job to create
+  and execute a local saved `tfplan` instead of uploading raw binary plans as
+  artifacts or running a fresh unplanned apply. The platform Service Discovery
+  replacement check must inspect that same saved plan. On apply workflows,
+  `_shifter-platform.yml` still pushes the Guacamole ECR images before the
+  platform Terraform plan because the Guacamole module resolves current image
+  digests with `aws_ecr_image` data sources during plan. This ordering is
+  required for fresh AWS accounts where the repositories exist but the tags have
+  not been published yet.
 
 - `portal-deploy-mode-source-of-truth`
   Enforces ADR-003-R4 for the AWS portal deploy path. `_shifter-platform.yml`

--- a/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/ci-cd.md
@@ -131,12 +131,26 @@ Each component follows the same pattern:
    - Checkout repo (tfvars are committed)
    - `terraform init`
    - `terraform validate`
-   - `terraform plan -out=tfplan`
+   - `terraform plan -lock-timeout=5m -out=tfplan`
    - Comment plan on PR (if PR)
 
 2. **Apply job** (if plan succeeds):
-   - Skip on PRs to prod
-   - `terraform apply -auto-approve`
+   - Skip on PRs
+   - Create a local saved `tfplan` with `terraform plan -lock-timeout=5m -out=tfplan`
+   - `terraform apply -lock-timeout=5m tfplan`
+
+Branch and manual deploy runs are queued by the Deploy workflow's concurrency
+group so a newer push cannot cancel a Terraform process after it has started
+mutating remote infrastructure or while it holds the backend lock. Pull request
+runs may still be cancelled by newer commits because they do not execute apply
+jobs.
+
+The saved plan file created inside the apply job is the apply contract. If state
+moves after that local plan, Terraform should fail the saved-plan apply instead
+of silently executing a fresh unplanned apply. Raw binary plans are not uploaded
+as workflow artifacts because they can include unredacted plan/state data. The
+platform Service Discovery replacement check reads the same saved `tfplan` that
+the apply step consumes.
 
 **Note**: The committed `terraform.tfvars` files ship an `example.com`
 baseline. Deployment-specific values (domains, alarm emails, allow-list


### PR DESCRIPTION
## Summary

Harden AWS deploy Terraform applies so environment-branch deploys queue instead of cancelling in-flight applies, every plan/apply waits on the Terraform backend lock, and apply jobs execute the exact local saved plan they just generated.

## Requirement UIDs

- `GEN-2004`

## Related Issues

Closes #917

## ADR Impact

- ADR-003

## Changes

- Queue branch and manual deploy runs while preserving pull request cancellation behavior.
- Generate a local saved `tfplan` inside core, range, and platform apply jobs and apply that file with `-lock-timeout=5m`.
- Run the platform Service Discovery deletion check against the same local saved plan that the apply job later executes.
- Extend ADR guard coverage, ADR registry documentation, developer docs, and changelog notes for the new deploy integrity contract.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Local validation passed: `python3 -m unittest scripts.adr_guard.tests.test_adr_guard.DeployWorkflowPlanScopeTests`; `python3 -m unittest scripts.adr_guard.tests.test_adr_guard`; `python3 scripts/adr_guard/adr_guard.py --all --level ci`; `actionlint`; `git diff --check`; `pre-commit run --all-files`.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: GEN-2004 ← .github/workflows/deploy.yml, GEN-2004 ← .github/workflows/_core.yml, GEN-2004 ← .github/workflows/_range.yml, GEN-2004 ← .github/workflows/_shifter-platform.yml, GEN-2004 ← scripts/adr_guard/adr_guard.py, GEN-2004 ← docs/adr/index.yaml
- TESTS: GEN-2004 ← scripts/adr_guard/tests/test_adr_guard.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/917.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
