### PR TITLE
security: harden rds auth and ca settings

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -114,6 +114,16 @@ jobs:
           python3 scripts/check_tf_iam_elb_scope/check_tf_iam_elb_scope.py \
             platform/terraform/modules/engine-provisioner/iam.tf
 
+      # ADR-004-R12 / issue #140: first-party RDS instances must keep
+      # IAM DB auth enabled and explicitly pin a CA identifier. Checkov
+      # enforces IAM auth, but CKV_AWS_211 currently passes when the CA
+      # attribute is absent, so this repo-native guard closes that gap.
+      - name: Run check-tf-rds-security
+        run: |
+          python3 scripts/check_tf_rds_security/check_tf_rds_security.py \
+            platform/terraform/modules/portal/rds/main.tf \
+            platform/terraform/modules/guacamole/rds.tf
+
       # Pin the behavior of the check_tf_* IAM/security checkers
       # themselves. The live-file invocations above only exercise the
       # happy-path shape; the test suites cover wildcards, list
@@ -130,6 +140,7 @@ jobs:
           python3 -m unittest scripts.check_tf_iam_elb_scope.test_check_tf_iam_elb_scope
           python3 -m unittest scripts.check_tf_sg_cidrs.test_check_tf_sg_cidrs
           python3 -m unittest scripts.check_tf_kms_secrets_grant.test_check_tf_kms_secrets_grant
+          python3 -m unittest scripts.check_tf_rds_security.test_check_tf_rds_security
 
   # Pin the behavior of the Polaris CTFd workshop sync helpers. Issue #702
   # shipped 38/39 challenges unsubmittable because flag-row reconciliation

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,6 +130,7 @@ jobs:
               - 'scripts/check_tf_iam_elb_scope/**'
               - 'scripts/check_tf_sg_cidrs/**'
               - 'scripts/check_tf_kms_secrets_grant/**'
+              - 'scripts/check_tf_rds_security/**'
               # Guardrail / ADR-registry surfaces. A change to any of
               # these must re-run Quality so adr_guard catches a broken
               # registry, malformed exception entry, or pre-commit hook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -218,7 +218,21 @@ repos:
         files: ^(platform/terraform/modules/engine-provisioner/iam\.tf|platform/terraform/modules/portal/ec2/main\.tf|platform/terraform/modules/guacamole/iam\.tf)$
         pass_filenames: false
 
-      # Pin the behavior of the three custom check_tf_* IAM/security
+      # Custom: RDS instance IAM auth and explicit CA certificate check.
+      # Checkov enforces IAM DB auth, but its current modern-CA rule
+      # passes when ca_cert_identifier is absent; this checker closes
+      # that gap for the two first-party RDS resources.
+      - id: check-tf-rds-security
+        name: RDS IAM auth and CA certificate (portal + Guacamole)
+        entry: >-
+          python3 scripts/check_tf_rds_security/check_tf_rds_security.py
+          platform/terraform/modules/portal/rds/main.tf
+          platform/terraform/modules/guacamole/rds.tf
+        language: system
+        files: ^(platform/terraform/modules/portal/rds/main\.tf|platform/terraform/modules/guacamole/rds\.tf)$
+        pass_filenames: false
+
+      # Pin the behavior of the custom check_tf_* IAM/security
       # checkers themselves. Their test suites (synthetic HCL fixtures
       # covering wildcards, list resources, scoped conditions, missing
       # grants, etc.) only exercise edge cases that the live-file
@@ -239,10 +253,11 @@ repos:
           python3 -m unittest scripts.check_tf_iam_ec2_scope.test_check_tf_iam_ec2_scope &&
           python3 -m unittest scripts.check_tf_iam_elb_scope.test_check_tf_iam_elb_scope &&
           python3 -m unittest scripts.check_tf_sg_cidrs.test_check_tf_sg_cidrs &&
