### PR TITLE
test(mission_control): rewrite core range/agent/model suites to behavior tests

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -167,7 +167,9 @@ entries. Completed so far:
 - `mission_control`: core range API, agents, models, and page-view suites
   (`test_range_api*`, `test_agents`, `test_models`, `test_views`,
   `test_engine_models`); engine-service view suites (`test_engine_services`,
-  `test_engine_services_lifecycle`) and `test_asset_hierarchy`.
+  `test_engine_services_lifecycle`) and `test_asset_hierarchy`; the SNS->
+  WebSocket handler suite (`test_handlers`), driven against the real in-memory
+  Channels layer.
 
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -166,7 +166,8 @@ entries. Completed so far:
 
 - `mission_control`: core range API, agents, models, and page-view suites
   (`test_range_api*`, `test_agents`, `test_models`, `test_views`,
-  `test_engine_models`).
+  `test_engine_models`); engine-service view suites (`test_engine_services`,
+  `test_engine_services_lifecycle`) and `test_asset_hierarchy`.
 
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -156,6 +156,22 @@ Current mechanisms:
   exception. During initial adoption, a base branch without the baseline
   file starts the ratchet from the first merged baseline.
 
+### ADR-019 baseline reduction (#957)
+
+Issue #957 rewrites the remaining non-decomposed mock-coupled test suites
+to behavior tests (drive a public entry point; assert outputs / ORM state /
+responses) and shrinks `boundary_mock_baseline.json` accordingly. Each group
+of suites lands as its own commit that removes the corresponding baseline
+entries. Completed so far:
+
+- `mission_control`: core range API, agents, models, and page-view suites
+  (`test_range_api*`, `test_agents`, `test_models`, `test_views`,
+  `test_engine_models`).
+
+Decomposition-owned suites are out of scope here and land with their own
+issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`
+(#885, #886, #889-#891), and `cms/scenario_editor/**` (#887, #888).
+
 ## Adding A Rule
 
 1. Add or update the ADR in `index.yaml`.

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -3087,26 +3087,6 @@
     },
     {
       "count": 5,
-      "path": "shifter/shifter_platform/tests/mission_control/test_agents.py",
-      "target": "mission_control.views.cms_delete_agent"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_agents.py",
-      "target": "mission_control.views.cms_list_agents"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_agents.py",
-      "target": "mission_control.views.get_allowed_extensions"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_agents.py",
-      "target": "mission_control.views.render"
-    },
-    {
-      "count": 5,
       "path": "shifter/shifter_platform/tests/mission_control/test_api_instance_ssh_url.py",
       "target": "engine.services.get_ssh_connection_info"
     },
@@ -3144,21 +3124,6 @@
       "count": 4,
       "path": "shifter/shifter_platform/tests/mission_control/test_context_processors.py",
       "target": "mission_control.context_processors.logger"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_models.py",
-      "target": "engine.models.Range.objects"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_models.py",
-      "target": "engine.models.connection"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_models.py",
-      "target": "engine.models.transaction"
     },
     {
       "count": 7,
@@ -3266,26 +3231,6 @@
       "target": "config.health_checks.get_channel_layer"
     },
     {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/mission_control/test_models.py",
-      "target": "cms.models.AgentConfig.objects.filter"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/mission_control/test_models.py",
-      "target": "cms.models.OperatingSystem.objects.for_extension"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_models.py",
-      "target": "engine.models.Range.objects"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_models.py",
-      "target": "management.models.ActivityLog.objects.create"
-    },
-    {
       "count": 3,
       "path": "shifter/shifter_platform/tests/mission_control/test_ngfw_detail.py",
       "target": "engine.services.get_ranges_for_ngfw"
@@ -3324,126 +3269,6 @@
       "count": 7,
       "path": "shifter/shifter_platform/tests/mission_control/test_oidc.py",
       "target": "config.oidc.update_cognito_sub"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api.py",
-      "target": "cms.services.cancel_range"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api.py",
-      "target": "cms.services.destroy_range"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api.py",
-      "target": "mission_control.views.cms_create_range"
-    },
-    {
-      "count": 8,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api.py",
-      "target": "mission_control.views.cms_get_agent"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api.py",
-      "target": "mission_control.views.cms_list_scenarios"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api.py",
-      "target": "mission_control.views.get_active_range"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py",
-      "target": "engine.models.Range.SUBNET_INDEX_MAX"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py",
-      "target": "engine.models.Range.objects"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py",
-      "target": "engine.models.transaction"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py",
-      "target": "mission_control.views.cms_create_range"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py",
-      "target": "mission_control.views.cms_get_agent"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py",
-      "target": "mission_control.views.cms_list_agents"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py",
-      "target": "mission_control.views.cms_list_scenarios"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "cms.services.cancel_range"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "cms.services.destroy_range"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "cms.services.destroy_range_by_request_id"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "cms.services.pause_range"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "cms.services.resume_range"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "mission_control.views.audit_log_from_request"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "mission_control.views.cms_create_range"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "mission_control.views.cms_get_agent"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_range_api_audit.py",
-      "target": "mission_control.views.cms_list_scenarios"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_views.py",
-      "target": "cms.assets.services.AgentConfig"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_views.py",
-      "target": "mission_control.views.render"
     },
     {
       "count": 2,

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -3141,26 +3141,6 @@
       "target": "mission_control.guacamole.sign_and_encrypt_payload"
     },
     {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/mission_control/test_handlers.py",
-      "target": "mission_control.handlers.async_to_sync"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/mission_control/test_handlers.py",
-      "target": "mission_control.handlers.logger"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_handlers.py",
-      "target": "mission_control.handlers.process_ngfw_event"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/mission_control/test_handlers.py",
-      "target": "mission_control.handlers.process_range_event"
-    },
-    {
       "count": 1,
       "path": "shifter/shifter_platform/tests/mission_control/test_health.py",
       "target": "config.health_checks.ChannelLayerRedisHealthCheck._probe"

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -3106,11 +3106,6 @@
       "target": "mission_control.guacamole.create_guacamole_ssh_url"
     },
     {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/mission_control/test_asset_hierarchy.py",
-      "target": "cms.models.AgentConfig.objects.filter"
-    },
-    {
       "count": 20,
       "path": "shifter/shifter_platform/tests/mission_control/test_context_processors.py",
       "target": "mission_control.context_processors.get_active_range"
@@ -3124,56 +3119,6 @@
       "count": 4,
       "path": "shifter/shifter_platform/tests/mission_control/test_context_processors.py",
       "target": "mission_control.context_processors.logger"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services.py",
-      "target": "engine.ecs.start_range_provisioning"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services.py",
-      "target": "engine.interpreter.interpret"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services.py",
-      "target": "engine.models.Range.allocate_subnet_index"
-    },
-    {
-      "count": 8,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services.py",
-      "target": "engine.models.Range.objects.create"
-    },
-    {
-      "count": 15,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services.py",
-      "target": "engine.models.Range.objects.get"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services.py",
-      "target": "engine.models.Subnet"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services.py",
-      "target": "engine.services.transaction.atomic"
-    },
-    {
-      "count": 6,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services_lifecycle.py",
-      "target": "engine.ecs.start_teardown"
-    },
-    {
-      "count": 17,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services_lifecycle.py",
-      "target": "engine.models.Range.objects.get"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/mission_control/test_engine_services_lifecycle.py",
-      "target": "engine.services.transaction.atomic"
     },
     {
       "count": 7,

--- a/shifter/shifter_platform/tests/mission_control/conftest.py
+++ b/shifter/shifter_platform/tests/mission_control/conftest.py
@@ -1,0 +1,130 @@
+"""Shared fixtures for mission_control behavior tests.
+
+These tests drive the real Django views/URLs with a real database and assert
+observable behavior (HTTP responses + persisted ORM state) instead of patching
+first-party service/view internals. The only boundaries that would need mocking
+are process/network/cloud SDKs; in the test settings ECS/local-provisioner are
+unconfigured, so range provisioning is a no-op and no cloud mock is required.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+import cms.scenarios.hydrator as _hydrator
+from cms.models import AgentConfig, OperatingSystem, Scenario
+from cms.scenarios.registry import load_scenario_template as _GENUINE_LOAD_SCENARIO
+
+User = get_user_model()
+
+
+@pytest.fixture(autouse=True)
+def _restore_real_scenario_loader():
+    """Guard the scenario loader binding against cross-suite mock leakage.
+
+    Legacy mock-coupled cms suites (``test_scenario_hydrator``,
+    ``test_services_range*``) patch ``cms.scenarios.hydrator.load_scenario``.
+    Under pytest-xdist that patched binding can leak into a worker that later
+    runs these behavior tests, which drive real scenario hydration, leaving
+    ``load_scenario`` a ``Mock``. Rebind it to the genuine loader (captured at
+    import, before any patch is active) so each test starts from real state.
+    Remove once those cms suites are rewritten to behavior tests (#957).
+    """
+    _hydrator.load_scenario = _GENUINE_LOAD_SCENARIO
+    yield
+
+
+# A scenario definition whose victim resolves to a Windows agent
+# (xdr_agent=True), so create_range hydrates cleanly with a single
+# Windows AgentConfig and no cloud configured.
+HYDRATABLE_DEFINITION: dict[str, Any] = {
+    "instances": [
+        {"name": "Attacker", "role": "attacker", "os_type": "kali", "xdr_agent": False},
+        {"name": "Target", "role": "victim", "os_type": "windows", "xdr_agent": True},
+    ],
+    "subnets": [{"name": "core", "instances": ["Attacker", "Target"]}],
+    "ngfw": False,
+}
+
+
+@pytest.fixture
+def windows_os(db) -> OperatingSystem:
+    """The seeded (or created) Windows operating system row."""
+    os_obj, _ = OperatingSystem.objects.get_or_create(
+        slug="windows", defaults={"name": "Windows", "extensions": [".msi"]}
+    )
+    return os_obj
+
+
+@pytest.fixture
+def linux_os(db) -> OperatingSystem:
+    """A Linux operating system row for agent-OS variations."""
+    os_obj, _ = OperatingSystem.objects.get_or_create(
+        slug="linux-debian", defaults={"name": "Linux (Debian/Ubuntu)", "extensions": [".deb"]}
+    )
+    return os_obj
+
+
+@pytest.fixture
+def make_agent(db, windows_os) -> Callable[..., AgentConfig]:
+    """Factory creating a real AgentConfig owned by ``user``."""
+
+    def _make(user, *, os=None, name="Test XDR Agent", **overrides) -> AgentConfig:
+        fields: dict[str, Any] = {
+            "name": name,
+            "s3_key": "agents/test/agent.msi",
+            "original_filename": "agent.msi",
+            "file_size_bytes": 50_000_000,
+            "sha256_hash": "abc123",
+            "user": user,
+            "os": os or windows_os,
+        }
+        fields.update(overrides)
+        return AgentConfig.objects.create(**fields)
+
+    return _make
+
+
+@pytest.fixture
+def hydratable_scenario(db) -> Scenario:
+    """A DB custom scenario that hydrates with a single Windows agent."""
+    staff = User.objects.create_user(
+        username="scenario-author@example.com",
+        email="scenario-author@example.com",
+        is_staff=True,
+    )
+    return Scenario.objects.create(
+        scenario_id="behavior-test",
+        name="Behavior Test Range",
+        description="Hydratable scenario for behavior tests.",
+        definition=HYDRATABLE_DEFINITION,
+        created_by=staff,
+        updated_by=staff,
+    )
+
+
+@pytest.fixture
+def launch_range_via_api(make_agent, hydratable_scenario) -> Callable[..., tuple[Any, AgentConfig, str]]:
+    """Launch a real range for ``(client, user)`` and return (response, agent, scenario_id).
+
+    Drives the real launch endpoint so downstream get/cancel/destroy tests
+    operate on genuinely-persisted range state.
+    """
+
+    def _launch(client, user, *, scenario_id: str | None = None) -> tuple[Any, AgentConfig, str]:
+        agent = make_agent(user)
+        scenario = scenario_id or hydratable_scenario.scenario_id
+        response = client.post(
+            reverse("mission_control:launch_range"),
+            data=json.dumps({"agent_id": agent.id, "scenario": scenario}),
+            content_type="application/json",
+        )
+        return response, agent, scenario
+
+    return _launch

--- a/shifter/shifter_platform/tests/mission_control/test_agents.py
+++ b/shifter/shifter_platform/tests/mission_control/test_agents.py
@@ -1,186 +1,95 @@
-"""Tests for agent upload and delete views."""
+"""Behavior tests for the agent list/upload page and agent deletion.
 
-from unittest.mock import MagicMock, patch
+Drives the real ``mission_control:agents`` and ``mission_control:delete_agent``
+URLs with database-backed agents. Auth/ownership rejections run entirely
+first-party; the successful-delete path removes the S3 object first, so it
+mocks the AWS SDK (a real cloud boundary) and sets a bucket name via
+``override_settings`` rather than patching first-party services.
+"""
+
+from unittest.mock import patch
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
-from django.http import HttpResponse
-from django.test import RequestFactory
+from django.test import Client, override_settings
 from django.urls import reverse
 
-from mission_control.views import agents, delete_agent
+from cms.models import AgentConfig
+
+pytestmark = pytest.mark.django_db
+
+AGENTS_URL = reverse("mission_control:agents")
 
 
-@pytest.fixture
-def rf():
-    return RequestFactory()
-
-
-@pytest.fixture
-def mock_user():
-    user = MagicMock()
-    user.id = 1
-    user.pk = 1
-    user.email = "test@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
-
-
-def _make_agent(**overrides):
-    """Build a mock agent object."""
-    defaults = {
-        "id": 1,
-        "name": "Test Agent",
-        "s3_key": "agents/1/abc123_test.msi",
-        "original_filename": "test.msi",
-        "file_size_bytes": 1024 * 1024,
-        "sha256_hash": "abc123",
-        "deleted_at": None,
-    }
-    defaults.update(overrides)
-    return MagicMock(**defaults)
+def _delete_url(agent_id):
+    return reverse("mission_control:delete_agent", args=[agent_id])
 
 
 class TestAgentsView:
-    def test_requires_login(self, rf):
-        request = rf.get("/mc/agents/")
-        request.user = AnonymousUser()
+    def test_requires_login(self):
+        assert Client().get(AGENTS_URL).status_code == 302
 
-        response = agents(request)
-        assert response.status_code == 302
+    def test_shows_user_agents(self, authenticated_client, make_agent):
+        client, user = authenticated_client(email="agentlist@example.com")
+        make_agent(user, name="Acme Sensor")
 
-    def test_shows_user_agents(self, rf, mock_user):
-        request = rf.get("/mc/agents/")
-        request.user = mock_user
-        agent = _make_agent()
+        response = client.get(AGENTS_URL)
+        assert response.status_code == 200
+        assert b"Acme Sensor" in response.content
 
-        with (
-            patch("mission_control.views.cms_list_agents", return_value=[agent]),
-            patch("mission_control.views.get_allowed_extensions", return_value=[".msi"]),
-            patch("mission_control.views.render") as mock_render,
-        ):
-            mock_render.return_value = HttpResponse("ok")
-            agents(request)
+    def test_shows_empty_state(self, authenticated_client):
+        client, _user = authenticated_client(email="noagents@example.com")
+        response = client.get(AGENTS_URL)
+        assert response.status_code == 200
 
-            context = mock_render.call_args[0][2]
-            assert context["agents"] == [agent]
+    def test_does_not_show_other_users_agents(self, authenticated_client, make_agent):
+        viewer_client, _viewer = authenticated_client(email="viewer@example.com")
+        _other_client, other = authenticated_client(email="agentowner@example.com")
+        make_agent(other, name="Private Sensor")
 
-    def test_hides_deleted_agents(self, rf, mock_user):
-        """Agents view only shows what cms_list_agents returns (no deleted)."""
-        request = rf.get("/mc/agents/")
-        request.user = mock_user
-
-        with (
-            patch("mission_control.views.cms_list_agents", return_value=[]),
-            patch("mission_control.views.get_allowed_extensions", return_value=[".msi"]),
-            patch("mission_control.views.render") as mock_render,
-        ):
-            mock_render.return_value = HttpResponse("ok")
-            agents(request)
-
-            context = mock_render.call_args[0][2]
-            assert context["agents"] == []
-
-    def test_shows_empty_state(self, rf, mock_user):
-        request = rf.get("/mc/agents/")
-        request.user = mock_user
-
-        with (
-            patch("mission_control.views.cms_list_agents", return_value=[]),
-            patch("mission_control.views.get_allowed_extensions", return_value=[".msi"]),
-            patch("mission_control.views.render") as mock_render,
-        ):
-            mock_render.return_value = HttpResponse("ok")
-            agents(request)
-
-            context = mock_render.call_args[0][2]
-            assert context["agents"] == []
+        response = viewer_client.get(AGENTS_URL)
+        assert response.status_code == 200
+        assert b"Private Sensor" not in response.content
 
 
 class TestDeleteAgent:
-    def test_requires_login(self, rf):
-        request = rf.post("/mc/agents/1/delete/")
-        request.user = AnonymousUser()
+    def test_requires_login(self, make_agent, authenticated_client):
+        _client, user = authenticated_client(email="delowner@example.com")
+        agent = make_agent(user)
+        assert Client().post(_delete_url(agent.id)).status_code == 302
 
-        response = delete_agent(request, 1)
-        assert response.status_code == 302
+    def test_requires_post(self, authenticated_client, make_agent):
+        client, user = authenticated_client(email="delget@example.com")
+        agent = make_agent(user)
+        assert client.get(_delete_url(agent.id)).status_code == 405
 
-    def test_requires_post(self, rf, mock_user):
-        request = rf.get("/mc/agents/1/delete/")
-        request.user = mock_user
+    @override_settings(AWS_S3_BUCKET_NAME="test-bucket")
+    def test_successful_delete(self, authenticated_client, make_agent):
+        client, user = authenticated_client(email="delok@example.com")
+        agent = make_agent(user)
 
-        response = delete_agent(request, 1)
-        assert response.status_code == 405
-
-    @patch("mission_control.views.cms_delete_agent")
-    def test_successful_delete(self, mock_cms_delete, rf, mock_user):
-        request = rf.post("/mc/agents/1/delete/")
-        request.user = mock_user
-        # messages framework needs _messages attribute
-        request._messages = MagicMock()
-
-        response = delete_agent(request, 1)
+        with patch("boto3.client"):  # cloud boundary: S3 object removal is a no-op
+            response = client.post(_delete_url(agent.id))
 
         assert response.status_code == 302
-        assert response.url == reverse("mission_control:agents")
-        mock_cms_delete.assert_called_once_with(mock_user, 1)
+        assert response.url == AGENTS_URL
+        # Soft-deleted: hidden from the default manager.
+        assert not AgentConfig.objects.filter(id=agent.id).exists()
 
-    @patch("mission_control.views.cms_delete_agent")
-    def test_cannot_delete_other_users_agent(self, mock_cms_delete, rf, mock_user):
-        """Deleting another user's agent shows error and redirects."""
-        from cms.services import CMSError
+    def test_cannot_delete_other_users_agent(self, authenticated_client, make_agent):
+        client, _user = authenticated_client(email="attacker@example.com")
+        _owner_client, owner = authenticated_client(email="victim@example.com")
+        agent = make_agent(owner)
 
-        mock_cms_delete.side_effect = CMSError("Agent not found or not owned by user")
+        response = client.post(_delete_url(agent.id), follow=True)
+        assert response.status_code == 200
+        assert any(
+            "not found" in str(m).lower() or "permission" in str(m).lower() for m in response.context["messages"]
+        )
+        # The agent is untouched.
+        assert AgentConfig.objects.filter(id=agent.id).exists()
 
-        request = rf.post("/mc/agents/1/delete/")
-        request.user = mock_user
-        request._messages = MagicMock()
-
-        response = delete_agent(request, 1)
+    def test_delete_nonexistent_agent(self, authenticated_client):
+        client, _user = authenticated_client(email="delghost@example.com")
+        response = client.post(_delete_url(999999))
         assert response.status_code == 302
-        assert response.url == reverse("mission_control:agents")
-
-    @patch("mission_control.views.cms_delete_agent")
-    def test_cannot_delete_already_deleted(self, mock_cms_delete, rf, mock_user):
-        """Deleting already-deleted agent shows error and redirects."""
-        from cms.services import CMSError
-
-        mock_cms_delete.side_effect = CMSError("Agent already deleted")
-
-        request = rf.post("/mc/agents/1/delete/")
-        request.user = mock_user
-        request._messages = MagicMock()
-
-        response = delete_agent(request, 1)
-        assert response.status_code == 302
-        assert response.url == reverse("mission_control:agents")
-
-    @patch("mission_control.views.cms_delete_agent")
-    def test_s3_error_prevents_delete(self, mock_cms_delete, rf, mock_user):
-        """S3 error during delete shows error and redirects."""
-        from cms.assets.services import AssetError
-
-        mock_cms_delete.side_effect = AssetError("Failed to delete from S3")
-
-        request = rf.post("/mc/agents/1/delete/")
-        request.user = mock_user
-        request._messages = MagicMock()
-
-        response = delete_agent(request, 1)
-        assert response.status_code == 302
-
-    @patch("mission_control.views.cms_delete_agent")
-    def test_delete_nonexistent_agent(self, mock_cms_delete, rf, mock_user):
-        """Deleting non-existent agent shows error and redirects."""
-        from cms.services import CMSError
-
-        mock_cms_delete.side_effect = CMSError("Agent not found")
-
-        request = rf.post("/mc/agents/99999/delete/")
-        request.user = mock_user
-        request._messages = MagicMock()
-
-        response = delete_agent(request, 99999)
-        assert response.status_code == 302
-        assert response.url == reverse("mission_control:agents")
+        assert response.url == AGENTS_URL

--- a/shifter/shifter_platform/tests/mission_control/test_asset_hierarchy.py
+++ b/shifter/shifter_platform/tests/mission_control/test_asset_hierarchy.py
@@ -1,14 +1,9 @@
-"""Unit tests for Asset/FileAsset abstract base classes.
+"""Tests for the Asset/FileAsset abstract base classes.
 
-Tests verify the abstract hierarchy provides:
-- Asset: Common fields (name, timestamps) and soft delete
-- FileAsset: S3 file storage fields and computed properties
-
-These tests use AgentConfig as the concrete implementation since
-abstract models cannot be instantiated directly.
+Field presence, computed properties, and the inheritance chain are exercised on
+in-memory ``AgentConfig`` instances (pure value logic). ``active_for_user`` is
+exercised against the real database rather than mocking ``.objects.filter``.
 """
-
-from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.utils import timezone
@@ -19,19 +14,16 @@ User = get_user_model()
 
 
 def _make_os():
-    """Build an in-memory OperatingSystem."""
     return OperatingSystem(slug="windows", name="Windows", extensions=[".msi"])
 
 
 def _make_user(**kwargs):
-    """Build an in-memory User (unsaved)."""
     defaults = {"id": 1, "username": "test@example.com", "email": "test@example.com"}
     defaults.update(kwargs)
     return User(**defaults)
 
 
 def _make_agent(**overrides):
-    """Build an in-memory AgentConfig with sensible defaults."""
     defaults = {
         "id": 1,
         "user": _make_user(),
@@ -49,148 +41,84 @@ def _make_agent(**overrides):
 
 
 class TestAssetAbstractBase:
-    """Tests for Asset abstract base class functionality.
-
-    Since Asset is abstract, we test through AgentConfig which inherits from it.
-    """
-
     def test_asset_is_abstract(self):
-        """Asset model class is abstract (cannot be instantiated directly)."""
         assert Asset._meta.abstract is True
 
     def test_has_name_field(self):
-        """Asset provides name field through inheritance."""
-        agent = _make_agent(name="Test Agent")
-        assert agent.name == "Test Agent"
+        assert _make_agent(name="Test Agent").name == "Test Agent"
 
-    def test_has_created_at_auto_set(self):
-        """Asset provides created_at field with auto_now_add."""
-        now = timezone.now()
-        agent = _make_agent(created_at=now)
+    def test_has_created_at(self):
+        agent = _make_agent(created_at=timezone.now())
         assert agent.created_at is not None
         assert (timezone.now() - agent.created_at).total_seconds() < 60
 
     def test_has_deleted_at_nullable(self):
-        """Asset provides deleted_at field that defaults to None."""
-        agent = _make_agent(deleted_at=None)
-        assert agent.deleted_at is None
+        assert _make_agent(deleted_at=None).deleted_at is None
 
-    def test_is_deleted_property_false_by_default(self):
-        """is_deleted returns False when deleted_at is None."""
-        agent = _make_agent(deleted_at=None)
-        assert agent.is_deleted is False
+    def test_is_deleted_false_by_default(self):
+        assert _make_agent(deleted_at=None).is_deleted is False
 
-    def test_is_deleted_property_true_when_set(self):
-        """is_deleted returns True when deleted_at is set."""
+    def test_is_deleted_true_when_set(self):
         agent = _make_agent()
         agent.deleted_at = timezone.now()
         assert agent.is_deleted is True
 
-    def test_active_for_user_excludes_deleted(self):
-        """active_for_user filters AgentConfig.objects (SoftDeleteManager, active-only)."""
-        user = _make_user()
-        active = _make_agent(name="Active", user=user)
+    def test_active_for_user_excludes_deleted_and_other_users(self, db, make_agent, django_user_model):
+        owner = django_user_model.objects.create_user(username="ah-owner@example.com", email="ah-owner@example.com")
+        other = django_user_model.objects.create_user(username="ah-other@example.com", email="ah-other@example.com")
+        active = make_agent(owner, name="Active")
+        deleted = make_agent(owner, name="Deleted")
+        deleted.deleted_at = timezone.now()
+        deleted.save(update_fields=["deleted_at"])
+        make_agent(other, name="Other")
 
-        mock_qs = MagicMock()
-        mock_qs.__iter__ = lambda self: iter([active])
-
-        with patch.object(AgentConfig.objects, "filter", return_value=mock_qs) as mock_filter:
-            result = list(AgentConfig.active_for_user(user))
-
-        mock_filter.assert_called_once_with(user=user)
-        assert len(result) == 1
-        assert result[0] == active
-
-    def test_active_for_user_filters_by_user(self):
-        """active_for_user only returns records for the specified user."""
-        user = _make_user()
-        my_agent = _make_agent(name="My Agent", user=user)
-
-        mock_qs = MagicMock()
-        mock_qs.__iter__ = lambda self: iter([my_agent])
-
-        with patch.object(AgentConfig.objects, "filter", return_value=mock_qs) as mock_filter:
-            result = list(AgentConfig.active_for_user(user))
-
-        mock_filter.assert_called_once_with(user=user)
-        assert len(result) == 1
-        assert result[0].name == "My Agent"
+        result = list(AgentConfig.active_for_user(owner))
+        assert result == [active]
 
 
 class TestFileAssetAbstractBase:
-    """Tests for FileAsset abstract base class functionality.
-
-    FileAsset extends Asset with S3 storage fields.
-    """
-
     def test_file_asset_is_abstract(self):
-        """FileAsset model class is abstract (cannot be instantiated directly)."""
         assert FileAsset._meta.abstract is True
 
     def test_has_s3_key_field(self):
-        """FileAsset provides s3_key field."""
-        agent = _make_agent(s3_key="users/123/agents/installer.msi")
-        assert agent.s3_key == "users/123/agents/installer.msi"
+        assert _make_agent(s3_key="users/123/agents/installer.msi").s3_key == "users/123/agents/installer.msi"
 
     def test_has_original_filename_field(self):
-        """FileAsset provides original_filename field."""
-        agent = _make_agent(original_filename="XDR_Agent_7.5.1.msi")
-        assert agent.original_filename == "XDR_Agent_7.5.1.msi"
+        assert _make_agent(original_filename="XDR_Agent_7.5.1.msi").original_filename == "XDR_Agent_7.5.1.msi"
 
     def test_has_file_size_bytes_field(self):
-        """FileAsset provides file_size_bytes field."""
-        agent = _make_agent(file_size_bytes=104857600)
-        assert agent.file_size_bytes == 104857600
+        assert _make_agent(file_size_bytes=104857600).file_size_bytes == 104857600
 
     def test_has_sha256_hash_field(self):
-        """FileAsset provides sha256_hash field."""
         hash_value = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-        agent = _make_agent(sha256_hash=hash_value)
-        assert agent.sha256_hash == hash_value
+        assert _make_agent(sha256_hash=hash_value).sha256_hash == hash_value
 
     def test_file_size_mb_property(self):
-        """file_size_mb returns size in megabytes rounded to 1 decimal."""
-        agent = _make_agent(file_size_bytes=104857600)
-        assert agent.file_size_mb == 100.0
+        assert _make_agent(file_size_bytes=104857600).file_size_mb == 100.0
 
     def test_file_size_mb_rounds_correctly(self):
-        """file_size_mb rounds to 1 decimal place."""
-        agent = _make_agent(file_size_bytes=54893568)
-        assert agent.file_size_mb == 52.4
+        assert _make_agent(file_size_bytes=54893568).file_size_mb == 52.4
 
 
 class TestAgentConfigInheritsCorrectly:
-    """Tests that AgentConfig properly inherits from FileAsset.
-
-    These tests verify the inheritance chain is correct and
-    AgentConfig-specific fields work alongside inherited fields.
-    """
-
-    def test_agent_config_is_subclass_of_file_asset(self):
-        """AgentConfig inherits from FileAsset."""
+    def test_subclass_of_file_asset(self):
         assert issubclass(AgentConfig, FileAsset)
 
-    def test_agent_config_is_subclass_of_asset(self):
-        """AgentConfig inherits from Asset (through FileAsset)."""
+    def test_subclass_of_asset(self):
         assert issubclass(AgentConfig, Asset)
 
-    def test_agent_config_has_os_field(self):
-        """AgentConfig has its own os foreign key field."""
+    def test_has_os_field(self):
         os_obj = _make_os()
         agent = _make_agent(os=os_obj)
         assert agent.os == os_obj
         assert agent.os.name == "Windows"
 
-    def test_agent_config_user_related_name(self):
-        """AgentConfig user FK has related_name='cms_agents'."""
+    def test_user_related_name(self):
         field = AgentConfig._meta.get_field("user")
         assert field.remote_field.related_name == "cms_agents"
 
-    def test_str_method_includes_name_and_os(self):
-        """__str__ returns name with OS for identification."""
-        agent = _make_agent(name="My XDR Agent")
-        assert str(agent) == "My XDR Agent (Windows)"
+    def test_str_includes_name_and_os(self):
+        assert str(_make_agent(name="My XDR Agent")) == "My XDR Agent (Windows)"
 
     def test_ordering_by_created_at_desc(self):
-        """Model meta has ordering by -created_at."""
         assert AgentConfig._meta.ordering == ["-created_at"]

--- a/shifter/shifter_platform/tests/mission_control/test_engine_models.py
+++ b/shifter/shifter_platform/tests/mission_control/test_engine_models.py
@@ -1,405 +1,130 @@
-"""Tests for Engine models.
+"""Behavior tests for the engine ``Range`` model.
 
-These tests verify Range model behavior using in-memory construction
-and mocks instead of database access.
+Value-logic (status enums, computed properties, ``get_instance_by_uuid``) is
+exercised on in-memory instances; the manager lookups
+(``get_active_for_user`` / ``get_destroyable_for_user``) run against the real
+database. ``allocate_subnet_index`` has its full behavior matrix in
+``test_range_api_agents_subnets.py``.
 """
-
-from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from engine.models import Range
 
 
-class TestRangeModel:
-    """Tests for Range model in engine.models."""
-
-    # -------------------------------------------------------------------------
-    # Import tests - Range should be importable from engine.models
-    # -------------------------------------------------------------------------
-
-    def test_range_status_enum_exists(self):
-        """Range.Status enum exists with expected values."""
-        assert hasattr(Range, "Status")
+class TestRangeStatusEnums:
+    def test_range_status_enum_values(self):
         assert Range.Status.PENDING == "pending"
         assert Range.Status.PROVISIONING == "provisioning"
         assert Range.Status.READY == "ready"
         assert Range.Status.PAUSED == "paused"
-        assert Range.Status.RESUMING == "resuming"
-        assert Range.Status.DESTROYING == "destroying"
         assert Range.Status.DESTROYED == "destroyed"
         assert Range.Status.FAILED == "failed"
 
     def test_terminal_statuses_defined(self):
-        """shared.enums.TERMINAL_STATUSES contains terminal states."""
         from shared.enums import TERMINAL_STATUSES, ResourceStatus
 
         assert ResourceStatus.DESTROYED in TERMINAL_STATUSES
         assert ResourceStatus.FAILED in TERMINAL_STATUSES
 
     def test_cancellable_statuses_defined(self):
-        """shared.enums.CANCELLABLE_STATUSES contains cancellable states."""
         from shared.enums import CANCELLABLE_STATUSES, ResourceStatus
 
         assert ResourceStatus.PENDING in CANCELLABLE_STATUSES
         assert ResourceStatus.PROVISIONING in CANCELLABLE_STATUSES
 
-    # -------------------------------------------------------------------------
-    # Model method tests (class methods use mocked querysets)
-    # -------------------------------------------------------------------------
 
-    def test_get_active_for_user_returns_none_when_no_range(self):
-        """get_active_for_user returns None when user has no active range."""
-        user = Mock()
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.first.return_value = None
+class TestRangeUserLookups:
+    """get_active_for_user / get_destroyable_for_user against real rows."""
 
-        with patch.object(Range, "objects", mock_qs):
-            result = Range.get_active_for_user(user)
-
-        assert result is None
-
-    def test_get_active_for_user_returns_active_range(self):
-        """get_active_for_user returns user's active range."""
-        user = Mock()
-        expected_range = Range(user_id=1, status=Range.Status.READY)
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.first.return_value = expected_range
-
-        with patch.object(Range, "objects", mock_qs):
-            result = Range.get_active_for_user(user)
-
-        assert result == expected_range
-        mock_qs.filter.assert_called_once_with(
-            user=user,
-            status__in=[
-                Range.Status.PENDING,
-                Range.Status.PROVISIONING,
-                Range.Status.READY,
-                Range.Status.PAUSED,
-                Range.Status.RESUMING,
-            ],
+    @pytest.fixture
+    def user(self, db, django_user_model):
+        return django_user_model.objects.create_user(
+            username="rangelookup@example.com", email="rangelookup@example.com"
         )
 
-    def test_get_active_for_user_excludes_destroying(self):
-        """get_active_for_user excludes DESTROYING ranges via the filter."""
-        user = Mock()
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.first.return_value = None
+    def test_get_active_returns_none_when_no_range(self, user):
+        assert Range.get_active_for_user(user) is None
 
-        with patch.object(Range, "objects", mock_qs):
-            Range.get_active_for_user(user)
+    def test_get_active_returns_active_range(self, user):
+        active = Range.objects.create(user=user, status=Range.Status.READY)
+        assert Range.get_active_for_user(user) == active
 
-        # Verify DESTROYING is not in the status__in list
-        call_kwargs = mock_qs.filter.call_args[1]
-        assert Range.Status.DESTROYING not in call_kwargs["status__in"]
+    def test_get_active_excludes_destroyed_and_destroying(self, user):
+        Range.objects.create(user=user, status=Range.Status.DESTROYED)
+        Range.objects.create(user=user, status=Range.Status.DESTROYING)
+        assert Range.get_active_for_user(user) is None
 
-    def test_get_destroyable_for_user_includes_failed(self):
-        """get_destroyable_for_user includes FAILED ranges."""
-        user = Mock()
-        failed_range = Range(user_id=1, status=Range.Status.FAILED)
-        mock_qs = MagicMock()
-        mock_qs.filter.return_value.first.return_value = failed_range
+    def test_get_active_ignores_other_users(self, user, django_user_model):
+        other = django_user_model.objects.create_user(username="rl-other@example.com", email="rl-other@example.com")
+        Range.objects.create(user=other, status=Range.Status.READY)
+        assert Range.get_active_for_user(user) is None
 
-        with patch.object(Range, "objects", mock_qs):
-            result = Range.get_destroyable_for_user(user)
+    def test_get_destroyable_includes_failed(self, user):
+        failed = Range.objects.create(user=user, status=Range.Status.FAILED)
+        assert Range.get_destroyable_for_user(user) == failed
 
-        assert result == failed_range
-        call_kwargs = mock_qs.filter.call_args[1]
-        assert Range.Status.FAILED in call_kwargs["status__in"]
 
-    def test_allocate_subnet_index_returns_first_available(self):
-        """allocate_subnet_index returns the first available index."""
-        mock_qs = MagicMock()
-        # No used indices
-        mock_qs.exclude.return_value.exclude.return_value.values_list.return_value = []
-
-        with (
-            patch.object(Range, "objects", mock_qs),
-            patch("engine.models.transaction") as mock_txn,
-            patch("engine.models.connection", create=True) as mock_conn,
-        ):
-            # Mock the atomic context manager
-            mock_txn.atomic.return_value.__enter__ = Mock(return_value=None)
-            mock_txn.atomic.return_value.__exit__ = Mock(return_value=False)
-            mock_conn.vendor = "sqlite"
-
-            index = Range.allocate_subnet_index()
-
-        assert index == 1
-
-    def test_allocate_subnet_index_skips_used_indices(self):
-        """allocate_subnet_index skips indices used by active ranges."""
-        mock_qs = MagicMock()
-        # Index 1 is used
-        mock_qs.exclude.return_value.exclude.return_value.values_list.return_value = [1]
-
-        with (
-            patch.object(Range, "objects", mock_qs),
-            patch("engine.models.transaction") as mock_txn,
-            patch("engine.models.connection", create=True) as mock_conn,
-        ):
-            mock_txn.atomic.return_value.__enter__ = Mock(return_value=None)
-            mock_txn.atomic.return_value.__exit__ = Mock(return_value=False)
-            mock_conn.vendor = "sqlite"
-
-            index = Range.allocate_subnet_index()
-
-        assert index == 2
-
-    def test_allocate_subnet_index_reuses_destroyed(self):
-        """allocate_subnet_index reuses indices from DESTROYED ranges.
-
-        DESTROYED ranges are excluded from the used_indices query, so their
-        indices become available for reuse.
-        """
-        mock_qs = MagicMock()
-        # No active ranges using any index (destroyed index 1 excluded by filter)
-        mock_qs.exclude.return_value.exclude.return_value.values_list.return_value = []
-
-        with (
-            patch.object(Range, "objects", mock_qs),
-            patch("engine.models.transaction") as mock_txn,
-            patch("engine.models.connection", create=True) as mock_conn,
-        ):
-            mock_txn.atomic.return_value.__enter__ = Mock(return_value=None)
-            mock_txn.atomic.return_value.__exit__ = Mock(return_value=False)
-            mock_conn.vendor = "sqlite"
-
-            index = Range.allocate_subnet_index()
-
-        assert index == 1
-
-    # -------------------------------------------------------------------------
-    # Model property tests
-    # -------------------------------------------------------------------------
-
+class TestRangeProperties:
     def test_is_usable_ready(self):
-        """is_usable returns True for READY ranges."""
-        r = Range(user_id=1, status=Range.Status.READY)
-        assert r.is_usable is True
+        assert Range(user_id=1, status=Range.Status.READY).is_usable is True
 
     def test_is_usable_paused(self):
-        """is_usable returns True for PAUSED ranges."""
-        r = Range(user_id=1, status=Range.Status.PAUSED)
-        assert r.is_usable is True
+        assert Range(user_id=1, status=Range.Status.PAUSED).is_usable is True
 
     def test_is_usable_failed(self):
-        """is_usable returns False for FAILED ranges."""
-        r = Range(user_id=1, status=Range.Status.FAILED)
-        assert r.is_usable is False
+        assert Range(user_id=1, status=Range.Status.FAILED).is_usable is False
 
     def test_is_terminal_destroyed(self):
-        """is_terminal returns True for DESTROYED ranges."""
-        r = Range(user_id=1, status=Range.Status.DESTROYED)
-        assert r.is_terminal is True
+        assert Range(user_id=1, status=Range.Status.DESTROYED).is_terminal is True
 
     def test_is_terminal_failed(self):
-        """is_terminal returns True for FAILED ranges."""
-        r = Range(user_id=1, status=Range.Status.FAILED)
-        assert r.is_terminal is True
+        assert Range(user_id=1, status=Range.Status.FAILED).is_terminal is True
 
     def test_is_terminal_ready(self):
-        """is_terminal returns False for READY ranges."""
-        r = Range(user_id=1, status=Range.Status.READY)
-        assert r.is_terminal is False
+        assert Range(user_id=1, status=Range.Status.READY).is_terminal is False
 
 
 class TestRangeGetInstanceByUUID:
-    """Tests for Range.get_instance_by_uuid().
-
-    Tests the instance lookup method contract:
-    - Inputs: uuid string (required, non-empty)
-    - Outputs: instance dict or None
-    - Side effects: none (pure read operation)
-    - Errors: ValueError for invalid uuid input
-    """
-
-    # -------------------------------------------------------------------------
-    # Outputs - returns matching instance dict
-    # -------------------------------------------------------------------------
+    def _range(self, instances):
+        return Range(user_id=1, status=Range.Status.READY, provisioned_instances=instances)
 
     def test_returns_instance_when_uuid_matches(self):
-        """Method returns instance dict when UUID matches."""
-        instance_data = {
-            "uuid": "abc-123-def",
-            "role": "attacker",
-            "private_ip": "10.1.1.10",
-            "ssh_key_secret_arn": "arn:aws:secretsmanager:us-east-2:123:secret:key",
-        }
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[instance_data],
-        )
-
-        result = range_obj.get_instance_by_uuid("abc-123-def")
-
-        assert result == instance_data
+        data = {"uuid": "abc-123-def", "role": "attacker", "private_ip": "10.1.1.10"}
+        assert self._range([data]).get_instance_by_uuid("abc-123-def") == data
 
     def test_returns_correct_instance_from_multiple(self):
-        """Method returns correct instance when multiple exist."""
-        attacker = {
-            "uuid": "attacker-uuid-111",
-            "role": "attacker",
-            "private_ip": "10.1.1.10",
-        }
-        victim = {
-            "uuid": "victim-uuid-222",
-            "role": "victim",
-            "private_ip": "10.1.1.20",
-        }
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[attacker, victim],
-        )
-
-        result = range_obj.get_instance_by_uuid("victim-uuid-222")
-
-        assert result == victim
+        attacker = {"uuid": "attacker-111", "role": "attacker"}
+        victim = {"uuid": "victim-222", "role": "victim"}
+        assert self._range([attacker, victim]).get_instance_by_uuid("victim-222") == victim
 
     def test_returns_none_when_uuid_not_found(self):
-        """Method returns None when UUID doesn't match any instance."""
-        instance_data = {
-            "uuid": "existing-uuid",
-            "role": "attacker",
-            "private_ip": "10.1.1.10",
-        }
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[instance_data],
-        )
+        assert self._range([{"uuid": "existing", "role": "attacker"}]).get_instance_by_uuid("nope") is None
 
-        result = range_obj.get_instance_by_uuid("non-existent-uuid")
-
-        assert result is None
-
-    def test_returns_none_when_provisioned_instances_empty_or_null(self):
-        """Method returns None when provisioned_instances is empty or None."""
-        for instances_value in [[], None]:
-            range_obj = Range(
-                user_id=1,
-                status=Range.Status.READY,
-                provisioned_instances=instances_value,
-            )
-
-            result = range_obj.get_instance_by_uuid("any-uuid")
-            assert result is None, f"Expected None for provisioned_instances={instances_value}"
-
-    # -------------------------------------------------------------------------
-    # Input validation - uuid parameter
-    # -------------------------------------------------------------------------
+    def test_returns_none_when_empty_or_null(self):
+        for instances in ([], None):
+            assert self._range(instances).get_instance_by_uuid("any") is None
 
     def test_raises_on_invalid_uuid(self):
-        """Method raises ValueError for None or empty uuid."""
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[{"uuid": "test", "role": "attacker"}],
-        )
-
-        for invalid_uuid in [None, ""]:
+        range_obj = self._range([{"uuid": "test", "role": "attacker"}])
+        for invalid in (None, ""):
             with pytest.raises(ValueError, match="uuid"):
-                range_obj.get_instance_by_uuid(invalid_uuid)
-
-    # -------------------------------------------------------------------------
-    # Side effects - none expected (pure read operation)
-    # -------------------------------------------------------------------------
+                range_obj.get_instance_by_uuid(invalid)
 
     def test_has_no_side_effects(self):
-        """Method does not modify the provisioned_instances data."""
-        instance_data = {
-            "uuid": "abc-123-def",
-            "role": "attacker",
-            "private_ip": "10.1.1.10",
-        }
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[instance_data],
-        )
-        original_data = range_obj.provisioned_instances.copy()
-
+        data = {"uuid": "abc-123-def", "role": "attacker"}
+        range_obj = self._range([data])
+        original = [dict(data)]
         range_obj.get_instance_by_uuid("abc-123-def")
-
-        assert range_obj.provisioned_instances == original_data
-
-    # -------------------------------------------------------------------------
-    # Error handling - malformed data
-    # -------------------------------------------------------------------------
+        assert range_obj.provisioned_instances == original
 
     def test_skips_instances_without_uuid_key(self):
-        """Method skips instances that don't have a uuid key."""
-        malformed = {"role": "attacker", "private_ip": "10.1.1.10"}  # no uuid
-        valid = {"uuid": "valid-uuid", "role": "victim", "private_ip": "10.1.1.20"}
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[malformed, valid],
-        )
-
-        result = range_obj.get_instance_by_uuid("valid-uuid")
-
-        assert result == valid
+        malformed = {"role": "attacker"}
+        valid = {"uuid": "valid-uuid", "role": "victim"}
+        assert self._range([malformed, valid]).get_instance_by_uuid("valid-uuid") == valid
 
     def test_returns_none_when_all_instances_malformed(self):
-        """Method returns None when no instances have uuid key."""
-        malformed1 = {"role": "attacker", "private_ip": "10.1.1.10"}
-        malformed2 = {"role": "victim", "private_ip": "10.1.1.20"}
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[malformed1, malformed2],
-        )
-
-        result = range_obj.get_instance_by_uuid("any-uuid")
-
-        assert result is None
-
-    # -------------------------------------------------------------------------
-    # Boundary conditions
-    # -------------------------------------------------------------------------
-
-    def test_handles_single_instance(self):
-        """Method works correctly with single instance in list."""
-        instance = {"uuid": "only-one", "role": "attacker"}
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[instance],
-        )
-
-        result = range_obj.get_instance_by_uuid("only-one")
-
-        assert result == instance
-
-    def test_handles_many_instances(self):
-        """Method finds instance in large list."""
-        instances = [{"uuid": f"uuid-{i}", "role": "victim"} for i in range(100)]
-        target = {"uuid": "target-uuid", "role": "attacker"}
-        instances.insert(50, target)
-
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=instances,
-        )
-
-        result = range_obj.get_instance_by_uuid("target-uuid")
-
-        assert result == target
+        assert self._range([{"role": "attacker"}, {"role": "victim"}]).get_instance_by_uuid("any") is None
 
     def test_case_sensitive_uuid_match(self):
-        """Method performs case-sensitive UUID matching."""
-        instance = {"uuid": "ABC-123", "role": "attacker"}
-        range_obj = Range(
-            user_id=1,
-            status=Range.Status.READY,
-            provisioned_instances=[instance],
-        )
-
-        result = range_obj.get_instance_by_uuid("abc-123")
-
-        assert result is None  # lowercase doesn't match uppercase
+        assert self._range([{"uuid": "ABC-123", "role": "attacker"}]).get_instance_by_uuid("abc-123") is None

--- a/shifter/shifter_platform/tests/mission_control/test_engine_services.py
+++ b/shifter/shifter_platform/tests/mission_control/test_engine_services.py
@@ -1,563 +1,127 @@
-"""Tests for engine service functions.
+"""Behavior tests for engine service functions (create_range / get_range_status).
 
-Tests verify service layer behavior with mocked model layer.
+Drives the real engine.services API against a real database: create_range
+interprets a RequestSpec, persists Range/Subnet rows, allocates a subnet index,
+and dispatches ECS provisioning (a no-op under the unconfigured test settings).
+Assertions are on persisted state and return values, not on mocked ORM calls.
 """
 
 import logging
-from contextlib import nullcontext
-from unittest.mock import Mock, patch
+from uuid import uuid4
 
 import pytest
+from django.contrib.auth import get_user_model
+
+from engine import create_range, get_range_status
+from engine.models import Range
+from shared.schemas import InstanceSpec, RangeSpec, RequestSpec, SubnetSpec
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
 
 
-class _TestCreateRangeHelpers:
-    """Shared helpers for split TestCreateRange scenarios."""
-
-    @pytest.fixture
-    def valid_request_spec(self):
-        """Return a valid RequestSpec containing a RangeSpec for testing."""
-        from uuid import uuid4
-
-        from shared.schemas import InstanceSpec, RangeSpec, RequestSpec, SubnetSpec
-
-        request_id = uuid4()
-        return RequestSpec(
-            request_id=request_id,
-            user_id=1,
-            items=[
-                RangeSpec(
-                    user_id=1,
-                    scenario_id="test-scenario",
-                    subnets=[
-                        SubnetSpec(
-                            name="test_network",
-                            uuid=str(uuid4()),
-                            instances=[
-                                InstanceSpec(
-                                    name="attacker-kali",
-                                    uuid="uuid-1",
-                                    role="attacker",
-                                    os_type="kali",
-                                ),
-                                InstanceSpec(
-                                    name="victim-ubuntu",
-                                    uuid="uuid-2",
-                                    role="victim",
-                                    os_type="ubuntu",
-                                ),
-                            ],
-                            connected_to=[],
-                        )
-                    ],
-                )
-            ],
-        )
-
-    @pytest.fixture(autouse=True)
-    def mock_transaction_atomic(self):
-        """Keep these tests unit-level by skipping real DB transaction setup."""
-        with patch("engine.services.transaction.atomic", return_value=nullcontext()):
-            yield
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="engine-svc@example.com", email="engine-svc@example.com")
 
 
-class TestGetResourceStatus:
-    """Tests for get_range_status() in engine/services.py.
+def _request_spec(user_id):
+    return RequestSpec(
+        request_id=uuid4(),
+        user_id=user_id,
+        items=[
+            RangeSpec(
+                user_id=user_id,
+                scenario_id="test-scenario",
+                subnets=[
+                    SubnetSpec(
+                        name="test_network",
+                        uuid=str(uuid4()),
+                        instances=[
+                            InstanceSpec(name="attacker-kali", uuid=str(uuid4()), role="attacker", os_type="kali"),
+                            InstanceSpec(name="victim-ubuntu", uuid=str(uuid4()), role="victim", os_type="ubuntu"),
+                        ],
+                        connected_to=[],
+                    )
+                ],
+            )
+        ],
+    )
 
-    Tests SERVICE behavior with mocked model layer:
-    - Calls Range.objects.get correctly
-    - Returns dict with range_id and status
-    - Logs all errors from downstream
-    - Validates input
-    - Propagates errors
-    """
 
-    # -------------------------------------------------------------------------
-    # Service calls model correctly
-    # -------------------------------------------------------------------------
+class TestGetRangeStatus:
+    def test_returns_status_dict_for_existing_range(self, user):
+        range_obj = Range.objects.create(user=user, status=Range.Status.PROVISIONING)
+        result = get_range_status(range_obj.id)
+        assert isinstance(result, dict)
+        assert result["status"] == Range.Status.PROVISIONING
+        assert set(result) >= {"status", "error_message", "instances", "created_at", "ready_at"}
 
-    def test_calls_range_get_with_range_id(self):
-        """Service queries Range by id."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-        with patch.object(Range.objects, "get", return_value=mock_range) as mock_get:
-            get_range_status(42)
-            mock_get.assert_called_once_with(id=42)
-
-    # -------------------------------------------------------------------------
-    # Service returns correct structure
-    # -------------------------------------------------------------------------
-
-    def test_returns_dict_with_expected_keys(self):
-        """Service returns dict with status, error_message, instances, created_at, ready_at."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(
-            spec=Range,
-            id=42,
-            status=Range.Status.READY,
-            error_message="",
-            provisioned_instances=None,
-            created_at=None,
-            ready_at=None,
-        )
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            result = get_range_status(42)
-            assert isinstance(result, dict)
-            assert "status" in result
-            assert "error_message" in result
-            assert "instances" in result
-            assert "created_at" in result
-            assert "ready_at" in result
-
-    def test_returns_status_value(self):
-        """Service returns status string in dict."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(
-            spec=Range,
-            id=42,
-            status=Range.Status.PROVISIONING,
-            error_message="",
-            provisioned_instances=None,
-            created_at=None,
-            ready_at=None,
-        )
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            result = get_range_status(42)
-            assert result["status"] == Range.Status.PROVISIONING
-
-    def test_returns_ready_status_correctly(self):
-        """Service returns READY status when range is ready."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(
-            spec=Range,
-            id=1,
-            status=Range.Status.READY,
-            error_message="",
-            provisioned_instances=None,
-            created_at=None,
-            ready_at=None,
-        )
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            result = get_range_status(1)
-            assert result["status"] == Range.Status.READY
-
-    def test_returns_failed_status_correctly(self):
-        """Service returns FAILED status when range failed."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(
-            spec=Range,
-            id=1,
-            status=Range.Status.FAILED,
-            error_message="",
-            provisioned_instances=None,
-            created_at=None,
-            ready_at=None,
-        )
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            result = get_range_status(1)
-            assert result["status"] == Range.Status.FAILED
-
-    def test_returns_destroyed_status_correctly(self):
-        """Service returns DESTROYED status for destroyed range."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(
-            spec=Range,
-            id=1,
-            status=Range.Status.DESTROYED,
-            error_message="",
-            provisioned_instances=None,
-            created_at=None,
-            ready_at=None,
-        )
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            result = get_range_status(1)
-            assert result["status"] == Range.Status.DESTROYED
-
-    # -------------------------------------------------------------------------
-    # Logging - DEBUG on success
-    # -------------------------------------------------------------------------
-
-    def test_logs_debug_on_entry(self, caplog):
-        """Service logs debug on entry with range_id."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            caplog.at_level(logging.DEBUG, logger="engine"),
-        ):
-            get_range_status(42)
-        assert "42" in caplog.text
-
-    def test_logs_debug_on_success(self, caplog):
-        """Service logs debug on successful status retrieval."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            caplog.at_level(logging.DEBUG, logger="engine"),
-        ):
-            get_range_status(42)
-        # Should log success with range_id
-        assert "42" in caplog.text
-
-    # -------------------------------------------------------------------------
-    # Logging - ERROR on failures
-    # -------------------------------------------------------------------------
-
-    def test_logs_warning_when_range_not_found(self, caplog):
-        """Service logs warning when range not found and returns None."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        with (
-            patch.object(Range.objects, "get", side_effect=Range.DoesNotExist),
-            caplog.at_level(logging.WARNING, logger="engine"),
-        ):
-            result = get_range_status(999)
-            assert result is None
-        assert "not found" in caplog.text.lower()
-
-    def test_propagates_database_exception(self, caplog):
-        """Service propagates database exceptions."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        with (
-            patch.object(Range.objects, "get", side_effect=RuntimeError("DB connection failed")),
-            pytest.raises(RuntimeError),
-        ):
-            get_range_status(42)
-
-    # -------------------------------------------------------------------------
-    # Error handling - returns None when not found
-    # -------------------------------------------------------------------------
+    def test_reflects_each_status(self, user):
+        for status in (Range.Status.READY, Range.Status.FAILED, Range.Status.DESTROYED):
+            range_obj = Range.objects.create(user=user, status=status)
+            assert get_range_status(range_obj.id)["status"] == status
 
     def test_returns_none_when_range_not_found(self):
-        """Service returns None when range doesn't exist."""
-        from engine import get_range_status
-        from engine.models import Range
+        assert get_range_status(999999) is None
 
-        with patch.object(Range.objects, "get", side_effect=Range.DoesNotExist):
-            result = get_range_status(999)
-            assert result is None
-
-    # -------------------------------------------------------------------------
-    # Error propagation
-    # -------------------------------------------------------------------------
-
-    def test_propagates_model_exception(self):
-        """Service propagates exceptions from model."""
-        from engine import get_range_status
-        from engine.models import Range
-
-        with (
-            patch.object(Range.objects, "get", side_effect=RuntimeError("Model error")),
-            pytest.raises(RuntimeError, match="Model error"),
-        ):
-            get_range_status(42)
-
-    # -------------------------------------------------------------------------
-    # Input validation - range_id parameter
-    # -------------------------------------------------------------------------
+    def test_logs_warning_when_not_found(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="engine"):
+            assert get_range_status(999999) is None
+        assert "not found" in caplog.text.lower()
 
     def test_requires_range_id_argument(self):
-        """Service raises TypeError if range_id not provided."""
-        from engine import get_range_status
-
         with pytest.raises(TypeError):
             get_range_status()
 
-    def test_returns_none_for_nonexistent_range_id(self):
-        """Service returns None if range_id doesn't exist (ORM returns DoesNotExist)."""
-        from engine import get_range_status
-        from engine.models import Range
 
-        with patch.object(Range.objects, "get", side_effect=Range.DoesNotExist):
-            result = get_range_status(99999)
-            assert result is None
+class TestCreateRange:
+    def test_persists_range_and_subnet(self, user):
+        spec = _request_spec(user.id)
+        assert Range.objects.count() == 0
 
-    def test_orm_handles_invalid_range_id_type(self):
-        """ORM raises ValueError for invalid range_id type."""
-        from engine import get_range_status
-        from engine.models import Range
+        result = create_range(spec)
 
-        with (
-            patch.object(Range.objects, "get", side_effect=ValueError("invalid literal")),
-            pytest.raises(ValueError),
-        ):
-            get_range_status("not-an-id")
+        assert result == spec.request_id
+        range_obj = Range.objects.get()
+        assert range_obj.user_id == user.id
+        # A subnet index was allocated.
+        assert range_obj.subnet_index is not None
+        assert range_obj.subnet_index >= Range.SUBNET_INDEX_MIN
 
-    def test_returns_none_for_negative_range_id(self):
-        """Service returns None for negative range_id (no match)."""
-        from engine import get_range_status
-        from engine.models import Range
+    def test_returns_request_id(self, user):
+        spec = _request_spec(user.id)
+        assert create_range(spec) == spec.request_id
 
-        with patch.object(Range.objects, "get", side_effect=Range.DoesNotExist):
-            result = get_range_status(-1)
-            assert result is None
-
-
-class TestCreateRangePersistence(_TestCreateRangeHelpers):
-    """Persistence and provisioning tests for create_range()."""
-
-    def test_creates_range_with_provisioning_status(self, valid_request_spec):
-        """Service creates Range record with PROVISIONING status."""
-        from django.contrib.auth import get_user_model
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_range = Mock(spec=Range, id=42)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range.objects, "create", return_value=mock_range) as mock_create,
-            patch.object(Range, "allocate_subnet_index", return_value=5),
-            patch("engine.ecs.start_range_provisioning", return_value="arn:aws:ecs:test"),
-            patch("engine.models.Subnet"),  # Mock Subnet.objects.filter().update()
-        ):
-            create_range(valid_request_spec)
-            mock_create.assert_called_once()
-            call_kwargs = mock_create.call_args.kwargs
-            assert call_kwargs["status"] == Range.Status.PROVISIONING
-
-    def test_allocates_subnet_index(self, valid_request_spec):
-        """Service calls Range.allocate_subnet_index."""
-        from django.contrib.auth import get_user_model
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_range = Mock(spec=Range, id=42)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range.objects, "create", return_value=mock_range),
-            patch.object(Range, "allocate_subnet_index", return_value=5) as mock_allocate,
-            patch("engine.ecs.start_range_provisioning", return_value="arn:aws:ecs:test"),
-            patch("engine.models.Subnet"),  # Mock Subnet.objects.filter().update()
-        ):
-            create_range(valid_request_spec)
-            mock_allocate.assert_called_once()
-
-    def test_starts_ecs_provisioning(self, valid_request_spec):
-        """Service calls start_range_provisioning with request_id."""
-        from django.contrib.auth import get_user_model
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_range = Mock(spec=Range, id=42)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range.objects, "create", return_value=mock_range),
-            patch.object(Range, "allocate_subnet_index", return_value=5),
-            patch("engine.ecs.start_range_provisioning", return_value="arn:aws:ecs:test") as mock_start,
-            patch("engine.models.Subnet"),  # Mock Subnet.objects.filter().update()
-        ):
-            create_range(valid_request_spec)
-            mock_start.assert_called_once_with(valid_request_spec.request_id)
-
-
-class TestCreateRangeReturnsAndLogging(_TestCreateRangeHelpers):
-    """Return payload and logging tests for create_range()."""
-
-    def test_returns_request_id(self, valid_request_spec):
-        """Service returns request_id UUID."""
-        from django.contrib.auth import get_user_model
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_range = Mock(spec=Range, id=42)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range.objects, "create", return_value=mock_range),
-            patch.object(Range, "allocate_subnet_index", return_value=5),
-            patch("engine.ecs.start_range_provisioning", return_value="arn:aws:ecs:test"),
-            patch("engine.models.Subnet"),  # Mock Subnet.objects.filter().update()
-        ):
-            result = create_range(valid_request_spec)
-            assert result == valid_request_spec.request_id
-
-    def test_logs_debug_on_entry(self, valid_request_spec, caplog):
-        """Service logs debug on entry with range_config info."""
-        from django.contrib.auth import get_user_model
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_range = Mock(spec=Range, id=42)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range.objects, "create", return_value=mock_range),
-            patch.object(Range, "allocate_subnet_index", return_value=5),
-            patch("engine.ecs.start_range_provisioning", return_value="arn:aws:ecs:test"),
-            patch("engine.models.Subnet"),  # Mock Subnet.objects.filter().update()
-            caplog.at_level(logging.DEBUG, logger="engine"),
-        ):
-            create_range(valid_request_spec)
-
+    def test_logs_range_creation(self, user, caplog):
+        spec = _request_spec(user.id)
+        with caplog.at_level(logging.INFO, logger="engine"):
+            create_range(spec)
         assert "create_range" in caplog.text
 
-    def test_logs_info_on_range_created(self, valid_request_spec, caplog):
-        """Service logs info when range is created."""
-        from django.contrib.auth import get_user_model
+    def test_allocates_distinct_indices_for_concurrent_ranges(self, user, db, django_user_model):
+        other = django_user_model.objects.create_user(username="engine-svc2@example.com", email="e2@example.com")
+        create_range(_request_spec(user.id))
+        create_range(_request_spec(other.id))
+        indices = sorted(Range.objects.values_list("subnet_index", flat=True))
+        assert len(indices) == 2
+        assert indices[0] != indices[1]
 
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_range = Mock(spec=Range, id=42)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range.objects, "create", return_value=mock_range),
-            patch.object(Range, "allocate_subnet_index", return_value=5),
-            patch("engine.ecs.start_range_provisioning", return_value="arn:aws:ecs:test"),
-            patch("engine.models.Subnet"),  # Mock Subnet.objects.filter().update()
-            caplog.at_level(logging.INFO, logger="engine"),
-        ):
-            create_range(valid_request_spec)
-
-        assert "42" in caplog.text
-
-
-class TestCreateRangeErrorValidation(_TestCreateRangeHelpers):
-    """Error and input validation tests for create_range()."""
-
-    def test_propagates_subnet_allocation_error(self, valid_request_spec):
-        """Service propagates ValueError from subnet allocation."""
-        from django.contrib.auth import get_user_model
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(
-                Range,
-                "allocate_subnet_index",
-                side_effect=ValueError("No subnets available"),
-            ),
-            pytest.raises(ValueError, match="No subnets available"),
-        ):
-            create_range(valid_request_spec)
-
-    def test_propagates_database_error(self, valid_request_spec):
-        """Service propagates DatabaseError from Range.create."""
-        from django.contrib.auth import get_user_model
-        from django.db import DatabaseError
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range, "allocate_subnet_index", return_value=5),
-            patch.object(Range.objects, "create", side_effect=DatabaseError("DB error")),
-            pytest.raises(DatabaseError),
-        ):
-            create_range(valid_request_spec)
-
-    def test_propagates_ecs_client_error(self, valid_request_spec):
-        """Service propagates ClientError from ECS."""
-        from botocore.exceptions import ClientError
-        from django.contrib.auth import get_user_model
-
-        from engine import create_range
-        from engine.models import Range, Request
-
-        User = get_user_model()
-        mock_user = Mock(id=1)
-        mock_range = Mock(spec=Range, id=42)
-        mock_request = Mock(spec=Request)
-
-        with (
-            patch.object(User.objects, "get", return_value=mock_user),
-            patch("engine.interpreter.interpret", return_value=mock_request),
-            patch.object(Range.objects, "create", return_value=mock_range),
-            patch.object(Range, "allocate_subnet_index", return_value=5),
-            patch(
-                "engine.ecs.start_range_provisioning",
-                side_effect=ClientError(
-                    {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
-                    "RunTask",
-                ),
-            ),
-            patch("engine.models.Subnet"),  # Mock Subnet.objects.filter().update()
-            pytest.raises(ClientError),
-        ):
-            create_range(valid_request_spec)
+    def test_propagates_subnet_exhaustion(self, user, monkeypatch):
+        monkeypatch.setattr(Range, "SUBNET_INDEX_MAX", 1)
+        create_range(_request_spec(user.id))  # consumes index 1
+        with pytest.raises(ValueError, match="No subnet indices available"):
+            create_range(_request_spec(user.id))
 
     def test_raises_on_none_request(self):
-        """Service raises error if request is None."""
-        from engine import create_range
-
         with pytest.raises(TypeError):
             create_range(None)
 
-    def test_raises_on_non_requestspec_request(self):
-        """Service raises TypeError if request is not a RequestSpec."""
-        from engine import create_range
-
+    def test_raises_on_non_requestspec(self):
         with pytest.raises(TypeError, match="must be RequestSpec"):
             create_range("not a RequestSpec")
 
     def test_raises_on_dict_instead_of_requestspec(self):
-        """Service raises TypeError if dict passed instead of RequestSpec."""
-        from engine import create_range
-
         with pytest.raises(TypeError, match="must be RequestSpec"):
             create_range({"user_id": 1, "scenario_id": "test"})

--- a/shifter/shifter_platform/tests/mission_control/test_engine_services_lifecycle.py
+++ b/shifter/shifter_platform/tests/mission_control/test_engine_services_lifecycle.py
@@ -1,452 +1,99 @@
-"""Tests for engine service functions.
+"""Behavior tests for engine range lifecycle services (destroy_range / cancel_range).
 
-Tests verify service layer behavior with mocked model layer.
+Drives the real services against real ``Range`` rows and asserts the persisted
+status transition and return value. ECS teardown is unconfigured under test
+settings, so it is a no-op and needs no boundary mock.
 """
 
 import logging
-from contextlib import nullcontext
-from unittest.mock import Mock, patch
+from uuid import uuid4
 
 import pytest
+from django.contrib.auth import get_user_model
+
+from engine import cancel_range, destroy_range
+from engine.models import Range
+from shared.enums import ResourceStatus
+from shared.schemas import RangeContext
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
 
 
-class _TestCreateRangeHelpers:
-    """Shared helpers for split TestCreateRange scenarios."""
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="lifecycle@example.com", email="lifecycle@example.com")
 
-    @pytest.fixture
-    def valid_request_spec(self):
-        """Return a valid RequestSpec containing a RangeSpec for testing."""
-        from uuid import uuid4
 
-        from shared.schemas import InstanceSpec, RangeSpec, RequestSpec, SubnetSpec
-
-        request_id = uuid4()
-        return RequestSpec(
-            request_id=request_id,
-            user_id=1,
-            items=[
-                RangeSpec(
-                    user_id=1,
-                    scenario_id="test-scenario",
-                    subnets=[
-                        SubnetSpec(
-                            name="test_network",
-                            uuid=str(uuid4()),
-                            instances=[
-                                InstanceSpec(
-                                    name="attacker-kali",
-                                    uuid="uuid-1",
-                                    role="attacker",
-                                    os_type="kali",
-                                ),
-                                InstanceSpec(
-                                    name="victim-ubuntu",
-                                    uuid="uuid-2",
-                                    role="victim",
-                                    os_type="ubuntu",
-                                ),
-                            ],
-                            connected_to=[],
-                        )
-                    ],
-                )
-            ],
-        )
-
-    @pytest.fixture(autouse=True)
-    def mock_transaction_atomic(self):
-        """Keep these tests unit-level by skipping real DB transaction setup."""
-        with patch("engine.services.transaction.atomic", return_value=nullcontext()):
-            yield
+def _ctx(*, range_id, user_id, status=ResourceStatus.READY):
+    return RangeContext(
+        request_id=uuid4(),
+        range_id=range_id,
+        user_id=user_id,
+        scenario_id="test-scenario",
+        status=status,
+        instances=[],
+    )
 
 
 class TestDestroyRange:
-    """Tests for destroy_range() in engine/services.py.
+    def test_sets_status_to_destroying_and_returns_true(self, user):
+        range_obj = Range.objects.create(user=user, status=Range.Status.READY)
+        result = destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+        assert result is True
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
 
-    Tests SERVICE behavior:
-    - Takes RangeContext parameter
-    - Fetches Range and verifies it's in destroyable state
-    - Updates Range status to DESTROYING
-    - Starts ECS teardown task
-    - Returns bool indicating success
-    """
-
-    # -------------------------------------------------------------------------
-    # Valid RangeContext fixture
-    # -------------------------------------------------------------------------
-
-    @pytest.fixture
-    def range_context(self):
-        """Return a valid RangeContext for testing."""
-        from uuid import uuid4
-
-        from shared.enums import ResourceStatus
-        from shared.schemas import RangeContext
-
-        return RangeContext(
-            request_id=uuid4(),
-            range_id=42,
-            user_id=1,
-            scenario_id="test-scenario",
-            status=ResourceStatus.READY,
-            instances=[],
-        )
-
-    # -------------------------------------------------------------------------
-    # Service updates Range correctly
-    # -------------------------------------------------------------------------
-
-    def test_sets_status_to_destroying(self, range_context):
-        """Service sets Range status to DESTROYING."""
-        from engine import destroy_range
-        from engine.models import Range
-        from shared.enums import ResourceStatus
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            patch("engine.ecs.start_teardown", return_value="arn:aws:ecs:test"),
-        ):
-            destroy_range(range_context)
-            assert mock_range.status == ResourceStatus.DESTROYING.value
-            mock_range.save.assert_called()
-
-    def test_calls_range_get_with_range_id(self, range_context):
-        """Service queries Range by id."""
-        from engine import destroy_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range) as mock_get,
-            patch("engine.ecs.start_teardown", return_value="arn:aws:ecs:test"),
-        ):
-            destroy_range(range_context)
-            mock_get.assert_called_once_with(id=42)
-
-    def test_starts_ecs_teardown(self, range_context):
-        """Service calls start_teardown with range_id and user_id."""
-        from engine import destroy_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            patch("engine.ecs.start_teardown", return_value="arn:aws:ecs:test") as mock_teardown,
-        ):
-            destroy_range(range_context)
-            mock_teardown.assert_called_once_with(42, 1)
-
-    def test_returns_true_on_success(self, range_context):
-        """Service returns True on success."""
-        from engine import destroy_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            patch("engine.ecs.start_teardown", return_value="arn:aws:ecs:test"),
-        ):
-            result = destroy_range(range_context)
-            assert result is True
-
-    # -------------------------------------------------------------------------
-    # Logging - DEBUG on success
-    # -------------------------------------------------------------------------
-
-    def test_logs_debug_on_entry(self, range_context, caplog):
-        """Service logs debug on entry with range_id."""
-        from engine import destroy_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            patch("engine.ecs.start_teardown", return_value="arn:aws:ecs:test"),
-            caplog.at_level(logging.DEBUG, logger="engine"),
-        ):
-            destroy_range(range_context)
-
-        assert "42" in caplog.text
-
-    # -------------------------------------------------------------------------
-    # Returns False for non-destroyable states (doesn't raise)
-    # -------------------------------------------------------------------------
-
-    def test_returns_false_when_range_not_found(self, range_context, caplog):
-        """Service returns False and logs warning when range not found."""
-        from engine import destroy_range
-        from engine.models import Range
-
-        with (
-            caplog.at_level(logging.WARNING, logger="engine"),
-            patch.object(Range.objects, "get", side_effect=Range.DoesNotExist),
-        ):
-            result = destroy_range(range_context)
-            assert result is False
+    def test_returns_false_when_range_not_found(self, user, caplog):
+        with caplog.at_level(logging.WARNING, logger="engine"):
+            result = destroy_range(_ctx(range_id=999999, user_id=user.id))
+        assert result is False
         assert "not found" in caplog.text.lower()
 
-    def test_returns_false_when_range_already_destroyed(self, range_context, caplog):
-        """Service returns False when range already destroyed."""
-        from engine import destroy_range
-        from engine.models import Range
-        from shared.enums import ResourceStatus
-
-        mock_range = Mock(spec=Range, id=42, status=ResourceStatus.DESTROYED)
-
-        with (
-            caplog.at_level(logging.WARNING, logger="engine"),
-            patch.object(Range.objects, "get", return_value=mock_range),
-        ):
-            result = destroy_range(range_context)
-            assert result is False
+    def test_returns_false_when_already_destroyed(self, user, caplog):
+        range_obj = Range.objects.create(user=user, status=Range.Status.DESTROYED)
+        with caplog.at_level(logging.WARNING, logger="engine"):
+            result = destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+        assert result is False
         assert "already destroyed" in caplog.text.lower()
 
-    def test_returns_true_when_range_already_destroying(self, range_context, caplog):
-        """Service returns True (idempotent) when range already being destroyed."""
-        from engine import destroy_range
-        from engine.models import Range
-        from shared.enums import ResourceStatus
-
-        mock_range = Mock(spec=Range, id=42, status=ResourceStatus.DESTROYING)
-
-        with (
-            caplog.at_level(logging.INFO, logger="engine"),
-            patch.object(Range.objects, "get", return_value=mock_range),
-        ):
-            result = destroy_range(range_context)
-            assert result is True
+    def test_idempotent_when_already_destroying(self, user, caplog):
+        range_obj = Range.objects.create(user=user, status=Range.Status.DESTROYING)
+        with caplog.at_level(logging.INFO, logger="engine"):
+            result = destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+        assert result is True
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
         assert "already destroying" in caplog.text.lower()
 
-    # -------------------------------------------------------------------------
-    # Error propagation
-    # -------------------------------------------------------------------------
-
-    def test_propagates_ecs_client_error(self, range_context):
-        """Service propagates ClientError from ECS."""
-        from botocore.exceptions import ClientError
-
-        from engine import destroy_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            patch(
-                "engine.ecs.start_teardown",
-                side_effect=ClientError(
-                    {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
-                    "RunTask",
-                ),
-            ),
-            pytest.raises(ClientError),
-        ):
-            destroy_range(range_context)
+    def test_logs_range_id_on_entry(self, user, caplog):
+        range_obj = Range.objects.create(user=user, status=Range.Status.READY)
+        with caplog.at_level(logging.DEBUG, logger="engine"):
+            destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+        assert str(range_obj.id) in caplog.text
 
 
 class TestCancelRange:
-    """Tests for cancel_range() in engine/services.py.
+    def test_cancels_pending_range(self, user):
+        range_obj = Range.objects.create(user=user, status=Range.Status.PENDING)
+        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PENDING))
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
 
-    Tests SERVICE behavior:
-    - Takes RangeContext parameter with input validation
-    - Fetches Range and verifies it's in cancellable state
-    - Updates Range status to DESTROYING
-    - Returns silently for non-cancellable states (doesn't raise)
-    """
+    def test_cancels_provisioning_range(self, user):
+        range_obj = Range.objects.create(user=user, status=Range.Status.PROVISIONING)
+        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PROVISIONING))
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
 
-    # -------------------------------------------------------------------------
-    # Valid RangeContext fixtures
-    # -------------------------------------------------------------------------
+    def test_does_not_cancel_ready_range(self, user):
+        range_obj = Range.objects.create(user=user, status=Range.Status.READY)
+        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.READY))
+        range_obj.refresh_from_db()
+        # READY is not cancellable; status is unchanged.
+        assert range_obj.status == Range.Status.READY
 
-    @pytest.fixture
-    def pending_range_context(self):
-        """Return a RangeContext for a pending range."""
-        from uuid import uuid4
-
-        from shared.enums import ResourceStatus
-        from shared.schemas import RangeContext
-
-        return RangeContext(
-            request_id=uuid4(),
-            range_id=42,
-            user_id=1,
-            scenario_id="test-scenario",
-            status=ResourceStatus.PENDING,
-            instances=[],
-        )
-
-    @pytest.fixture
-    def provisioning_range_context(self):
-        """Return a RangeContext for a provisioning range."""
-        from uuid import uuid4
-
-        from shared.enums import ResourceStatus
-        from shared.schemas import RangeContext
-
-        return RangeContext(
-            request_id=uuid4(),
-            range_id=42,
-            user_id=1,
-            scenario_id="test-scenario",
-            status=ResourceStatus.PROVISIONING,
-            instances=[],
-        )
-
-    @pytest.fixture
-    def ready_range_context(self):
-        """Return a RangeContext for a ready range (not cancellable)."""
-        from uuid import uuid4
-
-        from shared.enums import ResourceStatus
-        from shared.schemas import RangeContext
-
-        return RangeContext(
-            request_id=uuid4(),
-            range_id=42,
-            user_id=1,
-            scenario_id="test-scenario",
-            status=ResourceStatus.READY,
-            instances=[],
-        )
-
-    # -------------------------------------------------------------------------
-    # Service updates Range correctly
-    # -------------------------------------------------------------------------
-
-    def test_sets_status_to_destroying(self, provisioning_range_context):
-        """Service sets Range status to DESTROYING when cancelling."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.PROVISIONING)
-
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            cancel_range(provisioning_range_context)
-            assert mock_range.status == Range.Status.DESTROYING
-            mock_range.save.assert_called()
-
-    def test_calls_range_get_with_range_id(self, pending_range_context):
-        """Service queries Range by id."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.PENDING)
-
-        with patch.object(Range.objects, "get", return_value=mock_range) as mock_get:
-            cancel_range(pending_range_context)
-            mock_get.assert_called_once_with(id=42)
-
-    def test_cancels_pending_range(self, pending_range_context):
-        """Service can cancel a PENDING range."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.PENDING)
-
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            cancel_range(pending_range_context)
-            assert mock_range.status == Range.Status.DESTROYING
-
-    def test_cancels_provisioning_range(self, provisioning_range_context):
-        """Service can cancel a PROVISIONING range."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.PROVISIONING)
-
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            cancel_range(provisioning_range_context)
-            assert mock_range.status == Range.Status.DESTROYING
-
-    def test_returns_none(self, pending_range_context):
-        """Service returns None on success."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.PENDING)
-
-        with patch.object(Range.objects, "get", return_value=mock_range):
-            result = cancel_range(pending_range_context)
-            assert result is None
-
-    # -------------------------------------------------------------------------
-    # Logging - DEBUG on success
-    # -------------------------------------------------------------------------
-
-    def test_logs_debug_on_entry(self, pending_range_context, caplog):
-        """Service logs debug on entry with range_id."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.PENDING)
-
-        with (
-            patch.object(Range.objects, "get", return_value=mock_range),
-            caplog.at_level(logging.DEBUG, logger="engine"),
-        ):
-            cancel_range(pending_range_context)
-
-        assert "42" in caplog.text
-
-    # -------------------------------------------------------------------------
-    # Returns silently for non-cancellable states (doesn't raise)
-    # -------------------------------------------------------------------------
-
-    def test_returns_silently_when_range_not_found(self, pending_range_context, caplog):
-        """Service returns silently and logs warning when range not found."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        with (
-            caplog.at_level(logging.WARNING, logger="engine"),
-            patch.object(Range.objects, "get", side_effect=Range.DoesNotExist),
-        ):
-            result = cancel_range(pending_range_context)
-            assert result is None
-        assert "not found" in caplog.text.lower()
-
-    def test_returns_silently_when_range_not_cancellable(self, ready_range_context, caplog):
-        """Service returns silently and logs warning when range is not cancellable."""
-        from engine import cancel_range
-        from engine.models import Range
-
-        mock_range = Mock(spec=Range, id=42, status=Range.Status.READY)
-
-        with (
-            caplog.at_level(logging.WARNING, logger="engine"),
-            patch.object(Range.objects, "get", return_value=mock_range),
-        ):
-            result = cancel_range(ready_range_context)
-            assert result is None
-        assert "not cancellable" in caplog.text.lower()
-
-    # -------------------------------------------------------------------------
-    # Input validation
-    # -------------------------------------------------------------------------
-
-    def test_raises_on_none_range_context(self):
-        """Service raises TypeError if range_ctx is None."""
-        from engine import cancel_range
-
-        with pytest.raises(TypeError, match="cannot be None"):
-            cancel_range(None)
-
-    def test_raises_on_invalid_range_context_type(self):
-        """Service raises TypeError if range_ctx is not a RangeContext."""
-        from engine import cancel_range
-
-        with pytest.raises(TypeError, match="must be RangeContext"):
-            cancel_range("not a RangeContext")
-
-    def test_raises_on_int_instead_of_range_context(self):
-        """Service raises TypeError if int passed instead of RangeContext."""
-        from engine import cancel_range
-
-        with pytest.raises(TypeError, match="must be RangeContext"):
-            cancel_range(42)
+    def test_cancel_missing_range_is_silent(self, user):
+        # No row exists; cancel returns without raising.
+        cancel_range(_ctx(range_id=999999, user_id=user.id, status=ResourceStatus.PENDING))

--- a/shifter/shifter_platform/tests/mission_control/test_handlers.py
+++ b/shifter/shifter_platform/tests/mission_control/test_handlers.py
@@ -1,435 +1,171 @@
-"""Tests for Mission Control handlers."""
+"""Behavior tests for Mission Control SNS->WebSocket handlers.
 
+Drives the handlers against the real in-memory Django Channels layer: a test
+channel subscribes to the expected group, the handler runs, and the broadcast
+is received and asserted. The channel layer is the real external transport
+boundary, so nothing first-party is patched.
+"""
+
+import asyncio
 import json
-import logging
-from unittest.mock import MagicMock, patch
-from uuid import UUID
+from uuid import uuid4
 
+import pytest
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from mission_control.handlers import (
+    EVENT_TYPE_NGFW,
+    parse_sns_message,
+    process_event,
+    process_ngfw_event,
+    process_range_event,
+)
+from shared.channels.groups import ngfw_event_group, range_event_group
 from shared.enums import ResourceStatus
 
-# Test UUID for request_id
-TEST_REQUEST_ID = UUID("12345678-1234-5678-1234-567812345678")
+
+def _sns(payload):
+    return {"Message": json.dumps(payload)}
 
 
-class TestProcessEvent:
-    """Tests for process_event dispatcher."""
+@pytest.fixture(autouse=True)
+def _flush_channel_layer():
+    layer = get_channel_layer()
+    async_to_sync(layer.flush)()
+    yield
+    async_to_sync(layer.flush)()
 
-    def test_routes_range_events_to_range_handler(self):
-        """Dispatcher routes range.* events to process_range_event."""
-        from mission_control.handlers import process_event
 
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.status.updated",
-                    "range_id": 1,
-                    "user_id": 42,
-                }
-            )
-        }
+def _subscribe(group):
+    layer = get_channel_layer()
+    channel = f"recv-{uuid4()}"
+    async_to_sync(layer.group_add)(group, channel)
+    return layer, channel
 
-        with patch("mission_control.handlers.process_range_event") as mock_range_handler:
-            process_event(message)
-            mock_range_handler.assert_called_once_with(message)
 
-    def test_routes_ngfw_events_to_ngfw_handler(self):
-        """Dispatcher routes ngfw.* events to process_ngfw_event."""
-        from mission_control.handlers import process_event
+def _receive(layer, channel, timeout=0.2):
+    async def _r():
+        try:
+            return await asyncio.wait_for(layer.receive(channel), timeout)
+        except TimeoutError:
+            return None
 
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "ngfw.status.updated",
-                    "ngfw_id": 1,
-                    "user_id": 42,
-                }
-            )
-        }
-
-        with patch("mission_control.handlers.process_ngfw_event") as mock_ngfw_handler:
-            process_event(message)
-            mock_ngfw_handler.assert_called_once_with(message)
-
-    def test_ignores_unknown_event_types(self):
-        """Dispatcher ignores events with unknown event_type prefix."""
-        from mission_control.handlers import process_event
-
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "unknown.event",
-                    "some_id": 1,
-                }
-            )
-        }
-
-        with (
-            patch("mission_control.handlers.process_range_event") as mock_range_handler,
-            patch("mission_control.handlers.process_ngfw_event") as mock_ngfw_handler,
-            patch("mission_control.handlers.logger") as mock_logger,
-        ):
-            process_event(message)
-            mock_range_handler.assert_not_called()
-            mock_ngfw_handler.assert_not_called()
-            mock_logger.debug.assert_called_once()
-            assert "unknown" in str(mock_logger.debug.call_args)
-
-    def test_handles_missing_event_type(self, caplog):
-        """Dispatcher handles messages without event_type gracefully."""
-        from mission_control.handlers import process_event
-
-        message = {"Message": json.dumps({"range_id": 1})}
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="mission_control.handlers"),
-            patch("mission_control.handlers.process_range_event") as mock_range_handler,
-            patch("mission_control.handlers.process_ngfw_event") as mock_ngfw_handler,
-        ):
-            process_event(message)
-            mock_range_handler.assert_not_called()
-            mock_ngfw_handler.assert_not_called()
+    return async_to_sync(_r)()
 
 
 class TestParseSnsMessage:
-    """Tests for parse_sns_message helper."""
-
-    def test_parses_sns_wrapped_message(self):
-        """Function unwraps SNS envelope to get event payload."""
-        from mission_control.handlers import parse_sns_message
-
-        sns_message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.status.updated",
-                    "range_id": 1,
-                    "user_id": 42,
-                }
-            )
-        }
-
-        result = parse_sns_message(sns_message)
-
+    def test_unwraps_sns_envelope(self):
+        result = parse_sns_message(_sns({"event_type": "range.status.updated", "range_id": 1, "user_id": 42}))
         assert result["event_type"] == "range.status.updated"
         assert result["range_id"] == 1
         assert result["user_id"] == 42
 
     def test_parses_string_input(self):
-        """Function parses string JSON input."""
-        from mission_control.handlers import parse_sns_message
-
-        sns_message = json.dumps(
-            {
-                "Message": json.dumps(
-                    {
-                        "event_type": "range.status.updated",
-                        "range_id": 1,
-                    }
-                )
-            }
-        )
-
-        result = parse_sns_message(sns_message)
-
+        result = parse_sns_message(json.dumps(_sns({"event_type": "range.status.updated", "range_id": 1})))
         assert result["event_type"] == "range.status.updated"
         assert result["range_id"] == 1
 
     def test_handles_non_wrapped_message(self):
-        """Function handles direct event payload (no SNS wrapper)."""
-        from mission_control.handlers import parse_sns_message
-
-        direct_message = {
-            "event_type": "range.status.updated",
-            "range_id": 1,
-            "user_id": 42,
-        }
-
-        result = parse_sns_message(direct_message)
-
+        result = parse_sns_message({"event_type": "range.status.updated", "range_id": 1})
         assert result["event_type"] == "range.status.updated"
-        assert result["range_id"] == 1
 
 
 class TestProcessRangeEvent:
-    """Tests for process_range_event handler."""
+    def test_broadcasts_status_update_to_request_group(self):
+        request_id = uuid4()
+        group = range_event_group(str(request_id))
+        layer, channel = _subscribe(group)
 
-    # ---------------------------------------------------------------------
-    # Happy path - broadcast to channel layer
-    # ---------------------------------------------------------------------
-
-    def test_broadcasts_status_update_to_channel_layer(self):
-        """Handler broadcasts status update to Django Channels group."""
-        from mission_control.handlers import process_range_event
-
-        message = {
-            "Message": json.dumps(
+        process_range_event(
+            _sns(
                 {
                     "event_type": "range.status.updated",
-                    "request_id": str(TEST_REQUEST_ID),
-                    "range_id": 1,
+                    "request_id": str(request_id),
                     "new_status": ResourceStatus.PROVISIONING.value,
                     "user_id": 42,
                 }
             )
-        }
+        )
 
-        with patch("mission_control.handlers.async_to_sync") as mock_async_to_sync:
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
+        msg = _receive(layer, channel)
+        assert msg is not None
+        assert msg["type"] == "range.status"
+        assert msg["request_id"] == str(request_id)
+        assert msg["new_status"] == ResourceStatus.PROVISIONING.value
+        assert msg["error_message"] is None
 
-            process_range_event(message)
-
-            # Verify async_to_sync was called with group_send
-            mock_async_to_sync.assert_called_once()
-
-            # Verify the sync wrapper was called with correct args
-            mock_send.assert_called_once()
-            args, _ = mock_send.call_args
-
-            # Verify group name uses request_id
-            assert args[0] == f"range_status_{TEST_REQUEST_ID}"
-
-            # Verify message content uses request_id
-            sent_message = args[1]
-            assert sent_message["type"] == "range.status"
-            assert sent_message["request_id"] == str(TEST_REQUEST_ID)
-            assert sent_message["new_status"] == ResourceStatus.PROVISIONING.value
-
-    def test_broadcasts_error_message_when_present(self):
-        """Handler includes error_message in broadcast when present."""
-        from mission_control.handlers import process_range_event
-
-        message = {
-            "Message": json.dumps(
+    def test_includes_error_message_when_present(self):
+        request_id = uuid4()
+        layer, channel = _subscribe(range_event_group(str(request_id)))
+        process_range_event(
+            _sns(
                 {
                     "event_type": "range.status.updated",
-                    "request_id": str(TEST_REQUEST_ID),
-                    "range_id": 2,
+                    "request_id": str(request_id),
                     "new_status": ResourceStatus.FAILED.value,
-                    "user_id": 42,
                     "error_message": "Subnet exhausted",
                 }
             )
-        }
-
-        with patch("mission_control.handlers.async_to_sync") as mock_async_to_sync:
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
-
-            process_range_event(message)
-
-            # Verify error_message included
-            args, _ = mock_send.call_args
-            sent_message = args[1]
-            assert sent_message["error_message"] == "Subnet exhausted"
-
-    def test_broadcasts_null_error_message_when_not_present(self):
-        """Handler includes null error_message when not in event."""
-        from mission_control.handlers import process_range_event
-
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.status.updated",
-                    "request_id": str(TEST_REQUEST_ID),
-                    "range_id": 3,
-                    "new_status": ResourceStatus.READY.value,
-                    "user_id": 42,
-                }
-            )
-        }
-
-        with patch("mission_control.handlers.async_to_sync") as mock_async_to_sync:
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
-
-            process_range_event(message)
-
-            # Verify error_message is None
-            args, _ = mock_send.call_args
-            sent_message = args[1]
-            assert sent_message["error_message"] is None
-
-    # ---------------------------------------------------------------------
-    # Event filtering
-    # ---------------------------------------------------------------------
+        )
+        assert _receive(layer, channel)["error_message"] == "Subnet exhausted"
 
     def test_ignores_non_status_events(self):
-        """Handler ignores events that are not range.status.updated."""
-        from mission_control.handlers import process_range_event
+        request_id = uuid4()
+        layer, channel = _subscribe(range_event_group(str(request_id)))
+        process_range_event(_sns({"event_type": "range.provisioned", "request_id": str(request_id)}))
+        assert _receive(layer, channel) is None
 
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.provisioned",
-                    "range_id": 4,
-                    "user_id": 42,
-                }
-            )
-        }
+    def test_does_not_broadcast_when_request_id_missing(self):
+        # Subscribe broadly is not possible without a request_id group; assert the
+        # handler returns without raising and emits nothing on a fresh channel.
+        layer = get_channel_layer()
+        channel = f"recv-{uuid4()}"
+        async_to_sync(layer.group_add)("range_status_unknown", channel)
+        process_range_event(_sns({"event_type": "range.status.updated", "new_status": "ready"}))
+        assert _receive(layer, channel) is None
 
-        with patch("mission_control.handlers.async_to_sync") as mock_async_to_sync:
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
 
-            process_range_event(message)
+class TestProcessNgfwEvent:
+    def test_broadcasts_to_app_group(self):
+        app_id = str(uuid4())
+        layer, channel = _subscribe(ngfw_event_group(app_id))
+        process_ngfw_event(_sns({"event_type": EVENT_TYPE_NGFW, "app_id": app_id, "status": "ready"}))
+        msg = _receive(layer, channel)
+        assert msg is not None
+        assert msg["type"] == "ngfw.status"
+        assert msg["app_id"] == app_id
+        assert msg["status"] == "ready"
 
-            # Should NOT have broadcast (async_to_sync not called)
-            mock_async_to_sync.assert_not_called()
+    def test_ignores_invalid_app_id(self):
+        layer, channel = _subscribe(ngfw_event_group("x"))
+        process_ngfw_event(_sns({"event_type": EVENT_TYPE_NGFW, "app_id": None}))
+        assert _receive(layer, channel) is None
 
-    # ---------------------------------------------------------------------
-    # Logging
-    # ---------------------------------------------------------------------
 
-    def test_logs_info_on_successful_broadcast(self):
-        """Handler logs INFO when broadcast succeeds."""
-        from mission_control.handlers import process_range_event
-
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.status.updated",
-                    "request_id": str(TEST_REQUEST_ID),
-                    "range_id": 5,
-                    "new_status": ResourceStatus.PROVISIONING.value,
-                    "user_id": 42,
-                }
-            )
-        }
-
-        with (
-            patch("mission_control.handlers.async_to_sync") as mock_async_to_sync,
-            patch("mission_control.handlers.logger") as mock_logger,
-        ):
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
-
-            process_range_event(message)
-
-        # Verify logger.info was called with expected content
-        mock_logger.info.assert_called_once()
-        call_args = mock_logger.info.call_args[0]
-        assert "MC broadcast to group" in call_args[0]
-        assert f"range_status_{TEST_REQUEST_ID}" in call_args[1]
-        assert call_args[2] == str(TEST_REQUEST_ID)  # request_id
-
-    def test_logs_debug_on_event_ignore(self):
-        """Handler logs DEBUG when ignoring non-status events."""
-        from mission_control.handlers import process_range_event
-
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.destroyed",
-                    "request_id": str(TEST_REQUEST_ID),
-                    "range_id": 1,
-                    "user_id": 42,
-                }
-            )
-        }
-
-        with (
-            patch("mission_control.handlers.async_to_sync") as mock_async_to_sync,
-            patch("mission_control.handlers.logger") as mock_logger,
-        ):
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
-
-            process_range_event(message)
-
-        # Verify logger.debug was called with expected content
-        mock_logger.debug.assert_called_once()
-        call_args = mock_logger.debug.call_args[0]
-        assert "Ignoring event_type" in call_args[0]
-        assert call_args[1] == "range.destroyed"
-
-    def test_logs_error_when_request_id_missing(self):
-        """Handler logs ERROR when request_id is missing from event."""
-        from mission_control.handlers import process_range_event
-
-        message = {
-            "Message": json.dumps(
+class TestProcessEventRouting:
+    def test_routes_range_event(self):
+        request_id = uuid4()
+        layer, channel = _subscribe(range_event_group(str(request_id)))
+        process_event(
+            _sns(
                 {
                     "event_type": "range.status.updated",
-                    "range_id": 1,
-                    "new_status": ResourceStatus.PROVISIONING.value,
-                    "user_id": 42,
-                    # No request_id
-                }
-            )
-        }
-
-        with (
-            patch("mission_control.handlers.async_to_sync") as mock_async_to_sync,
-            patch("mission_control.handlers.logger") as mock_logger,
-        ):
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
-
-            process_range_event(message)
-
-        # Verify logger.error was called
-        mock_logger.error.assert_called_once()
-        call_args = mock_logger.error.call_args[0]
-        assert "Missing request_id" in call_args[0]
-
-        # Should NOT have broadcast
-        mock_async_to_sync.assert_not_called()
-
-    # ---------------------------------------------------------------------
-    # Group name
-    # ---------------------------------------------------------------------
-
-    def test_uses_correct_group_name_format(self):
-        """Handler uses range_event_group helper for group name."""
-        from mission_control.handlers import process_range_event
-
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.status.updated",
-                    "request_id": str(TEST_REQUEST_ID),
-                    "range_id": 123,
+                    "request_id": str(request_id),
                     "new_status": ResourceStatus.READY.value,
-                    "user_id": 42,
                 }
             )
-        }
+        )
+        assert _receive(layer, channel) is not None
 
-        with patch("mission_control.handlers.async_to_sync") as mock_async_to_sync:
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
+    def test_routes_ngfw_event(self):
+        app_id = str(uuid4())
+        layer, channel = _subscribe(ngfw_event_group(app_id))
+        process_event(_sns({"event_type": EVENT_TYPE_NGFW, "app_id": app_id, "status": "ready"}))
+        assert _receive(layer, channel) is not None
 
-            process_range_event(message)
-
-            args, _ = mock_send.call_args
-            assert args[0] == f"range_status_{TEST_REQUEST_ID}"
-
-    # ---------------------------------------------------------------------
-    # Minimum required input
-    # ---------------------------------------------------------------------
-
-    def test_succeeds_with_minimum_required_input(self):
-        """Handler works with minimal event fields (request_id required)."""
-        from mission_control.handlers import process_range_event
-
-        # Minimal SNS message - no error_message, but request_id is required
-        message = {
-            "Message": json.dumps(
-                {
-                    "event_type": "range.status.updated",
-                    "request_id": str(TEST_REQUEST_ID),
-                    "range_id": 6,
-                    "new_status": ResourceStatus.PROVISIONING.value,
-                    "user_id": 42,
-                }
-            )
-        }
-
-        with patch("mission_control.handlers.async_to_sync") as mock_async_to_sync:
-            mock_send = MagicMock()
-            mock_async_to_sync.return_value = mock_send
-
-            process_range_event(message)
-
-            # Should have broadcast
-            mock_send.assert_called_once()
+    def test_ignores_unknown_event_type(self):
+        request_id = uuid4()
+        layer, channel = _subscribe(range_event_group(str(request_id)))
+        process_event(_sns({"event_type": "unknown.event", "request_id": str(request_id)}))
+        assert _receive(layer, channel) is None

--- a/shifter/shifter_platform/tests/mission_control/test_models.py
+++ b/shifter/shifter_platform/tests/mission_control/test_models.py
@@ -1,62 +1,19 @@
-"""Unit tests for Mission Control models — fully mocked, no DB access."""
+"""Behavior tests for Mission Control / catalog models.
+
+Pure value-logic on a model (computed properties, ``__str__``) is exercised on
+in-memory instances; anything that touches a manager/queryset is exercised
+against the real database instead of mocking ``.objects``.
+"""
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
 
 import pytest
-from django.db.models.base import ModelState
+from django.db.models import DurationField, ExpressionWrapper, F
 from django.utils import timezone
 
 from cms.models import AgentConfig, OperatingSystem
 from engine.models import Range
 from management.models import ActivityLog, UserProfile
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make(model_cls, **attrs):
-    """Create an in-memory Django model instance without DB or FK validation.
-
-    Uses __new__ to skip __init__ (avoids FK type checks), then injects
-    Django's required _state and sets all given attributes via __dict__.
-    FK-related objects are also stored in the fields_cache so that Django's
-    FK descriptor __get__ finds them without hitting the database.
-    """
-    obj = model_cls.__new__(model_cls)
-    obj._state = ModelState()
-    obj.__dict__.update(attrs)
-    # Populate the fields_cache for any FK fields whose related object was
-    # provided, so Django's ForwardManyToOneDescriptor.__get__ returns it
-    # without a DB query.
-    fk_field_names = {f.name for f in model_cls._meta.get_fields() if f.many_to_one or f.one_to_one}
-    for name in fk_field_names:
-        if name in attrs:
-            obj._state.fields_cache[name] = attrs[name]
-    return obj
-
-
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def mock_user():
-    """An in-memory mock User with common attributes."""
-    user = MagicMock()
-    user.pk = 1
-    user.username = "test@example.com"
-    user.email = "test@example.com"
-    return user
-
-
-@pytest.fixture
-def windows_os():
-    """An in-memory OperatingSystem instance."""
-    return OperatingSystem(slug="windows", name="Windows", extensions=[".msi"])
-
 
 # ---------------------------------------------------------------------------
 # OperatingSystem
@@ -68,45 +25,21 @@ class TestOperatingSystem:
         os = OperatingSystem(slug="test", name="Test OS", extensions=[".test"])
         assert str(os) == "Test OS"
 
-    # ``get_for_extension`` now delegates to
-    # ``OperatingSystemQuerySet.for_extension``; patch that method directly
-    # so the dispatch works through the new queryset entry point. The
-    # iteration / normalisation logic itself is covered by
-    # ``tests/cms/test_models_operating_system.py``.
+    @pytest.fixture
+    def os_row(self, db):
+        return OperatingSystem.objects.create(slug="exttest", name="Ext Test", extensions=[".widget"])
 
-    @patch.object(OperatingSystem.objects, "for_extension")
-    def test_get_for_extension_finds_match(self, mock_for_extension, windows_os):
-        """get_for_extension returns OS when extension matches."""
-        mock_for_extension.return_value = windows_os
-        result = OperatingSystem.get_for_extension(".msi")
-        assert result == windows_os
-        mock_for_extension.assert_called_once_with(".msi")
+    def test_get_for_extension_finds_match(self, os_row):
+        assert OperatingSystem.get_for_extension(".widget") == os_row
 
-    @patch.object(OperatingSystem.objects, "for_extension")
-    def test_get_for_extension_case_insensitive(self, mock_for_extension, windows_os):
-        """get_for_extension forwards extension as-is to the queryset method."""
-        mock_for_extension.return_value = windows_os
-        result = OperatingSystem.get_for_extension(".MSI")
-        assert result is not None
-        assert result.slug == "windows"
-        mock_for_extension.assert_called_once_with(".MSI")
+    def test_get_for_extension_case_insensitive(self, os_row):
+        assert OperatingSystem.get_for_extension(".WIDGET") == os_row
 
-    @patch.object(OperatingSystem.objects, "for_extension")
-    def test_get_for_extension_adds_dot_if_missing(self, mock_for_extension, windows_os):
-        """get_for_extension forwards the raw input; queryset normalises it."""
-        mock_for_extension.return_value = windows_os
-        result = OperatingSystem.get_for_extension("msi")
-        assert result is not None
-        assert result.slug == "windows"
-        mock_for_extension.assert_called_once_with("msi")
+    def test_get_for_extension_adds_dot_if_missing(self, os_row):
+        assert OperatingSystem.get_for_extension("widget") == os_row
 
-    @patch.object(OperatingSystem.objects, "for_extension")
-    def test_get_for_extension_returns_none_for_unknown(self, mock_for_extension, windows_os):
-        """get_for_extension returns whatever the queryset method returns (None for unknown)."""
-        mock_for_extension.return_value = None
-        result = OperatingSystem.get_for_extension(".xyz")
-        assert result is None
-        mock_for_extension.assert_called_once_with(".xyz")
+    def test_get_for_extension_returns_none_for_unknown(self, db):
+        assert OperatingSystem.get_for_extension(".no-such-ext") is None
 
 
 # ---------------------------------------------------------------------------
@@ -116,27 +49,21 @@ class TestOperatingSystem:
 
 class TestUserProfile:
     @pytest.fixture
-    def profile(self, mock_user):
-        """Build a UserProfile in-memory, bypassing FK validation."""
-        return _make(
-            UserProfile,
-            user=mock_user,
-            user_id=mock_user.pk,
-            deleted_at=None,
-            anonymized_at=None,
-        )
+    def profile(self, db, django_user_model):
+        user = django_user_model.objects.create_user(username="prof@example.com", email="prof@example.com")
+        # A profile is auto-created for each user via signal.
+        profile, _ = UserProfile.objects.get_or_create(user=user)
+        return profile
 
-    def test_str_returns_user_email(self, profile):
-        """__str__ returns profile description with email."""
-        assert "test@example.com" in str(profile)
+    def test_str_includes_user_email(self, profile):
+        assert "prof@example.com" in str(profile)
 
     def test_is_deleted_false_by_default(self, profile):
-        """is_deleted returns False when deleted_at is None."""
         assert profile.is_deleted is False
 
     def test_is_deleted_true_when_deleted_at_set(self, profile):
-        """is_deleted returns True when deleted_at is set."""
         profile.deleted_at = timezone.now()
+        profile.save(update_fields=["deleted_at"])
         assert profile.is_deleted is True
 
 
@@ -147,229 +74,124 @@ class TestUserProfile:
 
 class TestAgentConfig:
     @pytest.fixture
-    def agent(self, mock_user, windows_os):
-        """Build an AgentConfig in-memory, bypassing FK validation."""
-        return _make(
-            AgentConfig,
-            user=mock_user,
-            user_id=mock_user.pk,
-            os=windows_os,
-            os_id=windows_os.pk,
-            name="Test Agent",
-            s3_key="test/key.msi",
-            original_filename="installer.msi",
-            file_size_bytes=1024,
-            sha256_hash="abc123",
-            deleted_at=None,
+    def agent(self, db, make_agent, django_user_model):
+        user = django_user_model.objects.create_user(
+            username="agentowner2@example.com", email="agentowner2@example.com"
         )
+        return make_agent(user, name="Test Agent")
 
     def test_str_returns_name_and_os(self, agent):
-        """__str__ returns agent name with OS."""
         assert str(agent) == "Test Agent (Windows)"
 
     def test_is_deleted_false_by_default(self, agent):
-        """is_deleted returns False when deleted_at is None."""
         assert agent.is_deleted is False
 
     def test_is_deleted_true_when_deleted_at_set(self, agent):
-        """is_deleted returns True when deleted_at is set."""
         agent.deleted_at = timezone.now()
+        agent.save(update_fields=["deleted_at"])
         assert agent.is_deleted is True
 
-    @patch.object(AgentConfig.objects, "filter")
-    def test_active_for_user_excludes_deleted(self, mock_filter, mock_user, agent):
-        """active_for_user filters AgentConfig.objects (SoftDeleteManager, active-only)."""
-        agent.name = "Active Agent"
-        mock_filter.return_value = [agent]
+    def test_active_for_user_returns_only_user_active_agents(self, db, make_agent, django_user_model):
+        owner = django_user_model.objects.create_user(username="afu-owner@example.com", email="afu-owner@example.com")
+        other = django_user_model.objects.create_user(username="afu-other@example.com", email="afu-other@example.com")
+        keep = make_agent(owner, name="Keep")
+        deleted = make_agent(owner, name="Deleted")
+        deleted.deleted_at = timezone.now()
+        deleted.save(update_fields=["deleted_at"])
+        make_agent(other, name="Other")
 
-        result = list(AgentConfig.active_for_user(mock_user))
-        assert len(result) == 1
-        assert result[0] is agent
-        mock_filter.assert_called_once_with(user=mock_user)
-
-    @patch.object(AgentConfig.objects, "filter")
-    def test_active_for_user_only_returns_user_agents(self, mock_filter, mock_user, agent):
-        """active_for_user only returns agents for the specified user."""
-        agent.name = "My Agent"
-        mock_filter.return_value = [agent]
-
-        result = list(AgentConfig.active_for_user(mock_user))
-        assert len(result) == 1
-        assert result[0].name == "My Agent"
-        mock_filter.assert_called_once_with(user=mock_user)
+        result = list(AgentConfig.active_for_user(owner))
+        assert result == [keep]
 
 
 # ---------------------------------------------------------------------------
-# Range Properties (no DB needed — unchanged)
+# Range value-logic properties (pure, in-memory)
 # ---------------------------------------------------------------------------
 
 
 class TestRangeProperties:
-    """Tests for Range model properties using in-memory construction."""
-
     def test_str_with_scenario(self):
-        """__str__ includes scenario_id from range_config."""
-        range_obj = Range(
-            id=42,
-            range_config={"scenario_id": "ad_attack_lab"},
-        )
+        range_obj = Range(id=42, range_config={"scenario_id": "ad_attack_lab"})
         assert "ad_attack_lab" in str(range_obj)
         assert "42" in str(range_obj)
 
     def test_str_without_range_config(self):
-        """__str__ shows 'unknown' scenario when range_config is None."""
-        range_obj = Range(range_config=None)
-        assert "unknown" in str(range_obj)
-
-    # --- kali_private_ip property tests ---
+        assert "unknown" in str(Range(range_config=None))
 
     def test_kali_private_ip_returns_attacker_ip(self):
-        """kali_private_ip returns the attacker instance's private_ip."""
         range_obj = Range(
             provisioned_instances=[
                 {"role": "attacker", "os": "kali", "private_ip": "10.1.5.10"},
                 {"role": "victim", "os": "ubuntu", "private_ip": "10.1.5.20"},
-            ],
+            ]
         )
         assert range_obj.kali_private_ip == "10.1.5.10"
 
-    def test_kali_private_ip_returns_none_when_no_provisioned_instances(self):
-        """kali_private_ip returns None when provisioned_instances is empty."""
-        range_obj = Range(provisioned_instances=None)
+    def test_kali_private_ip_none_when_empty(self):
+        assert Range(provisioned_instances=None).kali_private_ip is None
+
+    def test_kali_private_ip_none_when_no_attacker(self):
+        range_obj = Range(provisioned_instances=[{"role": "victim", "private_ip": "10.1.5.20"}])
         assert range_obj.kali_private_ip is None
 
-    def test_kali_private_ip_returns_none_when_no_attacker(self):
-        """kali_private_ip returns None when no attacker instance exists."""
-        range_obj = Range(
-            provisioned_instances=[
-                {"role": "victim", "os": "ubuntu", "private_ip": "10.1.5.20"},
-            ],
-        )
+    def test_kali_private_ip_none_when_attacker_missing_ip(self):
+        range_obj = Range(provisioned_instances=[{"role": "attacker", "os": "kali"}])
         assert range_obj.kali_private_ip is None
-
-    def test_kali_private_ip_returns_none_when_attacker_missing_ip(self):
-        """kali_private_ip returns None when attacker has no private_ip field."""
-        range_obj = Range(
-            provisioned_instances=[
-                {"role": "attacker", "os": "kali"},
-            ],
-        )
-        assert range_obj.kali_private_ip is None
-
-    # --- victim_private_ip property tests ---
 
     def test_victim_private_ip_returns_first_victim_ip(self):
-        """victim_private_ip returns the first victim instance's private_ip."""
         range_obj = Range(
             provisioned_instances=[
-                {"role": "attacker", "os": "kali", "private_ip": "10.1.5.10"},
-                {"role": "victim", "os": "ubuntu", "private_ip": "10.1.5.20"},
-            ],
+                {"role": "attacker", "private_ip": "10.1.5.10"},
+                {"role": "victim", "private_ip": "10.1.5.20"},
+                {"role": "victim", "private_ip": "10.1.5.30"},
+            ]
         )
         assert range_obj.victim_private_ip == "10.1.5.20"
 
-    def test_victim_private_ip_returns_none_when_no_provisioned_instances(self):
-        """victim_private_ip returns None when provisioned_instances is empty."""
-        range_obj = Range(provisioned_instances=None)
+    def test_victim_private_ip_none_when_no_victims(self):
+        range_obj = Range(provisioned_instances=[{"role": "attacker", "private_ip": "10.1.5.10"}])
         assert range_obj.victim_private_ip is None
-
-    def test_victim_private_ip_returns_none_when_no_victims(self):
-        """victim_private_ip returns None when no victim instances exist."""
-        range_obj = Range(
-            provisioned_instances=[
-                {"role": "attacker", "os": "kali", "private_ip": "10.1.5.10"},
-            ],
-        )
-        assert range_obj.victim_private_ip is None
-
-    def test_victim_private_ip_returns_none_when_victim_missing_ip(self):
-        """victim_private_ip returns None when victim has no private_ip field."""
-        range_obj = Range(
-            provisioned_instances=[
-                {"role": "victim", "os": "ubuntu"},
-            ],
-        )
-        assert range_obj.victim_private_ip is None
-
-    def test_victim_private_ip_returns_first_when_multiple_victims(self):
-        """victim_private_ip returns first victim's IP when multiple victims exist."""
-        range_obj = Range(
-            provisioned_instances=[
-                {"role": "victim", "os": "ubuntu", "private_ip": "10.1.5.20"},
-                {"role": "victim", "os": "windows", "private_ip": "10.1.5.30"},
-            ],
-        )
-        assert range_obj.victim_private_ip == "10.1.5.20"
-
-    # --- NGFW/GWLB fields tests ---
 
     def test_gwlb_endpoint_id_defaults_to_empty(self):
-        """gwlb_endpoint_id defaults to empty string."""
-        range_obj = Range()
-        assert range_obj.gwlb_endpoint_id == ""
-
-
-# ---------------------------------------------------------------------------
-# Range DB Tests (now mocked)
-# ---------------------------------------------------------------------------
-
-
-class TestRangeDB:
-    """Tests for Range model properties — previously DB-backed, now mocked."""
+        assert Range().gwlb_endpoint_id == ""
 
     def test_standup_duration_returns_timedelta_when_ready(self):
-        """standup_duration returns timedelta when range is ready."""
         created = timezone.now()
-        ready = created + timedelta(minutes=3, seconds=30)
-
         range_obj = Range()
         range_obj.created_at = created
-        range_obj.ready_at = ready
-
+        range_obj.ready_at = created + timedelta(minutes=3, seconds=30)
         assert range_obj.standup_duration == timedelta(minutes=3, seconds=30)
 
-    def test_standup_duration_returns_none_when_not_ready(self):
-        """standup_duration returns None when ready_at is not set."""
+    def test_standup_duration_none_when_not_ready(self):
         range_obj = Range()
         range_obj.created_at = timezone.now()
         range_obj.ready_at = None
-
         assert range_obj.standup_duration is None
 
-    def test_standup_duration_returns_none_when_created_at_missing(self):
-        """standup_duration returns None when created_at is somehow None."""
-        range_obj = Range()
-        range_obj.created_at = None
-        range_obj.ready_at = timezone.now()
 
-        assert range_obj.standup_duration is None
+# ---------------------------------------------------------------------------
+# Range standup-duration ORM annotation (real rows)
+# ---------------------------------------------------------------------------
 
-    @patch("engine.models.Range.objects")
-    def test_standup_duration_queryset_annotation(self, mock_objects, mock_user):
-        """standup_duration can be computed via ORM annotation for filtering."""
-        from django.db.models import DurationField, ExpressionWrapper, F
 
-        # Build a mock annotated queryset chain
-        mock_qs = MagicMock()
-        mock_objects.annotate.return_value = mock_qs
+class TestRangeStandupAnnotation:
+    def test_annotation_filters_slow_ranges(self, db, django_user_model):
+        user = django_user_model.objects.create_user(username="standup@example.com", email="standup@example.com")
+        now = timezone.now()
+        fast = Range.objects.create(user=user, status=Range.Status.READY)
+        Range.objects.filter(pk=fast.pk).update(created_at=now, ready_at=now + timedelta(minutes=1))
+        slow = Range.objects.create(user=user, status=Range.Status.READY)
+        Range.objects.filter(pk=slow.pk).update(created_at=now, ready_at=now + timedelta(minutes=10))
 
-        slow_range_pk = 2
-        mock_qs.filter.return_value.values_list.return_value = [slow_range_pk]
-
-        # Execute the same query the original test used
-        result = (
+        slow_pks = set(
             Range.objects.annotate(
                 computed_standup=ExpressionWrapper(F("ready_at") - F("created_at"), output_field=DurationField())
             )
             .filter(computed_standup__gt=timedelta(minutes=5))
             .values_list("pk", flat=True)
         )
-
-        assert slow_range_pk in result
-        # Verify the annotate -> filter -> values_list chain was called
-        mock_objects.annotate.assert_called_once()
-        mock_qs.filter.assert_called_once()
-        mock_qs.filter.return_value.values_list.assert_called_once_with("pk", flat=True)
+        assert slow.pk in slow_pks
+        assert fast.pk not in slow_pks
 
 
 # ---------------------------------------------------------------------------
@@ -378,66 +200,30 @@ class TestRangeDB:
 
 
 class TestActivityLog:
-    @patch.object(ActivityLog.objects, "create")
-    def test_log_creates_entry(self, mock_create, mock_user):
-        """ActivityLog.log() creates a new entry."""
-        mock_log = MagicMock(spec=ActivityLog)
-        mock_log.action = "test_action"
-        mock_log.user = mock_user
-        mock_log.pk = 1
-        mock_create.return_value = mock_log
-
-        log = ActivityLog.log("test_action", user=mock_user)
-
-        assert log.action == "test_action"
-        assert log.user == mock_user
+    def test_log_creates_entry(self, db, django_user_model):
+        user = django_user_model.objects.create_user(username="act@example.com", email="act@example.com")
+        log = ActivityLog.log("test_action", user=user)
         assert log.pk is not None
-        mock_create.assert_called_once_with(user=mock_user, action="test_action", metadata={})
+        assert log.action == "test_action"
+        assert log.user == user
+        assert ActivityLog.objects.filter(pk=log.pk, action="test_action").exists()
 
-    @patch.object(ActivityLog.objects, "create")
-    def test_log_stores_metadata(self, mock_create):
-        """ActivityLog.log() stores kwargs as metadata."""
-        mock_log = MagicMock(spec=ActivityLog)
-        mock_log.metadata = {"foo": "bar", "count": 42}
-        mock_create.return_value = mock_log
-
+    def test_log_stores_metadata(self, db):
         log = ActivityLog.log("test_action", foo="bar", count=42)
-
+        log.refresh_from_db()
         assert log.metadata == {"foo": "bar", "count": 42}
-        mock_create.assert_called_once_with(user=None, action="test_action", metadata={"foo": "bar", "count": 42})
 
-    @patch.object(ActivityLog.objects, "create")
-    def test_log_works_without_user(self, mock_create):
-        """ActivityLog.log() works with anonymous actions."""
-        mock_log = MagicMock(spec=ActivityLog)
-        mock_log.user = None
-        mock_log.action = "anonymous_action"
-        mock_create.return_value = mock_log
-
+    def test_log_works_without_user(self, db):
         log = ActivityLog.log("anonymous_action")
-
         assert log.user is None
         assert log.action == "anonymous_action"
 
-    def test_str_with_user(self, mock_user):
-        """__str__ includes user email when user exists."""
-        log = _make(
-            ActivityLog,
-            user=mock_user,
-            user_id=mock_user.pk,
-            action="test_action",
-            timestamp=timezone.now(),
-        )
-        assert "test@example.com" in str(log)
+    def test_str_with_user(self, db, django_user_model):
+        user = django_user_model.objects.create_user(username="actstr@example.com", email="actstr@example.com")
+        log = ActivityLog.log("test_action", user=user)
+        assert "actstr@example.com" in str(log)
         assert "test_action" in str(log)
 
-    def test_str_without_user(self):
-        """__str__ shows 'anonymous' when user is None."""
-        log = _make(
-            ActivityLog,
-            user=None,
-            user_id=None,
-            action="test_action",
-            timestamp=timezone.now(),
-        )
+    def test_str_without_user(self, db):
+        log = ActivityLog.log("test_action")
         assert "anonymous" in str(log)

--- a/shifter/shifter_platform/tests/mission_control/test_range_api.py
+++ b/shifter/shifter_platform/tests/mission_control/test_range_api.py
@@ -1,611 +1,237 @@
-"""Tests for Range API endpoints.
+"""Behavior tests for the Range API endpoints.
 
-All tests mock the ORM — no @pytest.mark.django_db markers.
-Views are called via RequestFactory with mock users; CMS/engine
-service functions are patched at the view-module boundary.
+These tests drive the real Django URLs with a real database and assert
+observable behavior: HTTP status, response JSON, and persisted ORM state
+(Range rows, audit log rows). Range provisioning dispatches to ECS only when
+configured; under the test settings it is unconfigured, so create/cancel/
+destroy complete without any cloud call and no boundary mock is required.
+
+Fixtures (windows_os, make_agent, hydratable_scenario, launch_range_via_api)
+come from tests/mission_control/conftest.py; authenticated_client from the
+root conftest.
 """
 
-from unittest.mock import MagicMock, patch
-from uuid import uuid4
+import json
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
+from django.test import Client
+from django.urls import reverse
 
-from mission_control import views
-from shared.enums import ResourceStatus
-from shared.exceptions import CMSError
-from shared.schemas import RangeContext
+from engine.models import Range
+from risk_register.models import AuditLog
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def rf():
-    """Django RequestFactory (no DB needed)."""
-    return RequestFactory()
-
-
-@pytest.fixture
-def mock_user():
-    """Authenticated mock user."""
-    user = MagicMock()
-    user.id = 1
-    user.pk = 1
-    user.username = "rangetest"
-    user.email = "rangetest@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
-
-
-@pytest.fixture
-def other_user():
-    """A second authenticated mock user."""
-    user = MagicMock()
-    user.id = 2
-    user.pk = 2
-    user.username = "other"
-    user.email = "other@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
-
-
-@pytest.fixture
-def mock_agent():
-    """Mock AgentConfig object."""
-    agent = MagicMock()
-    agent.id = 10
-    agent.name = "Test XDR Agent"
-    agent.os = MagicMock()
-    agent.os.slug = "windows"
-    agent.os.name = "Windows"
-    agent.file_size_mb = 47.7
-    agent.original_filename = "agent.msi"
-    agent.s3_key = "agents/test/fake.msi"
-    agent.file_size_bytes = 50000000
-    agent.sha256_hash = "abc123"
-    return agent
-
-
-@pytest.fixture
-def mock_linux_agent():
-    """Mock Linux AgentConfig object."""
-    agent = MagicMock()
-    agent.id = 20
-    agent.name = "Linux Agent"
-    agent.os = MagicMock()
-    agent.os.slug = "linux-debian"
-    agent.os.name = "Linux (Debian/Ubuntu)"
-    agent.file_size_mb = 23.8
-    agent.original_filename = "agent.deb"
-    agent.s3_key = "agents/test/fake.deb"
-    agent.file_size_bytes = 25000000
-    agent.sha256_hash = "def456"
-    return agent
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_range_context(user_id=1, **overrides):
-    """Build a RangeContext with sensible defaults."""
-    defaults = {
-        "request_id": uuid4(),
-        "range_id": 42,
-        "user_id": user_id,
-        "scenario_id": "basic",
-        "status": ResourceStatus.READY,
-        "instances": [],
-        "agent_name": "Test XDR Agent",
-    }
-    defaults.update(overrides)
-    return RangeContext(**defaults)
-
-
-# ---------------------------------------------------------------------------
-# TestGetRange
-# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.django_db
 
 
 def _json(response):
-    """Extract JSON from a JsonResponse."""
-    import json
-
     return json.loads(response.content)
 
 
+# ---------------------------------------------------------------------------
+# get_range
+# ---------------------------------------------------------------------------
+
+
 class TestGetRange:
-    """Tests for get_range view.
+    def test_requires_login(self):
+        response = Client().get(reverse("mission_control:get_range"))
+        assert response.status_code == 302
 
-    The view consumes RangeContext from cms.get_active_range().
-    """
-
-    def test_requires_login(self, rf):
-        request = rf.get("/api/range/")
-        request.user = AnonymousUser()
-        response = views.get_range(request)
-        assert response.status_code == 302  # Redirect to login
-
-    def test_returns_no_range_when_none_exists(self, rf, mock_user):
-        request = rf.get("/api/range/")
-        request.user = mock_user
-
-        with patch.object(views, "get_active_range", return_value=None):
-            response = views.get_range(request)
-
+    def test_returns_no_range_when_none_exists(self, authenticated_client):
+        client, _ = authenticated_client(email="norange@example.com")
+        response = client.get(reverse("mission_control:get_range"))
         assert response.status_code == 200
         data = _json(response)
         assert data["has_range"] is False
         assert data["range"] is None
+        assert data["connection_urls"] == []
 
-    def test_returns_active_range(self, rf, mock_user):
-        request = rf.get("/api/range/")
-        request.user = mock_user
+    def test_returns_active_range_after_launch(self, authenticated_client, launch_range_via_api):
+        client, user = authenticated_client(email="active@example.com")
+        launch_resp, _agent, scenario_id = launch_range_via_api(client, user)
+        assert launch_resp.status_code == 200
 
-        mock_range_context = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.READY,
-        )
-
-        with patch.object(views, "get_active_range", return_value=mock_range_context):
-            response = views.get_range(request)
-
+        response = client.get(reverse("mission_control:get_range"))
         assert response.status_code == 200
         data = _json(response)
         assert data["has_range"] is True
-        assert data["range"]["range_id"] == 42
-        assert data["range"]["status"] == "ready"
-        assert data["range"]["agent_name"] == "Test XDR Agent"
-        assert data["range"]["scenario_id"] == "basic"
-        assert data["range"]["is_ready"] is True
-        assert data["range"]["is_terminal"] is False
+        assert data["range"]["scenario_id"] == scenario_id
+        assert data["range"]["user_id"] == user.id
+        # The persisted range is PENDING: create_range stores it and would move
+        # it to PROVISIONING only once the ECS task starts, which the test
+        # settings leave unconfigured.
+        assert data["range"]["status"] == "pending"
         assert data["range"]["is_active"] is True
+        assert data["range"]["is_terminal"] is False
+        # The launched range is the one returned.
+        assert data["range"]["request_id"] == _json(launch_resp)["range"]["request_id"]
 
-    def test_returns_provisioning_range(self, rf, mock_user):
-        """Test range in provisioning state has correct computed properties."""
-        request = rf.get("/api/range/")
-        request.user = mock_user
+    def test_does_not_return_another_users_range(self, authenticated_client, launch_range_via_api):
+        owner_client, owner = authenticated_client(email="owner@example.com")
+        launch_range_via_api(owner_client, owner)
 
-        mock_range_context = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-            agent_name="Test Agent",
-        )
-
-        with patch.object(views, "get_active_range", return_value=mock_range_context):
-            response = views.get_range(request)
-
+        other_client, _other = authenticated_client(email="other@example.com")
+        response = other_client.get(reverse("mission_control:get_range"))
         assert response.status_code == 200
-        data = _json(response)
-        assert data["has_range"] is True
-        assert data["range"]["status"] == "provisioning"
-        assert data["range"]["is_ready"] is False
-        assert data["range"]["is_terminal"] is False
-        assert data["range"]["is_active"] is True
+        assert _json(response)["has_range"] is False
 
-    def test_returns_destroying_range(self, rf, mock_user):
-        """Test range in destroying state has correct computed properties."""
-        request = rf.get("/api/range/")
-        request.user = mock_user
 
-        mock_range_context = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.DESTROYING,
-            agent_name="Test Agent",
-        )
-
-        with patch.object(views, "get_active_range", return_value=mock_range_context):
-            response = views.get_range(request)
-
-        assert response.status_code == 200
-        data = _json(response)
-        assert data["has_range"] is True
-        assert data["range"]["status"] == "destroying"
-        assert data["range"]["is_ready"] is False
-        assert data["range"]["is_terminal"] is False
-        assert data["range"]["is_active"] is True
+# ---------------------------------------------------------------------------
+# launch_range
+# ---------------------------------------------------------------------------
 
 
 class TestLaunchRange:
-    def test_requires_login(self, rf):
-        request = rf.post(
-            "/api/range/launch/",
+    def _launch(self, client, body):
+        return client.post(
+            reverse("mission_control:launch_range"),
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+
+    def test_requires_login(self):
+        response = Client().post(
+            reverse("mission_control:launch_range"),
             data="{}",
             content_type="application/json",
         )
-        request.user = AnonymousUser()
-        response = views.launch_range(request)
         assert response.status_code == 302
 
-    def test_requires_agent_id(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/launch/",
-            data="{}",
+    def test_rejects_invalid_json(self, authenticated_client):
+        client, _ = authenticated_client(email="badjson@example.com")
+        response = client.post(
+            reverse("mission_control:launch_range"),
+            data="not json",
             content_type="application/json",
         )
-        request.user = mock_user
-
-        with patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]):
-            response = views.launch_range(request)
-
         assert response.status_code == 400
-        assert "agent_id" in _json(response)["error"] or "agents" in _json(response)["error"]
+        assert "Invalid JSON" in _json(response)["error"]
 
-    def test_rejects_nonexistent_agent(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/launch/",
-            data='{"agent_id": 99999}',
-            content_type="application/json",
-        )
-        request.user = mock_user
+    def test_requires_agent(self, authenticated_client, hydratable_scenario):
+        client, _ = authenticated_client(email="noagent@example.com")
+        response = self._launch(client, {"scenario": hydratable_scenario.scenario_id})
+        assert response.status_code == 400
+        assert "agent" in _json(response)["error"].lower()
 
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", side_effect=CMSError("Agent not found")),
-        ):
-            response = views.launch_range(request)
+    def test_rejects_invalid_scenario(self, authenticated_client, make_agent):
+        client, user = authenticated_client(email="badscenario@example.com")
+        agent = make_agent(user)
+        response = self._launch(client, {"agent_id": agent.id, "scenario": "does-not-exist"})
+        assert response.status_code == 400
+        assert "scenario" in _json(response)["error"].lower()
 
+    def test_rejects_nonexistent_agent(self, authenticated_client, hydratable_scenario):
+        client, _ = authenticated_client(email="ghostagent@example.com")
+        response = self._launch(client, {"agent_id": 999999, "scenario": hydratable_scenario.scenario_id})
         assert response.status_code == 400
 
-    def test_successful_launch(self, rf, mock_user, mock_agent):
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
+    def test_successful_launch_creates_range_and_audit(self, authenticated_client, make_agent, hydratable_scenario):
+        client, user = authenticated_client(email="launch@example.com")
+        agent = make_agent(user)
 
-        range_ctx = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-            agent_name=mock_agent.name,
-        )
-
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(views, "cms_create_range", return_value=range_ctx),
-        ):
-            response = views.launch_range(request)
+        assert Range.objects.count() == 0
+        response = self._launch(client, {"agent_id": agent.id, "scenario": hydratable_scenario.scenario_id})
 
         assert response.status_code == 200
         data = _json(response)
         assert data["success"] is True
+        assert data["range"]["scenario_id"] == hydratable_scenario.scenario_id
         assert data["range"]["status"] == "provisioning"
-        assert data["range"]["agent_name"] == mock_agent.name
+        # A real range row was persisted.
+        assert Range.objects.count() == 1
+        # The provision was audited.
+        assert AuditLog.objects.filter(action=AuditLog.Action.PROVISION).exists()
 
-    def test_successful_launch_with_ecs(self, rf, mock_user, mock_agent):
-        """Test launch delegates to CMS service (ECS details are internal)."""
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
+    def test_rejects_second_concurrent_range(self, authenticated_client, make_agent, hydratable_scenario):
+        client, user = authenticated_client(email="double@example.com")
+        agent = make_agent(user)
+        first = self._launch(client, {"agent_id": agent.id, "scenario": hydratable_scenario.scenario_id})
+        assert first.status_code == 200
 
-        range_ctx = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-            agent_name=mock_agent.name,
-        )
+        second = self._launch(client, {"agent_id": agent.id, "scenario": hydratable_scenario.scenario_id})
+        assert second.status_code == 400
+        assert "active range" in _json(second)["error"].lower()
+        # No second range row was created.
+        assert Range.objects.count() == 1
 
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(views, "cms_create_range", return_value=range_ctx) as mock_create,
-        ):
-            response = views.launch_range(request)
 
-        assert response.status_code == 200
-        data = _json(response)
-        assert data["success"] is True
-        assert data["range"]["status"] == "provisioning"
-        # Verify cms_create_range was called with correct args
-        mock_create.assert_called_once_with(mock_user, "basic", {"windows": mock_agent.id})
-
-    def test_rejects_when_range_exists(self, rf, mock_user, mock_agent):
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(
-                views,
-                "cms_create_range",
-                side_effect=CMSError("You already have an active range"),
-            ),
-        ):
-            response = views.launch_range(request)
-
-        assert response.status_code == 400
-        assert "already have an active range" in _json(response)["error"]
-
-    def test_ad_scenario_requires_windows_agent_for_dc(self, rf, mock_user, mock_linux_agent):
-        """AD scenario requires Windows agent for DC.
-        Linux-only agent is insufficient because DC needs Windows agent.
-        """
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_linux_agent.id}, "scenario": "ad_attack_lab"}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with (
-            patch.object(
-                views,
-                "cms_list_scenarios",
-                return_value=[{"id": "basic"}, {"id": "ad_attack_lab"}],
-            ),
-            patch.object(views, "cms_get_agent", return_value=mock_linux_agent),
-            patch.object(
-                views,
-                "cms_create_range",
-                side_effect=CMSError("AD scenario requires a Windows agent for the DC"),
-            ),
-        ):
-            response = views.launch_range(request)
-
-        assert response.status_code == 400
-
-    def test_ad_scenario_success_with_windows_agent(self, rf, mock_user, mock_agent):
-        """AD scenario succeeds with Windows agent."""
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}, "scenario": "ad_attack_lab"}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        range_ctx = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-            scenario_id="ad_attack_lab",
-        )
-
-        with (
-            patch.object(
-                views,
-                "cms_list_scenarios",
-                return_value=[{"id": "basic"}, {"id": "ad_attack_lab"}],
-            ),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(views, "cms_create_range", return_value=range_ctx),
-        ):
-            response = views.launch_range(request)
-
-        assert response.status_code == 200
-        data = _json(response)
-        assert data["success"] is True
-        assert data["range"]["status"] == "provisioning"
-        assert data["range"]["scenario_id"] == "ad_attack_lab"
-
-    def test_basic_scenario_allows_any_agent(self, rf, mock_user, mock_linux_agent):
-        """Basic scenario works with any agent OS."""
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_linux_agent.id}, "scenario": "basic"}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        range_ctx = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-            scenario_id="basic",
-        )
-
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_linux_agent),
-            patch.object(views, "cms_create_range", return_value=range_ctx),
-        ):
-            response = views.launch_range(request)
-
-        assert response.status_code == 200
-        data = _json(response)
-        assert data["success"] is True
-        assert data["range"]["scenario_id"] == "basic"
+# ---------------------------------------------------------------------------
+# cancel_range / destroy_range
+# ---------------------------------------------------------------------------
 
 
 class TestCancelRange:
-    """Tests for cancel_range view.
-
-    The view requires range_id in the request body and delegates to
-    cms.cancel_range() which updates status to DESTROYED and calls engine.
-    """
-
-    def test_requires_login(self, rf):
-        request = rf.post(
-            "/api/range/cancel/",
+    def test_requires_login(self):
+        response = Client().post(
+            reverse("mission_control:cancel_range"),
             data="{}",
             content_type="application/json",
         )
-        request.user = AnonymousUser()
-        response = views.cancel_range(request)
         assert response.status_code == 302
 
-    def test_requires_range_id_in_body(self, rf, mock_user):
-        """Request must include range_id in JSON body."""
-        request = rf.post(
-            "/api/range/cancel/",
+    def test_requires_identifier(self, authenticated_client):
+        client, _ = authenticated_client(email="cancelnoid@example.com")
+        response = client.post(
+            reverse("mission_control:cancel_range"),
             data="{}",
             content_type="application/json",
         )
-        request.user = mock_user
-        response = views.cancel_range(request)
         assert response.status_code == 400
-        assert "range_id" in _json(response)["error"]
+        assert "request_id or range_id" in _json(response)["error"]
 
-    def test_returns_error_when_range_not_found(self, rf, mock_user):
-        """Returns error when range_id doesn't exist."""
-        request = rf.post(
-            "/api/range/cancel/",
-            data='{"range_id": 99999}',
+    def test_cancel_nonexistent_range(self, authenticated_client):
+        client, _ = authenticated_client(email="cancelghost@example.com")
+        response = client.post(
+            reverse("mission_control:cancel_range"),
+            data=json.dumps({"request_id": "00000000-0000-0000-0000-000000000000"}),
             content_type="application/json",
         )
-        request.user = mock_user
-
-        # View does `from cms import cancel_range` locally — mock at source
-        with patch(
-            "cms.services.cancel_range",
-            side_effect=CMSError("Range not found"),
-        ):
-            response = views.cancel_range(request)
-
         assert response.status_code == 400
 
-    def test_successful_cancel(self, rf, mock_user):
-        """Successfully cancels a range by setting status to DESTROYED."""
-        request = rf.post(
-            "/api/range/cancel/",
-            data='{"range_id": 42}',
+    def test_successful_cancel_of_launched_range(self, authenticated_client, launch_range_via_api):
+        client, user = authenticated_client(email="cancelok@example.com")
+        launch_resp, _agent, _scenario = launch_range_via_api(client, user)
+        request_id = _json(launch_resp)["range"]["request_id"]
+
+        response = client.post(
+            reverse("mission_control:cancel_range"),
+            data=json.dumps({"request_id": request_id}),
             content_type="application/json",
         )
-        request.user = mock_user
-
-        with patch(
-            "cms.services.cancel_range",
-        ) as mock_cancel:
-            response = views.cancel_range(request)
-
         assert response.status_code == 200
         assert _json(response)["success"] is True
-        mock_cancel.assert_called_once_with(mock_user, 42)
-
-    def test_cancel_delegates_to_cms(self, rf, mock_user):
-        """Cancel calls CMS cancel_range which handles status + engine call."""
-        request = rf.post(
-            "/api/range/cancel/",
-            data='{"range_id": 42}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with patch("cms.services.cancel_range") as mock_cancel:
-            views.cancel_range(request)
-
-        mock_cancel.assert_called_once_with(mock_user, 42)
-
-    def test_cannot_cancel_other_users_range(self, rf, other_user):
-        """Users cannot cancel ranges they don't own."""
-        request = rf.post(
-            "/api/range/cancel/",
-            data='{"range_id": 42}',
-            content_type="application/json",
-        )
-        request.user = other_user
-
-        with patch(
-            "cms.services.cancel_range",
-            side_effect=CMSError("Range not found"),
-        ):
-            response = views.cancel_range(request)
-
-        assert response.status_code == 400
+        # The cancel was audited.
+        assert AuditLog.objects.filter(action=AuditLog.Action.CANCEL).exists()
 
 
 class TestDestroyRange:
-    def test_requires_login(self, rf):
-        request = rf.post(
-            "/api/range/destroy/",
+    def test_requires_login(self):
+        response = Client().post(
+            reverse("mission_control:destroy_range"),
             data="{}",
             content_type="application/json",
         )
-        request.user = AnonymousUser()
-        response = views.destroy_range(request)
         assert response.status_code == 302
 
-    def test_returns_error_when_no_range(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/destroy/",
-            data='{"range_id": 99999}',
+    def test_destroy_nonexistent_range(self, authenticated_client):
+        client, _ = authenticated_client(email="destroyghost@example.com")
+        response = client.post(
+            reverse("mission_control:destroy_range"),
+            data=json.dumps({"request_id": "00000000-0000-0000-0000-000000000000"}),
             content_type="application/json",
         )
-        request.user = mock_user
-
-        with patch(
-            "cms.services.destroy_range",
-            side_effect=CMSError("Range not found"),
-        ):
-            response = views.destroy_range(request)
-
         assert response.status_code == 400
 
-    def test_successful_destroy(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/destroy/",
-            data='{"range_id": 42}',
+    def test_successful_destroy_of_launched_range(self, authenticated_client, launch_range_via_api):
+        client, user = authenticated_client(email="destroyok@example.com")
+        launch_resp, _agent, _scenario = launch_range_via_api(client, user)
+        request_id = _json(launch_resp)["range"]["request_id"]
+
+        response = client.post(
+            reverse("mission_control:destroy_range"),
+            data=json.dumps({"request_id": request_id}),
             content_type="application/json",
         )
-        request.user = mock_user
-
-        with patch("cms.services.destroy_range") as mock_destroy:
-            response = views.destroy_range(request)
-
         assert response.status_code == 200
-        data = _json(response)
-        assert data["success"] is True
-        mock_destroy.assert_called_once_with(mock_user, 42)
-
-    def test_can_destroy_failed_range(self, rf, mock_user):
-        """Failed ranges can be destroyed to clean up."""
-        request = rf.post(
-            "/api/range/destroy/",
-            data='{"range_id": 42}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with patch("cms.services.destroy_range") as mock_destroy:
-            response = views.destroy_range(request)
-
-        assert response.status_code == 200
-        data = _json(response)
-        assert data["success"] is True
-        mock_destroy.assert_called_once_with(mock_user, 42)
-
-
-class TestLaunchRangeWhileDestroying:
-    """Test that users CAN launch while a range is being destroyed."""
-
-    def test_can_launch_while_destroying(self, rf, mock_user, mock_agent):
-        """User can launch a new range while old one is being cleaned up.
-
-        The CMS service handles subnet allocation internally — the view
-        just delegates to cms_create_range which succeeds if allowed.
-        """
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        range_ctx = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-        )
-
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(views, "cms_create_range", return_value=range_ctx),
-        ):
-            response = views.launch_range(request)
-
-        assert response.status_code == 200
-        data = _json(response)
-        assert data["success"] is True
-        assert data["range"]["status"] == "provisioning"
+        assert _json(response)["success"] is True
+        assert AuditLog.objects.filter(action=AuditLog.Action.DEPROVISION).exists()

--- a/shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py
+++ b/shifter/shifter_platform/tests/mission_control/test_range_api_agents_subnets.py
@@ -1,356 +1,111 @@
-"""Tests for Range API endpoints.
+"""Behavior tests for the agent-list API and Range subnet-index allocation.
 
-All tests mock the ORM — no @pytest.mark.django_db markers.
-Views are called via RequestFactory with mock users; CMS/engine
-service functions are patched at the view-module boundary.
+Drives the real ``/api/agents/`` endpoint with database-backed agents and
+exercises ``Range.allocate_subnet_index`` against real ``Range`` rows instead
+of mocking the ORM/transaction. ``SUBNET_INDEX_MAX`` is lowered with pytest's
+``monkeypatch`` (a plain attribute set, not a ``mock.patch`` of call topology)
+so the exhaustion path is reachable without creating thousands of rows.
 """
 
-from unittest.mock import MagicMock, patch
-from uuid import uuid4
+import json
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
+from django.test import Client
+from django.urls import reverse
 
-from mission_control import views
-from shared.enums import ResourceStatus
-from shared.schemas import RangeContext
+from engine.models import Range
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def rf():
-    """Django RequestFactory (no DB needed)."""
-    return RequestFactory()
-
-
-@pytest.fixture
-def mock_user():
-    """Authenticated mock user."""
-    user = MagicMock()
-    user.id = 1
-    user.pk = 1
-    user.username = "rangetest"
-    user.email = "rangetest@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
-
-
-@pytest.fixture
-def other_user():
-    """A second authenticated mock user."""
-    user = MagicMock()
-    user.id = 2
-    user.pk = 2
-    user.username = "other"
-    user.email = "other@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
-
-
-@pytest.fixture
-def mock_agent():
-    """Mock AgentConfig object."""
-    agent = MagicMock()
-    agent.id = 10
-    agent.name = "Test XDR Agent"
-    agent.os = MagicMock()
-    agent.os.slug = "windows"
-    agent.os.name = "Windows"
-    agent.file_size_mb = 47.7
-    agent.original_filename = "agent.msi"
-    agent.s3_key = "agents/test/fake.msi"
-    agent.file_size_bytes = 50000000
-    agent.sha256_hash = "abc123"
-    return agent
-
-
-@pytest.fixture
-def mock_linux_agent():
-    """Mock Linux AgentConfig object."""
-    agent = MagicMock()
-    agent.id = 20
-    agent.name = "Linux Agent"
-    agent.os = MagicMock()
-    agent.os.slug = "linux-debian"
-    agent.os.name = "Linux (Debian/Ubuntu)"
-    agent.file_size_mb = 23.8
-    agent.original_filename = "agent.deb"
-    agent.s3_key = "agents/test/fake.deb"
-    agent.file_size_bytes = 25000000
-    agent.sha256_hash = "def456"
-    return agent
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_range_context(user_id=1, **overrides):
-    """Build a RangeContext with sensible defaults."""
-    defaults = {
-        "request_id": uuid4(),
-        "range_id": 42,
-        "user_id": user_id,
-        "scenario_id": "basic",
-        "status": ResourceStatus.READY,
-        "instances": [],
-        "agent_name": "Test XDR Agent",
-    }
-    defaults.update(overrides)
-    return RangeContext(**defaults)
-
-
-# ---------------------------------------------------------------------------
-# TestGetRange
-# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.django_db
 
 
 def _json(response):
-    """Extract JSON from a JsonResponse."""
-    import json
-
     return json.loads(response.content)
 
 
 class TestListAgents:
-    def test_requires_login(self, rf):
-        request = rf.get("/api/agents/")
-        request.user = AnonymousUser()
-        response = views.list_agents(request)
+    def test_requires_login(self):
+        response = Client().get(reverse("mission_control:list_agents"))
         assert response.status_code == 302
 
-    def test_returns_user_agents(self, rf, mock_user, mock_agent):
-        request = rf.get("/api/agents/")
-        request.user = mock_user
+    def test_returns_user_agents(self, authenticated_client, make_agent):
+        client, user = authenticated_client(email="agents@example.com")
+        make_agent(user, name="Test XDR Agent")
 
-        agent_dict = {
-            "id": mock_agent.id,
-            "name": "Test XDR Agent",
-            "os_name": "Windows",
-            "os_slug": "windows",
-            "file_size_mb": 47.7,
-            "original_filename": "agent.msi",
-            "created_at": "2025-01-01T00:00:00Z",
-            "agent_type": "xdr",
-            "agent_type_display": "XDR",
-        }
-
-        with patch.object(views, "cms_list_agents", return_value=[agent_dict]):
-            response = views.list_agents(request)
-
+        response = client.get(reverse("mission_control:list_agents"))
         assert response.status_code == 200
-        data = _json(response)
-        assert len(data["agents"]) == 1
-        assert data["agents"][0]["id"] == mock_agent.id
-        assert data["agents"][0]["name"] == "Test XDR Agent"
+        agents = _json(response)["agents"]
+        assert len(agents) == 1
+        assert agents[0]["name"] == "Test XDR Agent"
 
-    def test_includes_os_slug_for_filtering(self, rf, mock_user, mock_agent):
-        """Agent list should include os_slug for frontend filtering."""
-        request = rf.get("/api/agents/")
-        request.user = mock_user
+    def test_includes_os_slug_for_filtering(self, authenticated_client, make_agent, windows_os):
+        client, user = authenticated_client(email="osslug@example.com")
+        make_agent(user, os=windows_os)
 
-        agent_dict = {
-            "id": mock_agent.id,
-            "name": "Test XDR Agent",
-            "os_name": "Windows",
-            "os_slug": "windows",
-            "file_size_mb": 47.7,
-            "original_filename": "agent.msi",
-            "created_at": "2025-01-01T00:00:00Z",
-            "agent_type": "xdr",
-            "agent_type_display": "XDR",
-        }
-
-        with patch.object(views, "cms_list_agents", return_value=[agent_dict]):
-            response = views.list_agents(request)
-
+        response = client.get(reverse("mission_control:list_agents"))
         assert response.status_code == 200
-        data = _json(response)
-        agent = data["agents"][0]
-        assert "os_slug" in agent
+        agent = _json(response)["agents"][0]
         assert agent["os_slug"] == "windows"
+
+    def test_only_returns_own_agents(self, authenticated_client, make_agent):
+        owner_client, owner = authenticated_client(email="owner-a@example.com")
+        make_agent(owner, name="Owned")
+        _other_client, other = authenticated_client(email="other-a@example.com")
+        make_agent(other, name="Someone Else")
+
+        response = owner_client.get(reverse("mission_control:list_agents"))
+        names = [a["name"] for a in _json(response)["agents"]]
+        assert names == ["Owned"]
 
 
 class TestSubnetIndexAllocation:
-    """Tests for subnet_index allocation in Range model.
+    """Exercises Range.allocate_subnet_index against real rows."""
 
-    These tests mock Range.allocate_subnet_index and Range.objects
-    since they are pure model/ORM operations.
-    """
+    @pytest.fixture
+    def user(self, django_user_model):
+        return django_user_model.objects.create_user(username="subnet@example.com", email="subnet@example.com")
 
-    def test_allocates_index_on_launch(self, rf, mock_user, mock_agent):
-        """Launch should delegate to CMS which allocates a subnet_index."""
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
+    def _range(self, user, *, subnet_index, status=Range.Status.READY):
+        return Range.objects.create(user=user, subnet_index=subnet_index, status=status)
 
-        range_ctx = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-        )
+    def test_first_allocation_returns_one(self, user):
+        assert Range.allocate_subnet_index() == 1
 
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(views, "cms_create_range", return_value=range_ctx) as mock_create,
-        ):
-            response = views.launch_range(request)
+    def test_allocates_next_after_existing(self, user):
+        self._range(user, subnet_index=1)
+        assert Range.allocate_subnet_index() == 2
 
+    def test_fills_gaps(self, user):
+        self._range(user, subnet_index=1)
+        self._range(user, subnet_index=3)
+        assert Range.allocate_subnet_index() == 2
+
+    def test_skips_active_indices(self, user):
+        for i in (1, 2, 3, 4):
+            self._range(user, subnet_index=i)
+        assert Range.allocate_subnet_index() == 5
+
+    def test_reuses_destroyed_indices(self, user):
+        self._range(user, subnet_index=1, status=Range.Status.DESTROYED)
+        assert Range.allocate_subnet_index() == 1
+
+    def test_reuses_failed_indices(self, user):
+        self._range(user, subnet_index=1, status=Range.Status.FAILED)
+        assert Range.allocate_subnet_index() == 1
+
+    def test_raises_when_exhausted(self, user, monkeypatch):
+        monkeypatch.setattr(Range, "SUBNET_INDEX_MAX", 3)
+        for i in (1, 2, 3):
+            self._range(user, subnet_index=i)
+        with pytest.raises(ValueError, match="No subnet indices available"):
+            Range.allocate_subnet_index()
+
+
+class TestLaunchAllocatesSubnetIndex:
+    def test_launched_range_has_subnet_index(self, authenticated_client, launch_range_via_api):
+        client, user = authenticated_client(email="launchidx@example.com")
+        response, _agent, _scenario = launch_range_via_api(client, user)
         assert response.status_code == 200
-        # Verify cms_create_range was called (it handles subnet allocation)
-        mock_create.assert_called_once()
 
-    def test_first_allocation_returns_one(self):
-        """First allocation should return index 1."""
-        from engine.models import Range
-
-        with (
-            patch("engine.models.transaction") as mock_tx,
-            patch("engine.models.Range.objects") as mock_objects,
-        ):
-            mock_tx.atomic.return_value.__enter__ = MagicMock()
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_qs = MagicMock()
-            mock_qs.values_list.return_value = []
-            mock_objects.exclude.return_value.exclude.return_value = mock_qs
-
-            index = Range.allocate_subnet_index()
-            assert index == 1
-
-    def test_allocates_sequential_indices(self):
-        """Allocations should fill gaps."""
-        from engine.models import Range
-
-        with (
-            patch("engine.models.transaction") as mock_tx,
-            patch("engine.models.Range.objects") as mock_objects,
-        ):
-            mock_tx.atomic.return_value.__enter__ = MagicMock()
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_qs = MagicMock()
-            mock_qs.values_list.return_value = [1]
-            mock_objects.exclude.return_value.exclude.return_value = mock_qs
-
-            index = Range.allocate_subnet_index()
-            assert index == 2
-
-    def test_reuses_destroyed_indices(self):
-        """Destroyed ranges should free up their indices."""
-        from engine.models import Range
-
-        with (
-            patch("engine.models.transaction") as mock_tx,
-            patch("engine.models.Range.objects") as mock_objects,
-        ):
-            mock_tx.atomic.return_value.__enter__ = MagicMock()
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_qs = MagicMock()
-            mock_qs.values_list.return_value = []
-            mock_objects.exclude.return_value.exclude.return_value = mock_qs
-
-            index = Range.allocate_subnet_index()
-            assert index == 1
-
-    def test_fills_gaps(self):
-        """Should fill gaps in index sequence."""
-        from engine.models import Range
-
-        with (
-            patch("engine.models.transaction") as mock_tx,
-            patch("engine.models.Range.objects") as mock_objects,
-        ):
-            mock_tx.atomic.return_value.__enter__ = MagicMock()
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_qs = MagicMock()
-            mock_qs.values_list.return_value = [1, 3]
-            mock_objects.exclude.return_value.exclude.return_value = mock_qs
-
-            index = Range.allocate_subnet_index()
-            assert index == 2
-
-    def test_skips_active_indices(self):
-        """Should not reuse indices from active ranges."""
-        from engine.models import Range
-
-        with (
-            patch("engine.models.transaction") as mock_tx,
-            patch("engine.models.Range.objects") as mock_objects,
-        ):
-            mock_tx.atomic.return_value.__enter__ = MagicMock()
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_qs = MagicMock()
-            mock_qs.values_list.return_value = [1, 2, 3, 4]
-            mock_objects.exclude.return_value.exclude.return_value = mock_qs
-
-            index = Range.allocate_subnet_index()
-            assert index == 5
-
-    def test_reuses_failed_indices(self):
-        """Failed ranges should free up their indices (like destroyed)."""
-        from engine.models import Range
-
-        with (
-            patch("engine.models.transaction") as mock_tx,
-            patch("engine.models.Range.objects") as mock_objects,
-        ):
-            mock_tx.atomic.return_value.__enter__ = MagicMock()
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_qs = MagicMock()
-            mock_qs.values_list.return_value = []
-            mock_objects.exclude.return_value.exclude.return_value = mock_qs
-
-            index = Range.allocate_subnet_index()
-            assert index == 1
-
-    def test_raises_when_exhausted(self):
-        """Should raise ValueError when all indices are used."""
-        from engine.models import Range
-
-        with (
-            patch("engine.models.transaction") as mock_tx,
-            patch("engine.models.Range.objects") as mock_objects,
-            patch.object(Range, "SUBNET_INDEX_MAX", 5),
-        ):
-            mock_tx.atomic.return_value.__enter__ = MagicMock()
-            mock_tx.atomic.return_value.__exit__ = MagicMock(return_value=False)
-            mock_qs = MagicMock()
-            mock_qs.values_list.return_value = [1, 2, 3, 4, 5]
-            mock_objects.exclude.return_value.exclude.return_value = mock_qs
-
-            with pytest.raises(ValueError, match="No subnet indices available"):
-                Range.allocate_subnet_index()
-
-    def test_capacity_error_on_launch(self, rf, mock_user, mock_agent):
-        """API returns error when subnet allocation fails (no capacity).
-
-        CMS service raises CMSError (or ValueError propagates) when
-        allocate_subnet_index() fails.
-        """
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(
-                views,
-                "cms_create_range",
-                side_effect=ValueError("No subnet indices available"),
-            ),
-            pytest.raises(ValueError, match="No subnet indices available"),
-        ):
-            views.launch_range(request)
+        range_obj = Range.objects.get()
+        assert range_obj.subnet_index is not None
+        assert range_obj.subnet_index >= Range.SUBNET_INDEX_MIN

--- a/shifter/shifter_platform/tests/mission_control/test_range_api_audit.py
+++ b/shifter/shifter_platform/tests/mission_control/test_range_api_audit.py
@@ -1,278 +1,86 @@
-"""Tests for Range API endpoints.
+"""Behavior tests for HTTP-layer audit logging of range lifecycle actions (#694).
 
-All tests mock the ORM — no @pytest.mark.django_db markers.
-Views are called via RequestFactory with mock users; CMS/engine
-service functions are patched at the view-module boundary.
+Each range lifecycle endpoint must record a real ``AuditLog`` row carrying the
+acting user and request context. These tests drive the endpoints and assert the
+persisted audit rows instead of patching ``audit_log_from_request`` and
+inspecting call kwargs.
 """
 
-from unittest.mock import MagicMock, patch
-from uuid import uuid4
+import json
 
 import pytest
-from django.test import RequestFactory
+from django.test import Client
+from django.urls import reverse
 
-from mission_control import views
-from shared.enums import ResourceStatus
-from shared.exceptions import CMSError
-from shared.schemas import RangeContext
+from risk_register.models import AuditLog
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.django_db
+
+GHOST_REQUEST_ID = "00000000-0000-0000-0000-000000000000"
 
 
-@pytest.fixture
-def rf():
-    """Django RequestFactory (no DB needed)."""
-    return RequestFactory()
+def _range_audit(action):
+    return AuditLog.objects.filter(entity_type=AuditLog.EntityType.RANGE, action=action)
 
 
-@pytest.fixture
-def mock_user():
-    """Authenticated mock user."""
-    user = MagicMock()
-    user.id = 1
-    user.pk = 1
-    user.username = "rangetest"
-    user.email = "rangetest@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
+def _has_http_audit(action, *, actor_id, request_id, scenario=None):
+    """True if an HTTP-layer audit row for this action carries the request context.
 
-
-@pytest.fixture
-def other_user():
-    """A second authenticated mock user."""
-    user = MagicMock()
-    user.id = 2
-    user.pk = 2
-    user.username = "other"
-    user.email = "other@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
-
-
-@pytest.fixture
-def mock_agent():
-    """Mock AgentConfig object."""
-    agent = MagicMock()
-    agent.id = 10
-    agent.name = "Test XDR Agent"
-    agent.os = MagicMock()
-    agent.os.slug = "windows"
-    agent.os.name = "Windows"
-    agent.file_size_mb = 47.7
-    agent.original_filename = "agent.msi"
-    agent.s3_key = "agents/test/fake.msi"
-    agent.file_size_bytes = 50000000
-    agent.sha256_hash = "abc123"
-    return agent
-
-
-@pytest.fixture
-def mock_linux_agent():
-    """Mock Linux AgentConfig object."""
-    agent = MagicMock()
-    agent.id = 20
-    agent.name = "Linux Agent"
-    agent.os = MagicMock()
-    agent.os.slug = "linux-debian"
-    agent.os.name = "Linux (Debian/Ubuntu)"
-    agent.file_size_mb = 23.8
-    agent.original_filename = "agent.deb"
-    agent.s3_key = "agents/test/fake.deb"
-    agent.file_size_bytes = 25000000
-    agent.sha256_hash = "def456"
-    return agent
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_range_context(user_id=1, **overrides):
-    """Build a RangeContext with sensible defaults."""
-    defaults = {
-        "request_id": uuid4(),
-        "range_id": 42,
-        "user_id": user_id,
-        "scenario_id": "basic",
-        "status": ResourceStatus.READY,
-        "instances": [],
-        "agent_name": "Test XDR Agent",
-    }
-    defaults.update(overrides)
-    return RangeContext(**defaults)
-
-
-# ---------------------------------------------------------------------------
-# TestGetRange
-# ---------------------------------------------------------------------------
-
-
-def _json(response):
-    """Extract JSON from a JsonResponse."""
-    import json
-
-    return json.loads(response.content)
+    Both the view (HTTP boundary) and the CMS service layer audit a lifecycle
+    action, so we assert the HTTP-layer row is present rather than that it is
+    the only row.
+    """
+    for row in _range_audit(action):
+        state = row.new_state or {}
+        if row.actor_id != actor_id or state.get("request_id") != request_id:
+            continue
+        if scenario is not None and state.get("scenario") != scenario:
+            continue
+        return True
+    return False
 
 
 class TestRangeLifecycleAudit:
-    """HTTP-layer audit entries for range lifecycle actions (#694).
-
-    Verifies that each range lifecycle endpoint in mission_control records an
-    AuditLog entry via risk_register.services.audit_log_from_request, carrying
-    source IP / user agent / HTTP request_id alongside the action. The CMS
-    service-layer audit calls are tested separately; these tests pin the
-    HTTP boundary so the request context is not silently lost.
-    """
-
-    def test_launch_range_records_provision_audit(self, rf, mock_user, mock_agent):
-        request = rf.post(
-            "/api/range/launch/",
-            data=f'{{"agent_id": {mock_agent.id}, "scenario": "basic"}}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-        range_ctx = _make_range_context(
-            user_id=mock_user.id,
-            status=ResourceStatus.PROVISIONING,
-            agent_name=mock_agent.name,
-        )
-
-        with (
-            patch.object(views, "cms_list_scenarios", return_value=[{"id": "basic"}]),
-            patch.object(views, "cms_get_agent", return_value=mock_agent),
-            patch.object(views, "cms_create_range", return_value=range_ctx),
-            patch.object(views, "audit_log_from_request") as mock_audit,
-        ):
-            response = views.launch_range(request)
-
+    def test_launch_records_provision_audit(self, authenticated_client, launch_range_via_api):
+        client, user = authenticated_client(email="audit-launch@example.com")
+        response, _agent, scenario_id = launch_range_via_api(client, user)
         assert response.status_code == 200
-        mock_audit.assert_called_once()
-        kwargs = mock_audit.call_args.kwargs
-        assert kwargs["entity_type"] == views.AuditLog.EntityType.RANGE
-        assert kwargs["action"] == views.AuditLog.Action.PROVISION
-        assert kwargs["new_state"]["scenario"] == "basic"
-        assert kwargs["new_state"]["request_id"] == str(range_ctx.request_id)
+        request_id = json.loads(response.content)["range"]["request_id"]
 
-    def test_cancel_range_records_cancel_audit(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/cancel/",
-            data='{"range_id": 42}',
+        # The HTTP boundary recorded a PROVISION audit row carrying the actor
+        # and request context.
+        assert _has_http_audit(AuditLog.Action.PROVISION, actor_id=user.id, request_id=request_id, scenario=scenario_id)
+
+    def test_cancel_records_cancel_audit(self, authenticated_client, launch_range_via_api):
+        client, user = authenticated_client(email="audit-cancel@example.com")
+        launch_resp, _agent, _scenario = launch_range_via_api(client, user)
+        request_id = json.loads(launch_resp.content)["range"]["request_id"]
+
+        response = client.post(
+            reverse("mission_control:cancel_range"),
+            data=json.dumps({"request_id": request_id}),
             content_type="application/json",
         )
-        request.user = mock_user
-
-        with (
-            patch("cms.services.cancel_range"),
-            patch.object(views, "audit_log_from_request") as mock_audit,
-        ):
-            response = views.cancel_range(request)
-
         assert response.status_code == 200
-        mock_audit.assert_called_once()
-        kwargs = mock_audit.call_args.kwargs
-        assert kwargs["entity_type"] == views.AuditLog.EntityType.RANGE
-        assert kwargs["entity_id"] == 42
-        assert kwargs["action"] == views.AuditLog.Action.CANCEL
 
-    def test_destroy_range_records_deprovision_audit(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/destroy/",
-            data='{"range_id": 42}',
+        assert _has_http_audit(AuditLog.Action.CANCEL, actor_id=user.id, request_id=request_id)
+
+    def test_failed_action_does_not_audit(self, authenticated_client):
+        client, _user = authenticated_client(email="audit-fail@example.com")
+        response = client.post(
+            reverse("mission_control:destroy_range"),
+            data=json.dumps({"request_id": GHOST_REQUEST_ID}),
             content_type="application/json",
         )
-        request.user = mock_user
-
-        with (
-            patch("cms.services.destroy_range"),
-            patch.object(views, "audit_log_from_request") as mock_audit,
-        ):
-            response = views.destroy_range(request)
-
-        assert response.status_code == 200
-        mock_audit.assert_called_once()
-        kwargs = mock_audit.call_args.kwargs
-        assert kwargs["entity_type"] == views.AuditLog.EntityType.RANGE
-        assert kwargs["entity_id"] == 42
-        assert kwargs["action"] == views.AuditLog.Action.DEPROVISION
-
-    def test_pause_range_records_pause_audit(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/pause/",
-            data='{"range_id": 42}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with (
-            patch("cms.services.pause_range"),
-            patch.object(views, "audit_log_from_request") as mock_audit,
-        ):
-            response = views.pause_range(request)
-
-        assert response.status_code == 200
-        mock_audit.assert_called_once()
-        kwargs = mock_audit.call_args.kwargs
-        assert kwargs["action"] == views.AuditLog.Action.PAUSE
-
-    def test_resume_range_records_resume_audit(self, rf, mock_user):
-        request = rf.post(
-            "/api/range/resume/",
-            data='{"range_id": 42}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with (
-            patch("cms.services.resume_range"),
-            patch.object(views, "audit_log_from_request") as mock_audit,
-        ):
-            response = views.resume_range(request)
-
-        assert response.status_code == 200
-        mock_audit.assert_called_once()
-        kwargs = mock_audit.call_args.kwargs
-        assert kwargs["action"] == views.AuditLog.Action.RESUME
-
-    def test_failed_destroy_does_not_audit(self, rf, mock_user):
-        """If the CMS layer rejects the destroy, no audit entry is recorded."""
-        request = rf.post(
-            "/api/range/destroy/",
-            data='{"range_id": 42}',
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        with (
-            patch("cms.services.destroy_range", side_effect=CMSError("nope")),
-            patch.object(views, "audit_log_from_request") as mock_audit,
-        ):
-            response = views.destroy_range(request)
-
         assert response.status_code == 400
-        mock_audit.assert_not_called()
+        # A rejected action records no DEPROVISION audit row.
+        assert not _range_audit(AuditLog.Action.DEPROVISION).exists()
 
-    def test_request_id_format_audits_against_uuid(self, rf, mock_user):
-        """request_id (UUID) format threads the UUID into new_state."""
-        request = rf.post(
-            "/api/range/destroy/",
-            data='{"request_id": "abc-123"}',
+    def test_requires_login_records_no_audit(self):
+        response = Client().post(
+            reverse("mission_control:launch_range"),
+            data="{}",
             content_type="application/json",
         )
-        request.user = mock_user
-
-        with (
-            patch("cms.services.destroy_range_by_request_id"),
-            patch.object(views, "audit_log_from_request") as mock_audit,
-        ):
-            response = views.destroy_range(request)
-
-        assert response.status_code == 200
-        kwargs = mock_audit.call_args.kwargs
-        # entity_id falls back to 0 when only request_id is provided
-        assert kwargs["entity_id"] == 0
-        assert kwargs["new_state"]["request_id"] == "abc-123"
+        assert response.status_code == 302
+        assert not _range_audit(AuditLog.Action.PROVISION).exists()

--- a/shifter/shifter_platform/tests/mission_control/test_views.py
+++ b/shifter/shifter_platform/tests/mission_control/test_views.py
@@ -1,222 +1,119 @@
-"""Tests for page-rendering views (dashboard, settings, help).
+"""Behavior tests for the page-rendering views (dashboard, settings, help).
 
-All ORM access is mocked — no @pytest.mark.django_db markers.
+Drives the real URLs with the test client and asserts the rendered template,
+response status, and template context instead of mocking ``render`` and
+inspecting its call args. The storage helper is exercised against real agents.
 """
 
 import time
-from unittest.mock import MagicMock, patch
 
 import pytest
-from django.contrib.auth.models import AnonymousUser
-from django.http import HttpResponse
-from django.test import RequestFactory
+from django.test import Client, override_settings
+from django.urls import reverse
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
+pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture
-def rf():
-    """Django RequestFactory."""
-    return RequestFactory()
-
-
-@pytest.fixture
-def mock_user():
-    """A mock authenticated user (no DB)."""
-    user = MagicMock()
-    user.pk = 1
-    user.id = 1
-    user.is_authenticated = True
-    user.is_active = True
-    user.is_staff = False
-    user.username = "test@example.com"
-    user.email = "test@example.com"
-    return user
-
-
-def _get_request(rf, path="/", user=None):
-    """Build a GET request with session and user attached."""
-    request = rf.get(path)
-    request.user = user or AnonymousUser()
-    request.session = {}
-    return request
-
-
-def _post_request(rf, path="/", user=None):
-    """Build a POST request with session and user attached."""
-    request = rf.post(path)
-    request.user = user or AnonymousUser()
-    request.session = {}
-    return request
-
-
-# ---------------------------------------------------------------------------
-# Dashboard View Tests
-# ---------------------------------------------------------------------------
+def _template_names(response):
+    return [t.name for t in response.templates if t.name]
 
 
 class TestDashboardView:
-    def test_requires_login(self, rf):
-        from mission_control.views import dashboard
+    URL = reverse("mission_control:dashboard")
 
-        request = _get_request(rf)
-        response = dashboard(request)
+    def test_requires_login(self):
+        response = Client().get(self.URL)
         assert response.status_code == 302
-        assert "/oidc/authenticate/" in response.url or "login" in response.url.lower()
 
-    def test_requires_get(self, rf, mock_user):
-        from mission_control.views import dashboard
+    def test_requires_get(self, authenticated_client):
+        client, _ = authenticated_client(email="dash-post@example.com")
+        assert client.post(self.URL).status_code == 405
 
-        request = _post_request(rf, user=mock_user)
-        response = dashboard(request)
-        assert response.status_code == 405
-
-    @patch("mission_control.views.render")
-    def test_renders_dashboard(self, mock_render, rf, mock_user):
-        from mission_control.views import dashboard
-
-        mock_render.return_value = HttpResponse("ok")
-        request = _get_request(rf, user=mock_user)
-        dashboard(request)
-
-        mock_render.assert_called_once()
-        _request, template, context = mock_render.call_args.args
-        assert template == "mission_control/dashboard.html"
-        assert context["page_title"] == "Ranges"
-        assert context["active_nav"] == "ranges"
-
-
-# ---------------------------------------------------------------------------
-# Settings View Tests
-# ---------------------------------------------------------------------------
+    def test_renders_dashboard(self, authenticated_client):
+        client, _ = authenticated_client(email="dash@example.com")
+        response = client.get(self.URL)
+        assert response.status_code == 200
+        assert "mission_control/dashboard.html" in _template_names(response)
+        assert response.context["page_title"] == "Ranges"
+        assert response.context["active_nav"] == "ranges"
 
 
 class TestSettingsView:
-    def test_requires_login(self, rf):
-        from mission_control.views import settings
+    URL = reverse("mission_control:settings")
 
-        request = _get_request(rf)
-        response = settings(request)
-        assert response.status_code == 302
+    def test_requires_login(self):
+        assert Client().get(self.URL).status_code == 302
 
-    def test_requires_get(self, rf, mock_user):
-        from mission_control.views import settings
+    def test_requires_get(self, authenticated_client):
+        client, _ = authenticated_client(email="set-post@example.com")
+        assert client.post(self.URL).status_code == 405
 
-        request = _post_request(rf, user=mock_user)
-        response = settings(request)
-        assert response.status_code == 405
-
-    @patch("mission_control.views.render")
-    def test_renders_settings(self, mock_render, rf, mock_user):
-        from mission_control.views import settings
-
-        mock_render.return_value = HttpResponse("ok")
-        request = _get_request(rf, user=mock_user)
-        settings(request)
-
-        mock_render.assert_called_once()
-        _request, template, context = mock_render.call_args.args
-        assert template == "mission_control/settings.html"
-        assert context["page_title"] == "Settings"
-        assert context["active_nav"] == "settings"
-
-
-# ---------------------------------------------------------------------------
-# Help View Tests
-# ---------------------------------------------------------------------------
+    def test_renders_settings(self, authenticated_client):
+        client, _ = authenticated_client(email="set@example.com")
+        response = client.get(self.URL)
+        assert response.status_code == 200
+        assert "mission_control/settings.html" in _template_names(response)
+        assert response.context["page_title"] == "Settings"
+        assert response.context["active_nav"] == "settings"
 
 
 class TestHelpView:
-    def test_requires_login(self, rf):
-        from mission_control.views import help_page
+    URL = reverse("mission_control:help")
 
-        request = _get_request(rf)
-        response = help_page(request)
-        assert response.status_code == 302
+    def test_requires_login(self):
+        assert Client().get(self.URL).status_code == 302
 
-    def test_requires_get(self, rf, mock_user):
-        from mission_control.views import help_page
+    def test_requires_get(self, authenticated_client):
+        client, _ = authenticated_client(email="help-post@example.com")
+        assert client.post(self.URL).status_code == 405
 
-        request = _post_request(rf, user=mock_user)
-        response = help_page(request)
-        assert response.status_code == 405
-
-    @patch("mission_control.views.render")
-    def test_renders_help(self, mock_render, rf, mock_user, settings):
-        from mission_control.views import help_page
-
-        settings.SHIFTER_SUPPORT_EMAIL = "support@test.example.com"
-
-        mock_render.return_value = HttpResponse("ok")
-        request = _get_request(rf, user=mock_user)
-        help_page(request)
-
-        mock_render.assert_called_once()
-        _request, template, context = mock_render.call_args.args
-        assert template == "mission_control/help.html"
-        assert context["page_title"] == "Help"
-        assert context["active_nav"] == "help"
-        assert context["support_email"] == "support@test.example.com"
-
-
-# ---------------------------------------------------------------------------
-# Helper Function Tests
-# ---------------------------------------------------------------------------
+    @override_settings(SHIFTER_SUPPORT_EMAIL="support@test.example.com")
+    def test_renders_help(self, authenticated_client):
+        client, _ = authenticated_client(email="help@example.com")
+        response = client.get(self.URL)
+        assert response.status_code == 200
+        assert "mission_control/help.html" in _template_names(response)
+        assert response.context["page_title"] == "Help"
+        assert response.context["active_nav"] == "help"
+        assert response.context["support_email"] == "support@test.example.com"
 
 
 class TestGetUserStorageUsed:
-    @patch("cms.assets.services.AgentConfig")
-    def test_returns_zero_for_no_agents(self, mock_agent_config, mock_user):
+    def test_returns_zero_for_no_agents(self, authenticated_client):
         from cms.assets.services import get_storage_used
 
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": None}
-        mock_agent_config.active_for_user.return_value = mock_qs
+        _client, user = authenticated_client(email="storage0@example.com")
+        assert get_storage_used(user) == 0
 
-        assert get_storage_used(mock_user) == 0
-
-    @patch("cms.assets.services.AgentConfig")
-    def test_sums_active_agent_sizes(self, mock_agent_config, mock_user):
+    def test_sums_active_agent_sizes(self, authenticated_client, make_agent):
         from cms.assets.services import get_storage_used
 
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": 3000}
-        mock_agent_config.active_for_user.return_value = mock_qs
+        _client, user = authenticated_client(email="storage-sum@example.com")
+        make_agent(user, name="A", file_size_bytes=1000)
+        make_agent(user, name="B", file_size_bytes=2000)
+        assert get_storage_used(user) == 3000
 
-        assert get_storage_used(mock_user) == 3000
+    def test_excludes_deleted_agents(self, authenticated_client, make_agent):
+        from django.utils import timezone
 
-    @patch("cms.assets.services.AgentConfig")
-    def test_excludes_deleted_agents(self, mock_agent_config, mock_user):
         from cms.assets.services import get_storage_used
 
-        # Simulate that active_for_user already excludes deleted agents
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": 1000}
-        mock_agent_config.active_for_user.return_value = mock_qs
-
-        assert get_storage_used(mock_user) == 1000
-
-
-# ---------------------------------------------------------------------------
-# Upload Lock Tests
-# ---------------------------------------------------------------------------
+        _client, user = authenticated_client(email="storage-del@example.com")
+        make_agent(user, name="Active", file_size_bytes=1000)
+        deleted = make_agent(user, name="Deleted", file_size_bytes=5000)
+        deleted.deleted_at = timezone.now()
+        deleted.save(update_fields=["deleted_at"])
+        assert get_storage_used(user) == 1000
 
 
 class TestUploadLock:
     def test_check_upload_in_progress_false_by_default(self):
         from mission_control.upload_session import check_upload_in_progress
 
-        session = {}
-        assert check_upload_in_progress(session) is False
+        assert check_upload_in_progress({}) is False
 
     def test_upload_lock_expires(self):
         from mission_control.upload_session import UPLOAD_LOCK_TIMEOUT, check_upload_in_progress
 
         session = {"upload_lock": {"started_at": time.time() - UPLOAD_LOCK_TIMEOUT - 10}}
         assert check_upload_in_progress(session) is False
-
-
-# Note: TestRangeToJson was removed as engine.serialization.range_to_dict no longer exists.
-# Ranges are now serialized via RangeContext.model_dump() directly in views.


### PR DESCRIPTION
First of several PRs for #957 (sequential on the `957-rewrite-mock-suites` branch). Rewrites the highest-traffic mock-coupled **mission_control** suites whose modules are *not* being decomposed, turning call-topology tests into behavior tests.

## What changed
Rewrote these suites to drive the real Django URLs/managers against a real database and assert observable behavior — HTTP responses, persisted ORM rows (`Range`, `AgentConfig`, `AuditLog`), subnet-index allocation — instead of patching first-party view/service/ORM internals:

- `tests/mission_control/test_range_api.py` — launch/cancel/destroy/get range
- `tests/mission_control/test_range_api_agents_subnets.py` — list-agents + real `Range.allocate_subnet_index`
- `tests/mission_control/test_range_api_audit.py` — real `AuditLog` rows for lifecycle actions
- `tests/mission_control/test_agents.py` — agent list/delete (S3 mocked at the `boto3` boundary)
- `tests/mission_control/test_views.py` — dashboard/settings/help pages + storage helper
- `tests/mission_control/test_models.py`, `test_engine_models.py` — catalog/Range/ActivityLog model logic

New `tests/mission_control/conftest.py` provides shared fixtures (OS rows, an `AgentConfig` factory, a hydratable custom `Scenario`, a real-launch helper). Under test settings ECS/local-provisioner are unconfigured, so the full launch → `cms.create_range` → engine path runs with **no cloud mock**.

## Boundary-mock policy (ADR-019)
- No first-party internal patches remain (only an allowed `boto3` boundary mock for the S3 delete path).
- `scripts/adr_guard/boundary_mock_baseline.json` shrunk by 35 entries (117 internal-patch allowances removed); recorded in `docs/adr/README.md`.

## Test isolation fix
Legacy mock-coupled cms suites (`test_scenario_hydrator`, `test_services_range*`) patch `cms.scenarios.hydrator.load_scenario`; under pytest-xdist that patched binding can leak into a worker that later runs these behavior tests. Added a documented autouse guard in the new conftest that restores the genuine loader binding. It is removed once those cms suites are rewritten (also under #957). Verified green under `-n2 --dist loadscope` against the actual polluters and via the full suite.

Refs #957.