### PR TITLE
Fix portal migration safety under ASG deploy

### DIFF
--- a/.github/workflows/_shifter-platform.yml
+++ b/.github/workflows/_shifter-platform.yml
@@ -509,6 +509,85 @@ jobs:
           fi
           echo "asg_name=$ASG_NAME" >> "$GITHUB_OUTPUT"
 
+      - name: Run database migrations (ASG mode)
+        if: steps.config.outputs.enable_autoscaling == 'true'
+        env:
+          ASG_NAME: ${{ steps.asg.outputs.asg_name }}
+        run: |
+          echo "Selecting one in-service ASG instance for deploy-owned migration: $ASG_NAME"
+          MIGRATION_INSTANCE_ID=$(aws autoscaling describe-auto-scaling-groups \
+            --auto-scaling-group-names "$ASG_NAME" \
+            --query "AutoScalingGroups[0].Instances[?LifecycleState=='InService' && HealthStatus=='Healthy'] | [0].InstanceId" \
+            --output text)
+
+          if [ -z "$MIGRATION_INSTANCE_ID" ] || [ "$MIGRATION_INSTANCE_ID" = "None" ]; then
+            echo "::error::No healthy in-service instance found in ASG $ASG_NAME for database migration"
+            exit 1
+          fi
+
+          echo "Running migration on instance: $MIGRATION_INSTANCE_ID"
+
+          # Wait for cloud-init to complete so Docker and the ECR credential helper are available.
+          for i in $(seq 1 30); do
+            RESULT=$(aws ssm send-command --document-name "AWS-RunShellScript" --instance-ids "$MIGRATION_INSTANCE_ID" \
+              --parameters 'commands=["cloud-init status --wait || cloud-init status"]' \
+              --query "Command.CommandId" --output text 2>/dev/null) || true
+            if [ -n "$RESULT" ]; then
+              sleep 10
+              STATUS=$(aws ssm get-command-invocation --command-id "$RESULT" --instance-id "$MIGRATION_INSTANCE_ID" \
+                --query "StandardOutputContent" --output text 2>/dev/null) || true
+              if echo "$STATUS" | grep -q "done"; then echo "Cloud-init complete"; break; fi
+            fi
+            echo "Attempt $i: Waiting for cloud-init..."; sleep 10
+          done
+
+          DEPLOY_SCRIPT_PATH="${GITHUB_WORKSPACE}/scripts/portal-deploy/deploy_portal.sh"
+          DEPLOY_SCRIPT_B64=$(base64 -w0 "$DEPLOY_SCRIPT_PATH")
+          DEPLOY_ARGS=$(jq -cn \
+            --arg awsRegion "$AWS_REGION" \
+            --arg psPrefix "$PS_PREFIX" \
+            '[
+              "--aws-region", $awsRegion,
+              "--ps-prefix", $psPrefix,
+              "--migrate-only"
+            ]')
+
+          PARAMS_FILE=$(mktemp)
+          jq -n \
+            --arg deployScriptB64 "$DEPLOY_SCRIPT_B64" \
+            --argjson deployArgs "$DEPLOY_ARGS" \
+            '{
+              commands: [
+                ("printf %s " + ($deployScriptB64 | @sh) + " | base64 -d > /tmp/shifter-deploy-portal.sh"),
+                "chmod 0755 /tmp/shifter-deploy-portal.sh",
+                ((["/tmp/shifter-deploy-portal.sh"] + $deployArgs) | @sh)
+              ]
+            }' > "$PARAMS_FILE"
+
+          COMMAND_ID=$(aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --instance-ids "$MIGRATION_INSTANCE_ID" \
+            --parameters "file://$PARAMS_FILE" \
+            --timeout-seconds 900 \
+            --query "Command.CommandId" --output text)
+
+          rm -f "$PARAMS_FILE"
+
+          echo "Migration SSM Command ID: $COMMAND_ID"
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$MIGRATION_INSTANCE_ID" \
+            --cli-read-timeout 30 \
+            --cli-connect-timeout 30
+
+          STATUS=$(aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$MIGRATION_INSTANCE_ID" --query "Status" --output text)
+          if [ "$STATUS" != "Success" ]; then
+            echo "Migration failed!"
+            aws ssm get-command-invocation --command-id "$COMMAND_ID" --instance-id "$MIGRATION_INSTANCE_ID" --query "StandardErrorContent" --output text
+            exit 1
+          fi
+          echo "Database migration completed successfully."
+
       - name: Deploy via SSM (single instance mode)
         if: steps.config.outputs.enable_autoscaling != 'true'
         env:

--- a/changelog.d/918.fixed.md
+++ b/changelog.d/918.fixed.md
@@ -1,0 +1,1 @@
+Prevent AWS portal deploys from racing Django migrations across multi-instance boot by running a single deploy-owned migration before runtime containers start with boot migrations disabled.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -672,7 +672,7 @@
     "title": "Django templates use native gettext for user-facing literals",
     "status": "accepted",
     "scope": "shifter_platform",
-    "decision": "Django-rendered user-facing template literals are routed through Django's native gettext template tags and the platform-owned English catalog. Shifter adopts the minimum i18n infrastructure needed for template analysis and future catalog growth: `LocaleMiddleware` sits between session and common middleware, `LOCALE_PATHS` points at `shifter/shifter_platform/locale`, templates use `{% trans %}` / `{% blocktrans %}`, and runtime startup compiles message catalogs before static collection. English remains the only catalog for now; URL locale prefixes, locale-switching UX, translator workflow, RTL support, and locale-aware formatting are explicitly out of scope until a separate requirement adopts them.",
+    "decision": "Django-rendered user-facing template literals are routed through Django's native gettext template tags and the platform-owned English catalog. Shifter adopts the minimum i18n infrastructure needed for template analysis and future catalog growth: `LocaleMiddleware` sits between session and common middleware, `LOCALE_PATHS` points at `shifter/shifter_platform/locale`, templates use `{% trans %}` / `{% blocktrans %}`, and portal image builds compile message catalogs before static collection so runtime container startup does not rebuild immutable artifacts. English remains the only catalog for now; URL locale prefixes, locale-switching UX, translator workflow, RTL support, and locale-aware formatting are explicitly out of scope until a separate requirement adopts them.",
     "rules": [
       {
         "id": "ADR-016-R1",
@@ -686,14 +686,15 @@
       },
       {
         "id": "ADR-016-R3",
-        "description": "Container startup compiles Django message catalogs before static collection or application startup so runtime `.mo` files are present without committing generated binaries.",
-        "checks": ["django-compilemessages-runtime"]
+        "description": "Portal image builds compile Django message catalogs before static collection so runtime `.mo` files and static assets are present without committing generated binaries or rebuilding them at container startup.",
+        "checks": ["django-compilemessages-build"]
       }
     ],
     "exceptions": [],
     "enforcement": ["tests", "sonarcloud", "agent-policy"],
     "evidence": [
       "shifter/shifter_platform/config/settings.py",
+      "shifter/shifter_platform/Dockerfile",
       "shifter/shifter_platform/entrypoint.sh",
       "shifter/shifter_platform/locale/en/LC_MESSAGES/django.po",
       "shifter/shifter_platform/tests/config/test_i18n_configuration.py",

--- a/platform/terraform/modules/portal/ec2/user_data.sh
+++ b/platform/terraform/modules/portal/ec2/user_data.sh
@@ -248,6 +248,10 @@ if [[ -n "$CTFD_PLATFORM_URL" ]]; then
   COMMON_ENV="$COMMON_ENV -e CTFD_PLATFORM_URL=$CTFD_PLATFORM_URL"
 fi
 
+# Migrations are deploy-owned. Runtime containers skip boot-time migration so
+# ASG refreshes and warm-pool reuse cannot race the same RDS schema.
+COMMON_ENV="$COMMON_ENV -e SKIP_MIGRATIONS=1"
+
 # ------------------------------------------------------------------------------
 # Deploy containers
 # ------------------------------------------------------------------------------

--- a/scripts/portal-deploy/deploy_portal.sh
+++ b/scripts/portal-deploy/deploy_portal.sh
@@ -7,6 +7,7 @@ WORKER_HEALTH_MONITOR_B64=""
 WORKER_HEALTH_SERVICE_B64=""
 WORKER_HEALTH_TIMER_B64=""
 WORKER_HEALTH_NAME_PREFIX=""
+MIGRATE_ONLY=false
 WORKER_HEALTH_BIN_PATH="/usr/local/bin/shifter-worker-health.sh"
 WORKER_HEALTH_SERVICE_PATH="/etc/systemd/system/shifter-worker-health.service"
 WORKER_HEALTH_TIMER_PATH="/etc/systemd/system/shifter-worker-health.timer"
@@ -15,10 +16,12 @@ DOCKER_ENV=()
 
 usage() {
   cat <<'EOF'
-Usage: deploy_portal.sh --ps-prefix PREFIX --worker-health-monitor-b64 B64 --worker-health-service-b64 B64 --worker-health-timer-b64 B64 --worker-health-name-prefix PREFIX [options]
+Usage: deploy_portal.sh --ps-prefix PREFIX [options]
 
 Required:
   --ps-prefix PREFIX
+
+Required unless --migrate-only is set:
   --worker-health-monitor-b64 B64
   --worker-health-service-b64 B64
   --worker-health-timer-b64 B64
@@ -26,6 +29,7 @@ Required:
 
 Options:
   --aws-region REGION
+  --migrate-only
   --worker-health-bin-path PATH
   --worker-health-service-path PATH
   --worker-health-timer-path PATH
@@ -64,6 +68,10 @@ parse_args() {
         require_value "$1" "${2:-}"
         PS_PREFIX="$2"
         shift 2
+        ;;
+      --migrate-only)
+        MIGRATE_ONLY=true
+        shift
         ;;
       --worker-health-monitor-b64)
         require_value "$1" "${2:-}"
@@ -112,10 +120,12 @@ parse_args() {
   done
 
   [[ -n "$PS_PREFIX" ]] || die_usage "--ps-prefix is required"
-  [[ -n "$WORKER_HEALTH_MONITOR_B64" ]] || die_usage "--worker-health-monitor-b64 is required"
-  [[ -n "$WORKER_HEALTH_SERVICE_B64" ]] || die_usage "--worker-health-service-b64 is required"
-  [[ -n "$WORKER_HEALTH_TIMER_B64" ]] || die_usage "--worker-health-timer-b64 is required"
-  [[ -n "$WORKER_HEALTH_NAME_PREFIX" ]] || die_usage "--worker-health-name-prefix is required"
+  if [[ "$MIGRATE_ONLY" != "true" ]]; then
+    [[ -n "$WORKER_HEALTH_MONITOR_B64" ]] || die_usage "--worker-health-monitor-b64 is required"
+    [[ -n "$WORKER_HEALTH_SERVICE_B64" ]] || die_usage "--worker-health-service-b64 is required"
+    [[ -n "$WORKER_HEALTH_TIMER_B64" ]] || die_usage "--worker-health-timer-b64 is required"
+    [[ -n "$WORKER_HEALTH_NAME_PREFIX" ]] || die_usage "--worker-health-name-prefix is required"
+  fi
 }
 
 get_param() {
@@ -173,6 +183,16 @@ install_worker_health() {
   printf 'WH_NAME_PREFIX=%s\n' "$WORKER_HEALTH_NAME_PREFIX" > "$WORKER_HEALTH_ENV_PATH"
   systemctl daemon-reload
   systemctl enable --now shifter-worker-health.timer
+}
+
+run_migrations() {
+  local image="$1"
+  shift
+  local -a common_env=("$@")
+
+  echo "Running database migrations..."
+  docker pull "$image"
+  docker run --rm "${common_env[@]}" -e SKIP_MIGRATIONS=1 "$image" python manage.py migrate --noinput
 }
 
 run_containers() {
@@ -297,6 +317,13 @@ main() {
   append_env_if_set PLATFORM_BOOTSTRAP_STAFF_EMAILS "$platform_bootstrap_staff_emails"
   append_env_if_set PLATFORM_BOOTSTRAP_SUPERUSER_EMAILS "$platform_bootstrap_superuser_emails"
 
+  run_migrations "$image" "${DOCKER_ENV[@]}"
+  if [[ "$MIGRATE_ONLY" == "true" ]]; then
+    echo "Migration complete!"
+    return
+  fi
+
+  append_env SKIP_MIGRATIONS "1"
   run_containers "$image" "${DOCKER_ENV[@]}"
   install_worker_health
   echo "Deployment complete!"

--- a/scripts/portal_deploy/tests/test_deploy_portal_script.py
+++ b/scripts/portal_deploy/tests/test_deploy_portal_script.py
@@ -194,7 +194,9 @@ class DeployPortalScriptTests(unittest.TestCase):
             env["MISSING_OPTIONAL_PARAMS"] = "1"
         return env
 
-    def _script_args(self, root: Path, *, ps_prefix: str = "/shifter/dev/portal") -> list[str]:
+    def _script_args(
+        self, root: Path, *, ps_prefix: str = "/shifter/dev/portal"
+    ) -> list[str]:
         return [
             str(SCRIPT_PATH),
             "--aws-region",
@@ -271,14 +273,20 @@ class DeployPortalScriptTests(unittest.TestCase):
             log = (root / "calls.log").read_text(encoding="utf-8")
             self.assertNotIn("docker pull", log)
 
-    def test_deploy_rewrites_worker_health_artifacts_and_tolerates_repeated_runs(self) -> None:
+    def test_deploy_rewrites_worker_health_artifacts_and_tolerates_repeated_runs(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             env = self._install_stubs(root)
             args = self._script_args(root)
 
-            first = subprocess.run(args, check=False, capture_output=True, text=True, env=env)
-            second = subprocess.run(args, check=False, capture_output=True, text=True, env=env)
+            first = subprocess.run(
+                args, check=False, capture_output=True, text=True, env=env
+            )
+            second = subprocess.run(
+                args, check=False, capture_output=True, text=True, env=env
+            )
 
             self.assertEqual(first.returncode, 0, first.stderr)
             self.assertEqual(second.returncode, 0, second.stderr)
@@ -289,23 +297,69 @@ class DeployPortalScriptTests(unittest.TestCase):
                 "monitor-v1\n",
             )
             self.assertEqual(
-                (root / "etc" / "shifter-worker-health.env").read_text(encoding="utf-8"),
+                (root / "etc" / "shifter-worker-health.env").read_text(
+                    encoding="utf-8"
+                ),
                 "WH_NAME_PREFIX=dev-portal\n",
             )
             log = (root / "calls.log").read_text(encoding="utf-8")
             self.assertEqual(log.count("docker run -d --name portal"), 2)
+            self.assertEqual(log.count("docker run --rm"), 2)
+            self.assertLess(
+                log.index("docker run --rm"),
+                log.index(
+                    "docker stop portal worker-cms worker-engine worker-mc ctf-scheduler"
+                ),
+            )
+            self.assertIn("python manage.py migrate --noinput", log)
+            self.assertIn("SKIP_MIGRATIONS=1", log)
             for name in ("worker-cms", "worker-engine", "worker-mc", "ctf-scheduler"):
                 self.assertIn(f"docker run -d --name {name}", log)
             self.assertIn("run_worker --queue cms", log)
             self.assertIn("run_worker --queue engine", log)
             self.assertIn("run_worker --queue mc", log)
             self.assertIn("python manage.py run_ctf_scheduler", log)
-            self.assertIn("docker stop portal worker-cms worker-engine worker-mc ctf-scheduler", log)
+            self.assertIn(
+                "docker stop portal worker-cms worker-engine worker-mc ctf-scheduler",
+                log,
+            )
             self.assertIn(
                 "DJANGO_ALLOWED_HOSTS=portal.dev.example.test,localhost,127.0.0.1",
                 log,
             )
             self.assertIn("systemctl enable --now shifter-worker-health.timer", log)
+
+    def test_migrate_only_runs_single_migration_without_runtime_restart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            env = self._install_stubs(root)
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_PATH),
+                    "--aws-region",
+                    "us-east-2",
+                    "--ps-prefix",
+                    "/shifter/dev/portal",
+                    "--migrate-only",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            log = (root / "calls.log").read_text(encoding="utf-8")
+            self.assertIn(
+                "docker pull 123456789012.dkr.ecr.us-east-2.amazonaws.com/shifter-dev-portal:abc123",
+                log,
+            )
+            self.assertIn("docker run --rm", log)
+            self.assertIn("SKIP_MIGRATIONS=1", log)
+            self.assertIn("python manage.py migrate --noinput", log)
+            self.assertNotIn("docker run -d --name portal", log)
+            self.assertNotIn("systemctl", log)
 
     def test_missing_optional_params_are_not_emitted_as_empty_env_vars(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -351,7 +405,9 @@ class DeployPortalScriptTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             log = (root / "calls.log").read_text(encoding="utf-8")
-            self.assertRegex(log, r"DJANGO_ALLOWED_HOSTS=portal\.dev\.example\.test(?!,)")
+            self.assertRegex(
+                log, r"DJANGO_ALLOWED_HOSTS=portal\.dev\.example\.test(?!,)"
+            )
             self.assertNotIn(
                 "DJANGO_ALLOWED_HOSTS=portal.dev.example.test,localhost,127.0.0.1",
                 log,

--- a/shifter/shifter_platform/Dockerfile
+++ b/shifter/shifter_platform/Dockerfile
@@ -97,6 +97,26 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Switch to non-root user
 USER appuser
 
+# Build immutable Django runtime artifacts once per image. These commands use
+# build-only settings env; runtime secrets are still hydrated by
+# entrypoint.sh when the container starts.
+RUN BUILD_DJANGO_SECRET_KEY="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')" && \
+    BUILD_FIELD_ENCRYPTION_KEY="$( \
+      python -c 'import cryptography.fernet as f; print(f.Fernet.generate_key().decode())' \
+    )" && \
+    DJANGO_SECRET_KEY="$BUILD_DJANGO_SECRET_KEY" \
+    FIELD_ENCRYPTION_KEY="$BUILD_FIELD_ENCRYPTION_KEY" \
+    OIDC_RP_CLIENT_ID=build-time-client \
+    OIDC_AUTH_DOMAIN=https://auth.example.test \
+    OIDC_ISSUER_URL=https://issuer.example.test \
+    python manage.py compilemessages && \
+    DJANGO_SECRET_KEY="$BUILD_DJANGO_SECRET_KEY" \
+    FIELD_ENCRYPTION_KEY="$BUILD_FIELD_ENCRYPTION_KEY" \
+    OIDC_RP_CLIENT_ID=build-time-client \
+    OIDC_AUTH_DOMAIN=https://auth.example.test \
+    OIDC_ISSUER_URL=https://issuer.example.test \
+    python manage.py collectstatic --noinput
+
 # Health check using Python (curl not available in slim image)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health/')" || exit 1

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -96,6 +96,14 @@ The first slice intentionally stays small:
   This includes the GCP deploy workflow's Terraform state-backend hardening
   (`_gcp-dev.yml`) so retention and IAM policy bootstrap logic remains valid.
 
+- Django i18n/static artifact tests
+  Enforce ADR-016-R3 in
+  `shifter/shifter_platform/tests/config/test_i18n_configuration.py` and
+  `shifter/shifter_platform/tests/platform/test_portal_dockerfile.py` by
+  requiring portal image builds to run `compilemessages` before
+  `collectstatic`, and requiring `entrypoint.sh` to stay free of runtime
+  static-artifact rebuilds.
+
 - `deploy-workflow-plan-scope`
   Enforces ADR-003-R2 for the AWS deploy workflows. The `shifter_platform`
   change filter in `.github/workflows/deploy.yml` must stay scoped to

--- a/shifter/shifter_platform/entrypoint.sh
+++ b/shifter/shifter_platform/entrypoint.sh
@@ -161,13 +161,6 @@ else
     echo "Skipping migrations (SKIP_MIGRATIONS is set)"
 fi
 
-# Collect static files
-echo "Compiling message catalogs..."
-python manage.py compilemessages
-
-echo "Collecting static files..."
-python manage.py collectstatic --noinput
-
 # Run command passed as arguments, or default to gunicorn + uvicorn workers.
 #
 # The production portal web process runs Gunicorn managing a pool of Uvicorn

--- a/shifter/shifter_platform/tests/config/test_i18n_configuration.py
+++ b/shifter/shifter_platform/tests/config/test_i18n_configuration.py
@@ -1,4 +1,4 @@
-"""Tests for the minimum Django i18n runtime contract."""
+"""Tests for the minimum Django i18n contract."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from django.conf import settings
 PLATFORM_ROOT = Path(__file__).resolve().parents[2]
 REPO_ROOT = PLATFORM_ROOT.parents[1]
 ENTRYPOINT = PLATFORM_ROOT / "entrypoint.sh"
+DOCKERFILE = PLATFORM_ROOT / "Dockerfile"
 TEMPLATE_ROOTS = (
     PLATFORM_ROOT / "templates",
     PLATFORM_ROOT / "cms" / "experiments" / "templates",
@@ -29,13 +30,20 @@ def test_locale_paths_uses_platform_locale_directory():
     assert settings.LOCALE_PATHS == [PLATFORM_ROOT / "locale"]
 
 
-def test_entrypoint_compiles_messages_before_collectstatic():
-    entrypoint = ENTRYPOINT.read_text()
+def test_image_build_compiles_messages_before_collectstatic():
+    dockerfile = DOCKERFILE.read_text()
 
-    compile_index = entrypoint.index("python manage.py compilemessages")
-    collectstatic_index = entrypoint.index("python manage.py collectstatic --noinput")
+    compile_index = dockerfile.index("python manage.py compilemessages")
+    collectstatic_index = dockerfile.index("python manage.py collectstatic --noinput")
 
     assert compile_index < collectstatic_index
+
+
+def test_entrypoint_does_not_build_static_artifacts_at_runtime():
+    entrypoint = ENTRYPOINT.read_text()
+
+    assert "python manage.py compilemessages" not in entrypoint
+    assert "python manage.py collectstatic --noinput" not in entrypoint
 
 
 def test_user_facing_templates_use_translation_tags():

--- a/shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py
+++ b/shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py
@@ -99,6 +99,31 @@ def test_aws_workflow_invokes_tracked_single_instance_deploy_script() -> None:
     assert "--worker-health-name-prefix" in workflow_text
 
 
+def test_aws_workflow_runs_one_asg_migration_before_instance_refresh() -> None:
+    workflow_text = AWS_WORKFLOW.read_text(encoding="utf-8")
+
+    migration_index = workflow_text.index("Run database migrations (ASG mode)")
+    refresh_index = workflow_text.index("aws autoscaling start-instance-refresh")
+
+    assert migration_index < refresh_index
+    assert "Instances[?LifecycleState=='InService' && HealthStatus=='Healthy'] | [0].InstanceId" in workflow_text
+    assert "--migrate-only" in workflow_text
+    assert "Migration failed!" in workflow_text
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_runtime_skip"),
+    [
+        (AWS_USER_DATA, 'COMMON_ENV="$COMMON_ENV -e SKIP_MIGRATIONS=1"'),
+        (AWS_REDEPLOY_SCRIPT, 'append_env SKIP_MIGRATIONS "1"'),
+    ],
+)
+def test_aws_runtime_containers_skip_boot_migrations(path: Path, expected_runtime_skip: str) -> None:
+    deployment_text = path.read_text(encoding="utf-8")
+
+    assert expected_runtime_skip in deployment_text
+
+
 @pytest.mark.parametrize(
     ("source_name", "loader"),
     [

--- a/shifter/shifter_platform/tests/platform/test_portal_dockerfile.py
+++ b/shifter/shifter_platform/tests/platform/test_portal_dockerfile.py
@@ -16,3 +16,20 @@ def test_portal_image_creates_owned_appuser_home() -> None:
     assert "/home/appuser/.terraform.d/plugin-cache" in dockerfile
     assert "/home/appuser/.pulumi" in dockerfile
     assert "chown -R appuser:appgroup /app/staticfiles /app/media /home/appuser" in dockerfile
+
+
+def test_portal_image_builds_django_artifacts_as_appuser() -> None:
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    user_index = dockerfile.index("USER appuser")
+    compile_index = dockerfile.index("python manage.py compilemessages")
+    collect_index = dockerfile.index("python manage.py collectstatic --noinput")
+    healthcheck_index = dockerfile.index("HEALTHCHECK")
+
+    assert user_index < compile_index < collect_index < healthcheck_index
+    assert "BUILD_DJANGO_SECRET_KEY=" in dockerfile
+    assert "BUILD_FIELD_ENCRYPTION_KEY=" in dockerfile
+    assert 'DJANGO_SECRET_KEY="$BUILD_DJANGO_SECRET_KEY"' in dockerfile
+    assert 'FIELD_ENCRYPTION_KEY="$BUILD_FIELD_ENCRYPTION_KEY"' in dockerfile
+    assert "OIDC_RP_CLIENT_ID=build-time-client" in dockerfile
+    assert "DJANGO_DEBUG=True" not in dockerfile


### PR DESCRIPTION
## Summary

Run portal database migrations once per deploy, before runtime containers start, and build Django static/message artifacts into the portal image.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #918

## ADR Impact

- ADR-016

## Changes

- Add a deploy-script migration-only mode and run it before single-instance restarts.
- Run a single ASG migration over SSM before instance refresh and set SKIP_MIGRATIONS on AWS runtime containers.
- Move Django compilemessages and collectstatic from entrypoint boot into the portal image build, with ADR-016/test coverage updates.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

pre-commit run --all-files; uv run --project shifter/shifter_platform pytest scripts/portal_deploy/tests/test_deploy_portal_script.py shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py shifter/shifter_platform/tests/platform/test_portal_dockerfile.py shifter/shifter_platform/tests/config/test_i18n_configuration.py; python3 scripts/adr_guard/adr_guard.py --all --level ci; actionlint; cd shifter/shifter_platform && uv run lint-imports --config ../../.importlinter; cd shifter/shifter_platform && uv run ruff check .; cd shifter/shifter_platform && uv run ruff format --check .; TFLINT_CONFIG=$(pwd)/.tflint.hcl && cd platform/terraform && tflint --recursive --config "$TFLINT_CONFIG"; git diff --check --cached.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: scripts/portal_deploy/tests/test_deploy_portal_script.py, shifter/shifter_platform/tests/platform/test_ctf_scheduler_startup.py, shifter/shifter_platform/tests/platform/test_portal_dockerfile.py, shifter/shifter_platform/tests/config/test_i18n_configuration.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/918.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.