-          python3 -m unittest scripts.check_tf_kms_secrets_grant.test_check_tf_kms_secrets_grant
+          python3 -m unittest scripts.check_tf_kms_secrets_grant.test_check_tf_kms_secrets_grant &&
+          python3 -m unittest scripts.check_tf_rds_security.test_check_tf_rds_security
           '
         language: system
-        files: ^scripts/check_tf_(iam_ec2_scope|iam_elb_scope|sg_cidrs|kms_secrets_grant)/
+        files: ^scripts/check_tf_(iam_ec2_scope|iam_elb_scope|sg_cidrs|kms_secrets_grant|rds_security)/
         pass_filenames: false
 
   # Kubernetes schema validation

--- a/changelog.d/140.security.md
+++ b/changelog.d/140.security.md
@@ -1,0 +1,1 @@
+Portal and Guacamole RDS instances now explicitly pin the AWS RDS CA certificate and keep IAM database authentication enabled, with a repo-native Terraform guardrail preventing either setting from regressing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,9 @@ Current mechanisms:
   - `check-tf-iam-ec2-scope`: local Terraform IAM hardening check that
     keeps engine-provisioner EC2 instance lifecycle actions scoped to
     Shifter-owned, Terraform-managed instances.
+  - `check-tf-rds-security`: local Terraform RDS hardening check that
+    keeps the portal and Guacamole RDS instances on IAM DB auth and an
+    explicit CA certificate identifier.
 - `.github/workflows/_quality.yml`: CI architecture gate. Its SonarCloud
   job restores coverage artifacts, sets up Temurin Java 21, and disables
   SonarScanner JRE auto-provisioning so the quality gate does not depend
@@ -75,6 +78,10 @@ Current mechanisms:
   soft-fail while manifest hardening proceeds as a separate workstream.
   Accepted-risk waivers MUST have an entry in `docs/adr/exceptions.yaml`
   with owner, reason, expiry, affected paths, and the Checkov policy ID.
+- `scripts/check_tf_rds_security/check_tf_rds_security.py`: ADR-004-R12
+  RDS hardening check for the two first-party AWS RDS instances. It
+  requires literal IAM DB auth enablement and an explicit non-empty CA
+  certificate identifier, complementing Checkov's RDS policies.
 - `scripts/adr_guard/adr_guard.py` `mcp-no-shell-exec` check:
   flags any file under `mcp/` (`.js`, `.mjs`, `.cjs`) that imports
   `child_process` (any shape — named, default, namespace, CommonJS

--- a/docs/adr/exceptions.yaml
+++ b/docs/adr/exceptions.yaml
@@ -153,7 +153,7 @@
   {
     "rule_id": "ADR-004-R11",
     "owner": "@Brad-Edwards",
-    "reason": "CKV_AWS_157 (RDS Multi-AZ): controlled by var.db_multi_az / var.multi_az and set per-environment (dev false / prod true). The default is false in the module so Checkov sees the bare declaration as non-Multi-AZ; environments override.",
+    "reason": "CKV_AWS_157 (RDS Multi-AZ): controlled by var.db_multi_az / var.multi_az and set per-environment (dev false / prod true). The default is false in the module so Checkov sees the bare declaration as non-Multi-AZ; environments override. RDS IAM authentication is enabled separately and is no longer waived.",
     "expires_on": "2027-05-26",
     "paths": [
       "platform/terraform/modules/portal/rds/main.tf",

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -148,6 +148,11 @@
         "id": "ADR-004-R11",
         "description": "Checkov is a blocking gate for first-party Terraform under `platform/terraform/`. The pre-commit hook (`.pre-commit-config.yaml` `checkov`) and the GitHub Actions security-iac job (`.github/workflows/_quality.yml`) both consume the same canonical config at `platform/terraform/.checkov.yaml`; `--soft-fail` is not set on either surface. Accepted-risk waivers (Checkov `skip-check` entries in `.checkov.yaml` or inline `# checkov:skip=CKV_X:...` comments on individual resources) MUST have a matching entry in `docs/adr/exceptions.yaml` with `rule_id: ADR-004-R11`, owner, reason (containing the Checkov policy ID), `expires_on`, and the affected `paths`. `adr_guard.py` rejects expired exceptions, forcing owner re-review. Terraform Checkov policy and Kubernetes Checkov policy are separate surfaces: the `security-k8s` job intentionally remains `soft_fail: true` while manifest hardening proceeds under a separate issue, and Kubernetes soft-fail debt does NOT justify Terraform soft-fail. If rule-level policy grows beyond a flat skip list, centralize it in `platform/terraform/.checkov.yaml` only — do NOT duplicate skip semantics across pre-commit args and workflow inputs.",
         "checks": []
+      },
+      {
+        "id": "ADR-004-R12",
+        "description": "First-party AWS RDS DB instances under `platform/terraform/modules/portal/rds/main.tf` and `platform/terraform/modules/guacamole/rds.tf` MUST keep `iam_database_authentication_enabled = true` and MUST explicitly set `ca_cert_identifier` to a non-empty expression. Checkov covers IAM authentication through CKV_AWS_161, but CKV_AWS_211 currently passes when the CA attribute is absent; the repo-native `scripts/check_tf_rds_security/check_tf_rds_security.py` checker closes that gap. The checker is wired as the `check-tf-rds-security` pre-commit hook and a CI step in `.github/workflows/_quality.yml`, and its unittest suite is included in the `check_tf_*` checker tests.",
+        "checks": []
       }
     ],
     "exceptions": [],
@@ -161,6 +166,7 @@
       ".github/workflows/_quality.yml",
       "scripts/adr_guard/adr_guard.py",
       "scripts/check_tf_kms_secrets_grant/check_tf_kms_secrets_grant.py",
+      "scripts/check_tf_rds_security/check_tf_rds_security.py",
       "platform/terraform/.checkov.yaml",
       "docs/adr/exceptions.yaml",
       "docs/architecture/checkov-soft-fail-preflight-757.md",

--- a/platform/terraform/.checkov.yaml
+++ b/platform/terraform/.checkov.yaml
@@ -87,8 +87,6 @@ skip-check:
   - CKV_AWS_157
   # CKV_AWS_293 — RDS deletion protection controlled by var.deletion_protection.
   - CKV_AWS_293
-  # CKV_AWS_161 — Guacamole RDS uses password auth (JDBC contract).
-  - CKV_AWS_161
 
   # ── Container networking ────────────────────────────────────────────────────
   # CKV_AWS_341 — Launch template hop_limit=2 required for bridged containers.

--- a/platform/terraform/environments/dev/portal/main.tf
+++ b/platform/terraform/environments/dev/portal/main.tf
@@ -256,6 +256,7 @@ module "rds" {
   db_name               = var.db_name
   db_username           = var.db_username
   engine_version        = var.db_engine_version
+  ca_cert_identifier    = var.db_ca_cert_identifier
   instance_class        = var.db_instance_class
   allocated_storage     = var.db_allocated_storage
   max_allocated_storage = var.db_max_allocated_storage
@@ -807,6 +808,7 @@ module "guacamole" {
   db_allocated_storage     = var.guacamole_db_allocated_storage
   db_max_allocated_storage = var.guacamole_db_max_allocated_storage
   db_engine_version        = var.guacamole_db_engine_version
+  db_ca_cert_identifier    = var.guacamole_db_ca_cert_identifier
   db_multi_az              = var.guacamole_db_multi_az
   db_backup_retention_days = var.guacamole_db_backup_retention_days
   db_deletion_protection   = var.guacamole_db_deletion_protection

--- a/platform/terraform/environments/dev/portal/variables.tf
+++ b/platform/terraform/environments/dev/portal/variables.tf
@@ -62,6 +62,12 @@ variable "db_engine_version" {
   type        = string
 }
 
+variable "db_ca_cert_identifier" {
+  description = "RDS CA certificate identifier for portal and provisioner database TLS."
+  type        = string
+  default     = "rds-ca-rsa2048-g1"
+}
+
 variable "db_instance_class" {
   description = "RDS instance class"
   type        = string
@@ -479,6 +485,12 @@ variable "guacamole_db_max_allocated_storage" {
 variable "guacamole_db_engine_version" {
   description = "PostgreSQL engine version for Guacamole"
   type        = string
+}
+
+variable "guacamole_db_ca_cert_identifier" {
+  description = "RDS CA certificate identifier for Guacamole database TLS."
+  type        = string
+  default     = "rds-ca-rsa2048-g1"
 }
 
 variable "guacamole_db_multi_az" {

--- a/platform/terraform/environments/prod/portal/main.tf
+++ b/platform/terraform/environments/prod/portal/main.tf
@@ -256,6 +256,7 @@ module "rds" {
   db_name               = var.db_name
   db_username           = var.db_username
   engine_version        = var.db_engine_version
+  ca_cert_identifier    = var.db_ca_cert_identifier
   instance_class        = var.db_instance_class
   allocated_storage     = var.db_allocated_storage
   max_allocated_storage = var.db_max_allocated_storage
@@ -772,6 +773,7 @@ module "guacamole" {
   db_allocated_storage     = var.guacamole_db_allocated_storage
   db_max_allocated_storage = var.guacamole_db_max_allocated_storage
   db_engine_version        = var.guacamole_db_engine_version
+  db_ca_cert_identifier    = var.guacamole_db_ca_cert_identifier
   db_multi_az              = var.guacamole_db_multi_az
   db_backup_retention_days = var.guacamole_db_backup_retention_days
   db_deletion_protection   = var.guacamole_db_deletion_protection

--- a/platform/terraform/environments/prod/portal/variables.tf
+++ b/platform/terraform/environments/prod/portal/variables.tf
@@ -62,6 +62,12 @@ variable "db_engine_version" {
   type        = string
 }
 
+variable "db_ca_cert_identifier" {
+  description = "RDS CA certificate identifier for portal and provisioner database TLS."
+  type        = string
+  default     = "rds-ca-rsa2048-g1"
+}
+
 variable "db_instance_class" {
   description = "RDS instance class"
   type        = string
@@ -391,6 +397,12 @@ variable "guacamole_db_max_allocated_storage" {
 variable "guacamole_db_engine_version" {
   description = "PostgreSQL engine version for Guacamole"
   type        = string
+}
+
+variable "guacamole_db_ca_cert_identifier" {
+  description = "RDS CA certificate identifier for Guacamole database TLS."
+  type        = string
+  default     = "rds-ca-rsa2048-g1"
 }
 
 variable "guacamole_db_multi_az" {

--- a/platform/terraform/modules/guacamole/rds.tf
+++ b/platform/terraform/modules/guacamole/rds.tf
@@ -87,7 +87,7 @@ resource "aws_secretsmanager_secret_version" "json_auth" {
 # ------------------------------------------------------------------------------
 
 resource "aws_db_instance" "guacamole" {
-  # checkov:skip=CKV_AWS_157:Guacamole uses password auth — IAM DB auth would require rewriting the Guacamole JDBC connector. See ADR-004-R11 exception.
+  # checkov:skip=CKV_AWS_157:Multi-AZ controlled by var.db_multi_az; environments choose.
   # checkov:skip=CKV_AWS_293:Deletion protection controlled by var.db_deletion_protection (dev false / prod true).
   identifier = "${var.name_prefix}-guacamole-db"
 
@@ -96,6 +96,7 @@ resource "aws_db_instance" "guacamole" {
   engine_version       = var.db_engine_version
   instance_class       = var.db_instance_class
   parameter_group_name = aws_db_parameter_group.guacamole.name
+  ca_cert_identifier   = var.db_ca_cert_identifier
 
   # Storage
   allocated_storage     = var.db_allocated_storage
@@ -133,6 +134,10 @@ resource "aws_db_instance" "guacamole" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 7
   performance_insights_kms_key_id       = aws_kms_key.rds.arn
+
+  # IAM Database Authentication can be enabled without changing the
+  # Guacamole JDBC/password runtime path.
+  iam_database_authentication_enabled = true
 
   # CloudWatch Log Exports
   enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]

--- a/platform/terraform/modules/guacamole/variables.tf
+++ b/platform/terraform/modules/guacamole/variables.tf
@@ -159,6 +159,16 @@ variable "db_engine_version" {
   type        = string
 }
 
+variable "db_ca_cert_identifier" {
+  description = "RDS CA certificate identifier for the Guacamole DB server certificate."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.db_ca_cert_identifier)) > 0
+    error_message = "db_ca_cert_identifier must be a non-empty RDS CA certificate identifier."
+  }
+}
+
 variable "db_multi_az" {
   description = "Enable Multi-AZ deployment for RDS"
   type        = bool

--- a/platform/terraform/modules/portal/rds/main.tf
+++ b/platform/terraform/modules/portal/rds/main.tf
@@ -117,6 +117,7 @@ resource "aws_db_instance" "this" {
   engine_version       = var.engine_version
   instance_class       = var.instance_class
   parameter_group_name = aws_db_parameter_group.this.name
+  ca_cert_identifier   = var.ca_cert_identifier
 
   # Storage
   allocated_storage     = var.allocated_storage

--- a/platform/terraform/modules/portal/rds/variables.tf
+++ b/platform/terraform/modules/portal/rds/variables.tf
@@ -42,6 +42,16 @@ variable "engine_version" {
   type        = string
 }
 
+variable "ca_cert_identifier" {
+  description = "RDS CA certificate identifier for the DB server certificate."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.ca_cert_identifier)) > 0
+    error_message = "ca_cert_identifier must be a non-empty RDS CA certificate identifier."
+  }
+}
+
 variable "instance_class" {
   description = "RDS instance class"
   type        = string

--- a/scripts/check_tf_rds_security/check_tf_rds_security.py
+++ b/scripts/check_tf_rds_security/check_tf_rds_security.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Lint RDS instance IAM auth and CA certificate settings in Terraform.
+
+This complements Checkov for the two first-party RDS instances under
+`platform/terraform`: Checkov enforces IAM database authentication, while
+its current modern-CA check passes when `ca_cert_identifier` is absent.
+
+Rules enforced for every `aws_db_instance` resource in the supplied files:
+
+    - `iam_database_authentication_enabled` must be the literal `true`.
+    - `ca_cert_identifier` must be explicitly set to a non-empty,
+      non-null expression.
+
+Usage:
+
+    python3 scripts/check_tf_rds_security/check_tf_rds_security.py FILE.tf [FILE.tf ...]
+
+Exit code 0 if every file passes, 1 if any RDS instance violates a rule.
+Designed to run from pre-commit and CI against the portal and Guacamole
+RDS module files.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_DB_INSTANCE_RE = re.compile(r'^\s*resource\s+"aws_db_instance"\s+"([^"]+)"\s*\{')
+_ASSIGNMENT_RE = re.compile(r"^\s*(?P<key>[A-Za-z0-9_]+)\s*=\s*(?P<value>.+?)\s*$")
+
+
+@dataclass
+class Violation:
+    file: Path
+    line: int
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}: {self.reason}"
+
+
+@dataclass
+class _ResourceBlock:
+    name: str
+    start_line: int
+    text: str
+
+
+def _brace_delta(line: str) -> int:
+    return line.count("{") - line.count("}")
+
+
+def _strip_inline_comment(value: str) -> str:
+    """Remove simple Terraform inline comments from an assignment value."""
+    for marker in (" #", " //"):
+        index = value.find(marker)
+        if index != -1:
+            value = value[:index]
+    return value.strip()
+
+
+def _extract_db_instance_blocks(path: Path) -> list[_ResourceBlock]:
+    lines = path.read_text().splitlines()
+    blocks: list[_ResourceBlock] = []
+    idx = 0
+
+    while idx < len(lines):
+        match = _DB_INSTANCE_RE.match(lines[idx])
+        if not match:
+            idx += 1
+            continue
+
+        name = match.group(1)
+        start_line = idx + 1
+        depth = _brace_delta(lines[idx])
+        block_lines = [lines[idx]]
+        idx += 1
+        while idx < len(lines) and depth > 0:
+            depth += _brace_delta(lines[idx])
+            block_lines.append(lines[idx])
+            idx += 1
+        blocks.append(_ResourceBlock(name, start_line, "\n".join(block_lines)))
+
+    return blocks
+
+
+def _top_level_assignments(block: _ResourceBlock) -> dict[str, tuple[int, str]]:
+    assignments: dict[str, tuple[int, str]] = {}
+    depth = 0
+
+    for offset, raw in enumerate(block.text.splitlines(), start=0):
+        if offset == 0:
+            depth += _brace_delta(raw)
+            continue
+
+        if depth == 1:
+            match = _ASSIGNMENT_RE.match(raw)
+            if match:
+                assignments[match.group("key")] = (
+                    block.start_line + offset,
+                    _strip_inline_comment(match.group("value")),
+                )
+
+        depth += _brace_delta(raw)
+
+    return assignments
+
+
+def _check_block(path: Path, block: _ResourceBlock) -> list[Violation]:
+    assignments = _top_level_assignments(block)
+    violations: list[Violation] = []
+
+    iam_auth = assignments.get("iam_database_authentication_enabled")
+    if iam_auth is None:
+        violations.append(
+            Violation(
+                path,
+                block.start_line,
+                "missing iam_database_authentication_enabled = true",
+            )
+        )
+    elif iam_auth[1] != "true":
+        violations.append(
+            Violation(
+                path,
+                iam_auth[0],
+                "iam_database_authentication_enabled must be literal true",
+            )
+        )
+
+    ca_cert = assignments.get("ca_cert_identifier")
+    if ca_cert is None:
+        violations.append(Violation(path, block.start_line, "missing ca_cert_identifier"))
+    elif ca_cert[1] in {'""', "null"}:
+        violations.append(
+            Violation(path, ca_cert[0], "ca_cert_identifier must not be empty or null")
+        )
+
+    return violations
+
+
+def check_file(path: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for block in _extract_db_instance_blocks(path):
+        violations.extend(_check_block(path, block))
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(
+            "usage: check_tf_rds_security.py FILE.tf [FILE.tf ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    all_violations: list[Violation] = []
+    for arg in argv[1:]:
+        path = Path(arg)
+        if not path.exists():
+            print(f"{path}: file not found", file=sys.stderr)
+            return 2
+        if path.suffix != ".tf":
+            continue
+        all_violations.extend(check_file(path))
+
+    if all_violations:
+        print(
+            "RDS instance security violations "
+            f"({len(all_violations)} total):",
+            file=sys.stderr,
+        )
+        for violation in all_violations:
+            print(f"  {violation}", file=sys.stderr)
+        print(
+            "\nFix: set iam_database_authentication_enabled = true and "
+            "ca_cert_identifier to an explicit non-empty CA identifier "
+            "expression on every aws_db_instance.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check_tf_rds_security/test_check_tf_rds_security.py
+++ b/scripts/check_tf_rds_security/test_check_tf_rds_security.py
@@ -1,0 +1,141 @@
+"""Tests for check_tf_rds_security.py.
+
+Run from the repo root:
+    python3 -m unittest scripts.check_tf_rds_security.test_check_tf_rds_security -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from .check_tf_rds_security import check_file
+
+
+def _write(tmp_path: Path, body: str, name: str = "rds.tf") -> Path:
+    path = tmp_path / name
+    path.write_text(textwrap.dedent(body).lstrip())
+    return path
+
+
+class CheckTfRdsSecurityTest(unittest.TestCase):
+    def test_rds_instance_without_iam_auth_or_ca_identifier_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_db_instance" "db" {
+                  identifier = "example"
+                  engine     = "postgres"
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertIn("missing iam_database_authentication_enabled = true", reasons)
+        self.assertIn("missing ca_cert_identifier", reasons)
+
+    def test_rds_instance_with_disabled_iam_auth_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_db_instance" "db" {
+                  identifier                              = "example"
+                  iam_database_authentication_enabled     = false
+                  ca_cert_identifier                      = var.rds_ca_cert_identifier
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertIn(
+            "iam_database_authentication_enabled must be literal true",
+            reasons,
+        )
+
+    def test_rds_instance_with_variable_iam_auth_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_db_instance" "db" {
+                  identifier                          = "example"
+                  iam_database_authentication_enabled = var.rds_iam_auth
+                  ca_cert_identifier                  = var.rds_ca_cert_identifier
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertIn(
+            "iam_database_authentication_enabled must be literal true",
+            reasons,
+        )
+
+    def test_rds_instance_with_empty_ca_identifier_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_db_instance" "db" {
+                  identifier                          = "example"
+                  iam_database_authentication_enabled = true
+                  ca_cert_identifier                  = ""
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertIn("ca_cert_identifier must not be empty or null", reasons)
+
+    def test_rds_instance_with_null_ca_identifier_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_db_instance" "db" {
+                  identifier                          = "example"
+                  iam_database_authentication_enabled = true
+                  ca_cert_identifier                  = null
+                }
+                """,
+            )
+
+            reasons = [violation.reason for violation in check_file(tf)]
+
+        self.assertIn("ca_cert_identifier must not be empty or null", reasons)
+
+    def test_rds_instance_with_iam_auth_and_ca_identifier_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_db_instance" "db" {
+                  identifier                          = "example"
+                  iam_database_authentication_enabled = true
+                  ca_cert_identifier                  = var.rds_ca_cert_identifier
+                }
+                """,
+            )
+
+            self.assertEqual(check_file(tf), [])
+
+    def test_non_rds_resources_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tf = _write(
+                Path(tmp),
+                """
+                resource "aws_db_parameter_group" "db" {
+                  name = "example"
+                }
+                """,
+            )
+
+            self.assertEqual(check_file(tf), [])


### PR DESCRIPTION
## Summary

Harden the AWS portal and Guacamole RDS instances by enabling IAM database authentication where missing, explicitly pinning the RDS CA certificate, and adding a repo-native guardrail that prevents either setting from regressing.

## Requirement UIDs

- `PLAT-2006`

## Related Issues

Closes #140

## ADR Impact

- ADR-004

## Changes

- Set `ca_cert_identifier` on the portal and Guacamole `aws_db_instance` resources through environment-overridable module inputs.
- Enable IAM database authentication on the Guacamole RDS instance while preserving its existing JDBC/password runtime path.
- Add `scripts/check_tf_rds_security` plus pre-commit and CI wiring to enforce literal IAM DB auth and explicit non-empty CA identifiers on first-party RDS resources.
- Remove the stale `CKV_AWS_161` Checkov waiver and update ADR-004 documentation/registry for the new guardrail.

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Ran full pre-commit, full Terraform Checkov, CI-level ADR guard, actionlint, TFLint with absolute config, Terraform validate for dev/prod portal roots, targeted RDS checker tests, and targeted Checkov for CKV_AWS_161/CKV_AWS_211. Codex review cycle 1 was clean. Test-quality cycle 1 found two checker-test coverage gaps; both were fixed and locally verified. User directed proceeding without an over-cap test-quality rerun.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: PLAT-2006 ← platform/terraform/modules/portal/rds/main.tf, PLAT-2006 ← platform/terraform/modules/guacamole/rds.tf, PLAT-2006 ← scripts/check_tf_rds_security/check_tf_rds_security.py, PLAT-2006 ← .pre-commit-config.yaml, PLAT-2006 ← .github/workflows/_quality.yml
- TESTS: PLAT-2006 ← scripts/check_tf_rds_security/test_check_tf_rds_security.py, PLAT-2006 ← pre-commit run --all-files, PLAT-2006 ← uvx checkov --config-file platform/terraform/.checkov.yaml --directory platform/terraform/ --compact --quiet

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/140.security.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.
