### PR TITLE
test: add in-process ASGI/Channels and page-render integration suites

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -679,6 +679,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      # Redis backs the real-stack ASGI/Channels integration evidence (#924).
+      # It is consumed only by the dedicated redis-posture step below; the main
+      # test step stays on the in-memory channel layer (no REDIS_HOST), so the
+      # default test ergonomics are unchanged.
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v6
 
@@ -702,7 +715,29 @@ jobs:
           DB_PASSWORD: test
         run: |
           uv run python manage.py collectstatic --noinput
-          uv run pytest tests/ --ignore=tests/documentation --cov=. --cov-report=term-missing --cov-report=xml:coverage.xml
+          uv run pytest tests/ --ignore=tests/documentation -m "not redis" --cov=. --cov-report=term-missing --cov-report=xml:coverage.xml
+
+      # Real-stack Redis channel-layer evidence (#924). Runs only the
+      # redis-marked integration tests against the Redis service, with xdist
+      # disabled (-n0) for deterministic stateful isolation. CHANNEL_LAYER_BACKEND
+      # / REDIS_HOST are scoped to this step, so the main suite above stays
+      # in-memory.
+      - name: Run Redis channel-layer integration tests
+        working-directory: shifter/shifter_platform
+        env:
+          TESTING: "1"
+          DJANGO_DEBUG: "true"
+          DJANGO_SECRET_KEY: ${{ github.run_id }}-${{ github.run_attempt }}
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_NAME: shifter
+          DB_USER: test
+          DB_PASSWORD: test
+          CHANNEL_LAYER_BACKEND: redis
+          REDIS_HOST: localhost
+          REDIS_PORT: "6379"
+        run: |
+          uv run pytest tests/integration/asgi -m redis -n0 -p no:cacheprovider
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4

--- a/docs/architecture/asgi-render-integration-preflight-924.md
+++ b/docs/architecture/asgi-render-integration-preflight-924.md
@@ -1,0 +1,230 @@
+# ASGI and Render Integration Test Preflight (#924)
+
+Status: pre-implementation guidance
+
+Date: 2026-06-14
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/924>
+
+## Scope Boundary
+
+Issue #924 is a verification-stack change. It adds evidence for two event-load
+paths that are currently under-tested:
+
+- browser websocket paths through the real portal ASGI application and channel
+  layer, and
+- authenticated HTML page renders through the real Django template/context
+  stack with numeric query budgets.
+
+This is requirement-free work. The GitHub issue is the source of truth. The
+implementation must not redesign ASGI routing, websocket protocols, terminal
+authorization, notification semantics, context processors, page templates, or
+the channel-layer posture contract merely to make tests easier.
+
+## Architecture Decisions
+
+- Use `config.asgi.application` as the only ASGI application under test. The
+  evidence must pass through `ProtocolTypeRouter`,
+  `AllowedHostsOriginValidator`, `AuthMiddlewareStack`, and the registered
+  Mission Control, experiment, and shared websocket routing.
+- A websocket integration test that manually writes `communicator.scope["user"]`
+  or `communicator.scope["url_route"]` is not real-stack evidence. It is a
+  consumer-level test. Real-stack tests should authenticate through Django's
+  session cookie and provide allowed `Host` / `Origin` headers so the existing
+  auth and origin gates decide the scope.
+- Keep channel-layer posture explicit. Redis-backed tests should set
+  `CHANNEL_LAYER_BACKEND=redis`, `REDIS_HOST`, and `REDIS_PORT` before the
+  ASGI/settings surface is built, and should fail loud if that posture cannot
+  be established. In-memory tests should use the documented
+  `CHANNEL_LAYER_BACKEND=in_memory` posture.
+- Do not globally move the whole platform test suite onto Redis. The existing
+  default test ergonomics are in-memory unless a targeted integration slice
+  opts into Redis.
+- `WebsocketCommunicator` alone is same-process evidence. If a test claims
+  multi-process or cross-worker notification delivery, it must actually use
+  isolated processes or workers that both import the real ASGI/channel-layer
+  stack. Two communicators in one event loop do not prove that property.
+- Redis is the only posture where cross-process fan-out is expected to succeed.
+  The in-memory posture can prove same-process websocket behavior and explicit
+  non-event posture, but it must not be described as event-representative
+  multi-process delivery.
+- Terminal websocket tests must keep authorization in
+  `engine.services.connect_terminal()` / `get_ssh_connection_info()` and SSH
+  mechanics in `engine.ssh.SSHConnection`. If interaction is exercised with a
+  loopback SSH server, patch only process/network/cloud SDK boundaries; do not
+  patch `SSHConsumer`, `connect_terminal`, `SSHConnection`, or `render`.
+- Page-render query budgets must use `django.test.Client` plus
+  `CaptureQueriesContext` around the actual request/response render. The
+  existing mocked view-topology tests remain useful unit tests, but they are not
+  query-budget evidence.
+- Query budgets should be numeric, named by page/scenario, and kept in test
+  code as the executable contract. Do not use broad "current plus slack"
+  assertions or comments in place of failing numbers.
+- No new ADR is needed for this verification work. A new ADR/design decision is
+  needed only if the implementation introduces a new runtime topology,
+  channel-layer contract, metrics framework, auth exchange, schema, or public
+  diagnostic surface.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #924 |
+| --- | --- | --- |
+| ASGI application | `shifter/shifter_platform/config/asgi.py` | Import and test the existing `application`; do not create a test-only router or settings module. |
+| Websocket auth/origin | `AllowedHostsOriginValidator`, `AuthMiddlewareStack`, Django session cookies | Let middleware build `scope["user"]`; do not inject authenticated users into consumer scope for real-stack tests. |
+| Websocket routes | `mission_control/routing.py`, `cms/experiments/routing.py`, `shared/routing.py` | Use public websocket paths such as `/ws/terminal/<uuid>/` and `/ws/notifications/`; do not call consumers directly. |
+| Channel-layer config | `config/_channels.py`, `config/settings.py`, ADR-018 docs | Use `CHANNEL_LAYER_BACKEND` and `_build_channel_layers`; do not create a parallel Redis fixture/config parser. |
+| Channel-layer readiness | `config/health_checks.py`, `/health` docs for #477/#919 | Keep readiness semantics separate from fan-out integration tests; do not redefine cache health in the ASGI suite. |
+| Terminal authorization | `engine/services/_terminal.py` | Reuse range ownership, readiness, instance lookup, and secret-reference checks. |
+| SSH transport | `engine/ssh.py` | Use `asyncssh` mechanics; no SSH CLI, temp key files, or subprocess wrappers for terminal interaction tests. |
+| Terminal capacity | `mission_control/terminal_sessions.py`, `TERMINAL_*` settings | Assert per-process caps and cleanup honestly; do not imply a global cap unless a shared store is introduced by a separate issue. |
+| Notifications | `shared/notifications.py`, `shared/consumers.py`, `shared/channels/groups.py` | Reuse registration, topic validation, subscription authorization, persistence, replay, and hashed group names. |
+| Websocket close codes | `shared.enums.WebSocketCloseCode` | Assert enum values or names; do not introduce numeric literals outside established tests. |
+| Page render path | `mission_control.views._pages`, `ctf.views`, `config/settings.py` template context processors | Exercise real `render()` through `Client`; do not patch `mission_control.views.render` in query-budget tests. |
+| Context/query ownership | `mission_control.context_processors`, `shared.context_processors`, `ctf.context_processors`, `cms.services`, `ctf.bridges` | Reuse existing role, range, and permission services; no duplicate DTOs or role/group validators. |
+| Test boundaries | ADR-019 and `scripts/adr_guard/boundary_mock_baseline.json` | New tests may patch process/network/cloud SDK/framework transport boundaries only; first-party internal patch debt must not grow. |
+| CI/test workflow | `.github/workflows/_quality.yml`, `pyproject.toml` pytest settings | Add Redis only to the targeted platform integration evidence path and keep xdist-sensitive tests isolated. |
+
+## Cross-Cutting Layers
+
+- Auth surface: HTTP page tests enter through Django middleware,
+  `AuthenticationMiddleware`, login/session state, and CTF decorators.
+  Websocket tests enter through session cookies under `AuthMiddlewareStack`.
+  Test fixtures may create users/groups/profiles, but the request path must not
+  bypass these gates by manually assigning request or websocket users.
+- Host/origin surface: websocket tests must satisfy
+  `AllowedHostsOriginValidator` with allowed `Host` and `Origin` headers. Do not
+  weaken `ALLOWED_HOSTS` or use wildcard host/origin settings for tests.
+- Authorization and validation surface: terminal access is validated by engine
+  services; range-status access by CMS services; notification access by
+  `authorize_subscription()` and `validate_topic()`; CTF page access by CTF
+  decorators/services; CMS authoring links by `shared.auth`. Tests should seed
+  the required domain state and assert behavior after these validators run.
+- Secret-handling surface: Redis passwords, CA PEM, DB credentials, session
+  cookies, private SSH keys, Guacamole URLs, and cloud secrets must not be
+  printed, placed in process argv, committed as fixtures, uploaded as artifacts,
+  or logged in assertion diagnostics. Test private keys may be generated at
+  runtime and kept in memory; if a secret-store boundary is stubbed, target the
+  cloud SDK/process boundary rather than first-party service functions.
+- Env-binding surface: `CHANNEL_LAYER_BACKEND`, `REDIS_HOST`, `REDIS_PORT`, and
+  `REDIS_TLS` are the channel-layer contract. `DJANGO_SECRET_KEY`, `TESTING`,
+  and database env stay with the existing platform test job. Invalid Redis
+  posture must fail closed through `config._channels`, not be caught and
+  downgraded in a fixture.
+- Config validators: `DJANGO_SECRET_KEY`, field encryption key defaults in test
+  mode, OIDC session refresh bypass fixtures, Redis TLS password/CA validation,
+  and Django template context registration must remain active. Do not suppress
+  settings import failures or monkeypatch validators away.
+- OS/process exposure: multi-process tests must pass only non-secret knobs in
+  env/argv. They must account for process-local terminal session registries,
+  Redis connections, DB connections, websocket FDs, SSH sockets, and pytest
+  worker isolation. Stateful ASGI/Redis tests should not run under uncontrolled
+  `xdist` parallelism.
+- Network exposure: Redis in CI should be bound to the GitHub Actions service
+  network/localhost for the test job only. Loopback SSH servers, if used, stay
+  on localhost and random free ports. Do not broaden Terraform, Kubernetes, or
+  Docker Compose network posture for test convenience.
+- Error-envelope surface: browser-facing websocket failures should continue to
+  use `WebSocketCloseCode`; HTTP pages and APIs should continue using existing
+  authored responses/classifiers. Test failure output may include sanitized route
+  names, close codes, and query counts, not raw exception text with secrets.
+- Observability surface: use existing ECS-style application logging and sanitized
+  identifiers. Integration tests may assert non-secret startup posture fields
+  or aggregate counts, but should not scrape or expose Redis URLs, session
+  cookies, terminal payloads, SSH bytes, or full SQL with sensitive literals.
+- Persistence surface: tests may create normal Django rows for users, sessions,
+  ranges, notifications, and CTF state. Do not add migrations, audit tables,
+  replay schemas, or durable measurement tables for this issue.
+- Workflow surface: touching `.github/workflows/**` is guardrail work. Run
+  ADR guard and `actionlint`, and keep the workflow change limited to the Redis
+  service/env needed for the targeted integration evidence.
+
+## Extensibility Seam
+
+The durable seam is an evidence matrix, not a new runtime abstraction:
+
+- websocket path: terminal, range/status if covered, and notifications;
+- channel-layer posture: `in_memory` and `redis`;
+- process topology: same-process communicator and explicit multi-process worker
+  harness where cross-worker delivery is claimed;
+- page scenario: authenticated Mission Control dashboard, terminal, active-range
+  or participant range page, and representative CTF participant pages;
+- budget row: route name/path, fixture shape, numeric query budget, and whether
+  active range / CTF role / notification state is present.
+
+Future pages or websocket topics should add rows to that matrix without
+rewriting ASGI routing, channel-layer config, terminal authorization, shared
+notification schemas, or context processor contracts.
+
+## Gotchas
+
+- Import timing matters. Django settings and Channels layer managers cache
+  configuration. Backend posture changes should be process-isolated or use one
+  canonical fixture that rebuilds/clears the Channels layer safely.
+- `WebsocketCommunicator` against `SSHConsumer.as_asgi()` is still valuable, but
+  it is not evidence for `config.asgi.application`, origin validation, routing,
+  or auth middleware.
+- The terminal session registry is process-local by design. A reconnect-storm
+  test must assert cleanup for the process under test; it must not imply a
+  cross-process global cap.
+- Abnormal websocket close coverage must still wait for cleanup paths to run
+  before asserting registry counts, audit rows, or Redis group state.
+- Notification fan-out has both live channel-layer delivery and persisted replay
+  semantics. Test both intentionally if both are in scope; do not treat replay
+  as proof of live cross-worker delivery.
+- Query budgets are sensitive to fixture setup, auth session creation, lazy
+  context processors, and CTF group/profile lookups. Capture only the request
+  under test, after setup and login are complete.
+- A lazy object is not proof of fewer queries if common sidebars touch it on
+  every page. Budget tests must exercise fully rendered templates.
+- CI already uses `pytest-xdist` by default. Redis-backed stateful tests need a
+  deterministic isolation story such as a targeted `-n 0` command, unique Redis
+  prefixes/topics, or process-local cleanup.
+
+## Anti-Patterns
+
+- Creating a second ASGI app, URL router, Redis settings module, notification
+  registry, terminal DTO, role schema, error hierarchy, logging formatter, or
+  query-budget framework.
+- Bypassing `AllowedHostsOriginValidator`, session auth, CTF decorators,
+  context processors, or Django templates to make tests faster.
+- Growing first-party internal mocks for `render`, `connect_terminal`,
+  `get_active_range`, `get_user_role`, notification publishers, model helpers,
+  or consumer methods.
+- Treating in-memory Channels as evidence for multi-process event fan-out.
+- Sending terminal input/output through shared notification groups or Redis
+  channel-layer groups.
+- Logging terminal streams, private keys, signed Guacamole URLs, session
+  cookies, Redis auth URLs, DB credentials, or raw environment dumps.
+- Making query budgets advisory, snapshot-only, or hidden in documentation
+  instead of executable failing assertions.
+- Weakening ADR guard, import-linter, actionlint, Ruff, or CI service health
+  checks to land the suite.
+
+## Non-Goals
+
+- No implementation, production code rewrite, ASGI routing change, channel-layer
+  posture change, worker model change, or deployment topology change in this
+  preflight.
+- No new Ground Control requirement; issue #924 remains the authoritative
+  contract.
+- No new metrics framework, public diagnostic endpoint, cache policy, schema,
+  migration, audit model, notification protocol, terminal protocol, or auth
+  exchange.
+- No decision to replace Guacamole, split terminal traffic into a separate
+  service, add a global terminal cap, or make Redis mandatory for all local and
+  unit tests.
+
+## Validation
+
+For this preflight documentation change, run:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+```
+
+Implementation follow-ups must also run the stack-native checks for changed
+surfaces: from `shifter/shifter_platform`, `uv run ruff check .`,
+`uv run ruff format --check .`, targeted pytest suites for
+`tests/integration/asgi/` and `tests/integration/mission_control/`, and
+`uv run lint-imports --config ../../.importlinter` if Python imports change.
+If workflow files are touched, also run `actionlint`.

--- a/shifter/shifter_platform/pyproject.toml
+++ b/shifter/shifter_platform/pyproject.toml
@@ -58,6 +58,9 @@ pythonpath = [".."]  # Add shifter/ to path so cyberscript is importable
 # end-to-end runtime on representative slices while keeping full-suite
 # parallelism enabled.
 addopts = "-n auto --maxprocesses=4 --dist loadscope --reuse-db"
+markers = [
+    "redis: integration tests requiring a real Redis channel layer (run with -m redis -n0; needs a Redis service)",
+]
 
 [tool.coverage.run]
 # ``source = ["."]`` makes coverage record paths from the

--- a/shifter/shifter_platform/tests/integration/asgi/_redis_fanout_child.py
+++ b/shifter/shifter_platform/tests/integration/asgi/_redis_fanout_child.py
@@ -1,0 +1,34 @@
+"""Child-process entrypoint for the cross-process Redis fan-out test (#924).
+
+Lives in its own light module (only stdlib at import time; Django/Channels are
+imported lazily inside the function) so a ``multiprocessing`` spawn child can
+import it without pulling in pytest or the heavy test module. The child is a
+genuinely separate OS process that publishes to the Redis channel layer; the
+parent test process receives the message over its real ASGI websocket, proving
+fan-out crosses the process boundary through Redis.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping, Sequence
+
+
+def publish_dispatch(sys_path: Sequence[str], env: Mapping[str, str], group: str, notification_id: int) -> None:
+    """Set up Django in a fresh process and group_send one notification dispatch."""
+    for path in sys_path:
+        if path not in sys.path:
+            sys.path.insert(0, path)
+    os.environ.update(env)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+    import django
+
+    django.setup()
+
+    from asgiref.sync import async_to_sync
+    from channels.layers import get_channel_layer
+
+    layer = get_channel_layer()
+    async_to_sync(layer.group_send)(group, {"type": "notification.dispatch", "notification_id": notification_id})

--- a/shifter/shifter_platform/tests/integration/asgi/conftest.py
+++ b/shifter/shifter_platform/tests/integration/asgi/conftest.py
@@ -1,0 +1,214 @@
+"""Shared fixtures for the real-stack ASGI/Channels integration suite (#924).
+
+These tests drive the *real* ``config.asgi.application`` through
+``channels.testing.WebsocketCommunicator`` — the full
+``ProtocolTypeRouter`` -> ``AllowedHostsOriginValidator`` ->
+``AuthMiddlewareStack`` -> ``URLRouter`` stack. The channel layer is never
+mocked; authentication is via a real Django session cookie rather than
+``scope["user"]`` injection. See
+``docs/architecture/asgi-render-integration-preflight-924.md`` for the
+binding guardrails.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+from collections.abc import Iterator
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import Client
+
+User = get_user_model()
+
+# Origin/Host that satisfy the default test ``ALLOWED_HOSTS``
+# (``localhost,127.0.0.1``) so ``AllowedHostsOriginValidator`` admits the
+# handshake and the inner consumer decides the outcome.
+ALLOWED_ORIGIN = b"http://localhost"
+ALLOWED_HOST = b"localhost"
+DISALLOWED_ORIGIN = b"http://evil.example.com"
+
+
+def _redis_endpoint() -> tuple[str, int]:
+    return os.environ.get("REDIS_HOST", "localhost").strip() or "localhost", int(os.environ.get("REDIS_PORT", "6379"))
+
+
+def _redis_reachable() -> bool:
+    host, port = _redis_endpoint()
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except OSError:
+        return False
+
+
+@contextlib.contextmanager
+def _swapped_channel_layers(settings, layers: dict) -> Iterator[None]:
+    """Install ``layers`` as ``CHANNEL_LAYERS`` and rebuild the layer cache.
+
+    Channels caches built backends on ``channel_layers.backends`` and reads
+    ``settings.CHANNEL_LAYERS`` lazily, so a posture switch must clear that
+    cache both on entry (so the consumer and publisher pick up the new
+    backend) and on exit (so the next test rebuilds from the restored
+    settings). The pytest-django ``settings`` fixture restores
+    ``CHANNEL_LAYERS`` itself.
+    """
+    from channels.layers import channel_layers
+
+    settings.CHANNEL_LAYERS = layers
+    channel_layers.backends.clear()
+    try:
+        yield
+    finally:
+        channel_layers.backends.clear()
+
+
+@pytest.fixture
+def in_memory_channel_layer(settings) -> Iterator[None]:
+    """Force the in-memory channel-layer posture for the test.
+
+    Deterministic regardless of the ambient ``CHANNEL_LAYER_BACKEND`` env so
+    the same test behaves identically in the in-memory and Redis CI steps.
+    """
+    layers = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+    with _swapped_channel_layers(settings, layers):
+        yield
+
+
+@pytest.fixture
+def redis_channel_layer(settings) -> Iterator[None]:
+    """Force the Redis channel-layer posture, skipping when Redis is absent.
+
+    The layer config is built through ``config._channels`` (the canonical
+    parser) rather than a parallel fixture-local one, per the preflight.
+    """
+    if not _redis_reachable():
+        pytest.skip("Redis not reachable for the redis-posture integration test")
+
+    from config._channels import _build_channel_layers
+
+    host, port = _redis_endpoint()
+    layers = _build_channel_layers({"CHANNEL_LAYER_BACKEND": "redis", "REDIS_HOST": host, "REDIS_PORT": str(port)})
+    with _swapped_channel_layers(settings, layers):
+        yield
+
+
+@pytest.fixture
+def asgi_application():
+    """The real composed ASGI application under test."""
+    from config.asgi import application
+
+    return application
+
+
+def handshake_headers(cookie_value: str | None = None, *, origin: bytes = ALLOWED_ORIGIN) -> list[tuple[bytes, bytes]]:
+    """Build websocket handshake headers (allowed Host, given Origin, opt cookie).
+
+    A non-None ``cookie_value`` adds the ``sessionid`` cookie so
+    ``AuthMiddlewareStack`` resolves ``scope["user"]`` from the real session
+    rather than by injecting the user into the consumer scope.
+    """
+    headers = [(b"origin", origin), (b"host", ALLOWED_HOST)]
+    if cookie_value:
+        headers.append((b"cookie", f"sessionid={cookie_value}".encode()))
+    return headers
+
+
+def make_user(email: str) -> User:
+    """Create an authenticated-capable user (call from sync setup / a thread)."""
+    return User.objects.create_user(username=email, email=email, password="ws-pass-123")
+
+
+def login_cookie(user) -> str:
+    """Return the ``sessionid`` value for a real logged-in session (sync only).
+
+    Must run outside the event loop (fixture setup or ``sync_to_async``); it
+    writes the session row via the sync ORM.
+    """
+    client = Client()
+    client.force_login(user)
+    return client.cookies["sessionid"].value
+
+
+@pytest.fixture
+def ws_user(db):
+    """A single authenticated-capable user, created during sync setup."""
+    return make_user("ws-user@example.com")
+
+
+@pytest.fixture
+def ws_cookie_value(db, ws_user) -> str:
+    """The ``sessionid`` for ``ws_user``, established during sync setup."""
+    return login_cookie(ws_user)
+
+
+@pytest.fixture
+def ws_headers(ws_cookie_value) -> list[tuple[bytes, bytes]]:
+    """Authenticated handshake headers (real session cookie, allowed Origin)."""
+    return handshake_headers(ws_cookie_value)
+
+
+@pytest.fixture
+def anon_headers() -> list[tuple[bytes, bytes]]:
+    """Allowed Origin/Host but no session cookie (anonymous handshake)."""
+    return handshake_headers()
+
+
+# Test notification types/topics registered for the notification-fan-out tests.
+NOTIFICATION_TYPE = "test_type"
+NOTIFICATION_TOPIC_PREFIX = "test."
+NOTIFICATION_TOPIC = "test.fanout"
+DENY_TYPE = "deny_type"
+DENY_TOPIC_PREFIX = "deny."
+DENY_TOPIC = "deny.blocked"
+
+
+def make_notification(user, *, topic: str = NOTIFICATION_TOPIC, payload: dict | None = None):
+    """Create an undelivered, unexpired notification row (sync ORM)."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from shared.models import WebSocketNotification
+
+    return WebSocketNotification.objects.create(
+        recipient=user,
+        notification_type=NOTIFICATION_TYPE,
+        topic=topic,
+        payload=payload if payload is not None else {"msg": "hello"},
+        expires_at=timezone.now() + timedelta(hours=1),
+    )
+
+
+@pytest.fixture
+def registered_notification_type():
+    """Register an allow-all and a deny-all test notification type.
+
+    Snapshots and restores ``shared.notifications._registry`` rather than
+    clearing it, so any notification types registered at app-init survive for
+    other tests sharing the worker process. The deny type makes the
+    unauthorized-subscription assertion deterministic regardless of which
+    production types happen to be registered.
+    """
+    from shared import notifications as notif
+
+    saved = dict(notif._registry)
+    allow = notif.register_notification_type(
+        name=NOTIFICATION_TYPE,
+        topic_prefix=NOTIFICATION_TOPIC_PREFIX,
+        can_subscribe=lambda _user, _topic: True,
+        replace=True,
+    )
+    notif.register_notification_type(
+        name=DENY_TYPE,
+        topic_prefix=DENY_TOPIC_PREFIX,
+        can_subscribe=lambda _user, _topic: False,
+        replace=True,
+    )
+    try:
+        yield allow
+    finally:
+        notif._registry.clear()
+        notif._registry.update(saved)

--- a/shifter/shifter_platform/tests/integration/asgi/test_notifications_multiprocess.py
+++ b/shifter/shifter_platform/tests/integration/asgi/test_notifications_multiprocess.py
@@ -1,0 +1,81 @@
+"""Cross-process notification fan-out test through real Redis (#924, TEST-6).
+
+A ``WebsocketCommunicator`` alone is same-process evidence. To prove the
+property the issue actually cares about — a notification published on one
+worker reaching a browser connected to another — this test spawns a genuinely
+separate OS process that publishes through the Redis channel layer, while the
+parent process holds the websocket on the real ``config.asgi.application``.
+Only the Redis posture is expected to deliver across processes, so the test is
+Redis-marked and skips when Redis is unreachable.
+
+The child does only ``group_send`` (no DB): the notification row is created in
+the parent's test DB and the parent's consumer reads it back, so the test does
+not depend on the SQLite test database being shareable across processes.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sys
+
+import pytest
+from asgiref.sync import sync_to_async
+from channels.testing import WebsocketCommunicator
+
+from shared.channels.groups import notification_user_topic_group
+
+from . import _redis_fanout_child
+from .conftest import NOTIFICATION_TOPIC, _redis_endpoint, make_notification
+
+NOTIFICATIONS_PATH = "/ws/notifications/"
+
+
+def _publish_from_child(group: str, notification_id: int) -> int:
+    """Spawn a separate process to publish the dispatch; return its exit code."""
+    host, port = _redis_endpoint()
+    env = {
+        "TESTING": os.environ.get("TESTING", "1"),
+        "DJANGO_SECRET_KEY": os.environ.get("DJANGO_SECRET_KEY", "ws-multiprocess-secret"),
+        "CHANNEL_LAYER_BACKEND": "redis",
+        "REDIS_HOST": host,
+        "REDIS_PORT": str(port),
+    }
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
+        target=_redis_fanout_child.publish_dispatch,
+        args=(list(sys.path), env, group, notification_id),
+    )
+    proc.start()
+    proc.join(timeout=60)
+    if proc.is_alive():  # pragma: no cover - safety net for a hung child
+        proc.terminate()
+        proc.join(timeout=5)
+    return proc.exitcode
+
+
+@pytest.mark.redis
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_cross_process_fanout_via_redis(
+    asgi_application, ws_user, ws_headers, registered_notification_type, redis_channel_layer
+):
+    """A notification published by a separate process reaches the websocket."""
+    communicator = WebsocketCommunicator(asgi_application, NOTIFICATIONS_PATH, headers=ws_headers)
+    connected, _ = await communicator.connect()
+    assert connected is True
+    await communicator.send_json_to({"type": "subscribe", "topic": NOTIFICATION_TOPIC})
+    assert (await communicator.receive_json_from())["type"] == "subscribed"
+
+    # Row lives in the parent's DB; the child only publishes over Redis.
+    notification = await sync_to_async(make_notification)(ws_user, payload={"msg": "cross-process"})
+    group = notification_user_topic_group(ws_user.id, NOTIFICATION_TOPIC)
+
+    exitcode = await sync_to_async(_publish_from_child)(group, notification.id)
+    assert exitcode == 0
+
+    message = await communicator.receive_json_from(timeout=10)
+    assert message["type"] == "notification"
+    assert message["id"] == notification.id
+    assert message["payload"] == {"msg": "cross-process"}
+    await communicator.disconnect()

--- a/shifter/shifter_platform/tests/integration/asgi/test_notifications_ws.py
+++ b/shifter/shifter_platform/tests/integration/asgi/test_notifications_ws.py
@@ -1,0 +1,187 @@
+"""Real-stack notification websocket integration tests (#924, TEST-6).
+
+Drives ``config.asgi.application`` through ``WebsocketCommunicator`` to the
+``SharedNotificationConsumer``: authentication, origin validation, topic
+subscription/authorization, live fan-out through the real channel layer (in
+both the in-memory and Redis postures), pending-notification replay, and clean
+disconnect. The channel layer is never mocked.
+
+The live in-memory fan-out test drives ``channel_layer.group_send`` directly on
+the test's event loop because ``publish_notification`` wraps ``group_send`` in
+``async_to_sync`` (illegal from a running loop) and the in-memory layer's queues
+are loop-bound. The Redis fan-out test exercises the full ``publish_notification``
+path (persist + fan-out) offloaded via ``sync_to_async``, which Redis delivers
+across the resulting loops. Together they cover both fan-out semantics honestly.
+"""
+
+from __future__ import annotations
+
+import pytest
+from asgiref.sync import sync_to_async
+from channels.layers import get_channel_layer
+from channels.testing import WebsocketCommunicator
+
+from shared.channels.groups import notification_user_topic_group
+from shared.enums import WebSocketCloseCode
+
+from .conftest import DENY_TOPIC, NOTIFICATION_TOPIC, NOTIFICATION_TYPE, handshake_headers, make_notification
+
+NOTIFICATIONS_PATH = "/ws/notifications/"
+
+
+async def _connect_subscribed(asgi_application, headers, topic: str = NOTIFICATION_TOPIC) -> WebsocketCommunicator:
+    """Connect, subscribe to ``topic``, and consume the subscribe ack."""
+    communicator = WebsocketCommunicator(asgi_application, NOTIFICATIONS_PATH, headers=headers)
+    connected, _ = await communicator.connect()
+    assert connected is True
+    await communicator.send_json_to({"type": "subscribe", "topic": topic})
+    ack = await communicator.receive_json_from()
+    assert ack == {"type": "subscribed", "topic": topic}
+    return communicator
+
+
+@pytest.mark.django_db(transaction=True)
+class TestNotificationWebsocketRealStack:
+    """SharedNotificationConsumer reached through the real composed ASGI app."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_closed_not_authenticated(self, asgi_application, anon_headers):
+        """An anonymous notification handshake is closed NOT_AUTHENTICATED (4001)."""
+        communicator = WebsocketCommunicator(asgi_application, NOTIFICATIONS_PATH, headers=anon_headers)
+        connected, code = await communicator.connect()
+
+        assert connected is False
+        assert code == WebSocketCloseCode.NOT_AUTHENTICATED
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_authenticated_allowed_origin_accepts(self, asgi_application, ws_headers, in_memory_channel_layer):
+        """Authenticated user + allowed Origin → accepted (positive origin control)."""
+        communicator = WebsocketCommunicator(asgi_application, NOTIFICATIONS_PATH, headers=ws_headers)
+        connected, _ = await communicator.connect()
+
+        assert connected is True
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_origin_rejected(self, asgi_application, ws_cookie_value):
+        """Authenticated user + cross-origin → denied by AllowedHostsOriginValidator."""
+        from .conftest import DISALLOWED_ORIGIN
+
+        headers = handshake_headers(ws_cookie_value, origin=DISALLOWED_ORIGIN)
+        communicator = WebsocketCommunicator(asgi_application, NOTIFICATIONS_PATH, headers=headers)
+        connected, code = await communicator.connect()
+
+        assert connected is False
+        assert code == 1000
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_subscribe_authorized_topic_acks(
+        self, asgi_application, ws_headers, registered_notification_type, in_memory_channel_layer
+    ):
+        """Subscribing to an authorized topic returns a ``subscribed`` ack."""
+        communicator = await _connect_subscribed(asgi_application, ws_headers)
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_subscribe_unauthorized_topic_denied(
+        self, asgi_application, ws_headers, registered_notification_type, in_memory_channel_layer
+    ):
+        """Subscribing to a topic whose authorizer denies → PERMISSION_DENIED (4003)."""
+        communicator = WebsocketCommunicator(asgi_application, NOTIFICATIONS_PATH, headers=ws_headers)
+        connected, _ = await communicator.connect()
+        assert connected is True
+
+        await communicator.send_json_to({"type": "subscribe", "topic": DENY_TOPIC})
+        output = await communicator.receive_output()
+
+        assert output["type"] == "websocket.close"
+        assert output["code"] == WebSocketCloseCode.PERMISSION_DENIED
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_subscribe_invalid_topic_closed(self, asgi_application, ws_headers, in_memory_channel_layer):
+        """A malformed topic string → INVALID_REQUEST (4005)."""
+        communicator = WebsocketCommunicator(asgi_application, NOTIFICATIONS_PATH, headers=ws_headers)
+        connected, _ = await communicator.connect()
+        assert connected is True
+
+        await communicator.send_json_to({"type": "subscribe", "topic": "INVALID TOPIC!"})
+        output = await communicator.receive_output()
+
+        assert output["type"] == "websocket.close"
+        assert output["code"] == WebSocketCloseCode.INVALID_REQUEST
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_live_fanout_in_memory(
+        self, asgi_application, ws_user, ws_headers, registered_notification_type, in_memory_channel_layer
+    ):
+        """A group_send through the real in-memory layer reaches the subscriber."""
+        communicator = await _connect_subscribed(asgi_application, ws_headers)
+
+        notification = await sync_to_async(make_notification)(ws_user, payload={"msg": "in-memory"})
+        group = notification_user_topic_group(ws_user.id, NOTIFICATION_TOPIC)
+        await get_channel_layer().group_send(
+            group, {"type": "notification.dispatch", "notification_id": notification.id}
+        )
+
+        message = await communicator.receive_json_from()
+        assert message["type"] == "notification"
+        assert message["id"] == notification.id
+        assert message["topic"] == NOTIFICATION_TOPIC
+        assert message["payload"] == {"msg": "in-memory"}
+        await communicator.disconnect()
+
+    @pytest.mark.redis
+    @pytest.mark.asyncio
+    async def test_live_fanout_redis(
+        self, asgi_application, ws_user, ws_headers, registered_notification_type, redis_channel_layer
+    ):
+        """The full publish_notification path fans out through real Redis."""
+        from shared.notifications import publish_notification
+
+        communicator = await _connect_subscribed(asgi_application, ws_headers)
+
+        notifications = await sync_to_async(publish_notification)(
+            NOTIFICATION_TYPE,
+            topic=NOTIFICATION_TOPIC,
+            payload={"msg": "redis"},
+            recipient_ids=[ws_user.id],
+        )
+
+        message = await communicator.receive_json_from(timeout=5)
+        assert message["type"] == "notification"
+        assert message["id"] == notifications[0].id
+        assert message["payload"] == {"msg": "redis"}
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_replay_pending_on_subscribe(
+        self, asgi_application, ws_user, ws_headers, registered_notification_type, in_memory_channel_layer
+    ):
+        """Pending undelivered notifications are replayed right after subscribe."""
+        pending = await sync_to_async(make_notification)(ws_user, payload={"queued": True})
+
+        communicator = await _connect_subscribed(asgi_application, ws_headers)
+        replayed = await communicator.receive_json_from()
+
+        assert replayed["type"] == "notification"
+        assert replayed["id"] == pending.id
+        assert replayed["payload"] == {"queued": True}
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_clean_disconnect_removes_group_membership(
+        self, asgi_application, ws_user, ws_headers, registered_notification_type, in_memory_channel_layer
+    ):
+        """Disconnect runs group_discard, leaving no stale channel-layer membership."""
+        communicator = await _connect_subscribed(asgi_application, ws_headers)
+
+        layer = get_channel_layer()
+        group = notification_user_topic_group(ws_user.id, NOTIFICATION_TOPIC)
+        assert len(layer.groups.get(group, {})) == 1
+
+        await communicator.disconnect()
+        assert len(layer.groups.get(group, {})) == 0

--- a/shifter/shifter_platform/tests/integration/asgi/test_terminal_ws.py
+++ b/shifter/shifter_platform/tests/integration/asgi/test_terminal_ws.py
@@ -1,0 +1,114 @@
+"""Real-stack terminal websocket integration tests (#924, TEST-6).
+
+These drive ``config.asgi.application`` end to end through
+``WebsocketCommunicator`` — routing, ``AllowedHostsOriginValidator``,
+``AuthMiddlewareStack``, and ``SSHConsumer`` — with a real session cookie and
+the real ``mission_control.terminal_sessions.session_registry``. The channel
+layer is never mocked.
+
+Scope note (see the preflight doc): a fully *accepted* SSH session is not
+exercised here. ``engine.services.get_ssh_connection_info`` hardcodes port 22
+and resolves the host/key from a real range row, so an accepted interactive
+session would need either a production change (forbidden for this
+verification issue) or a loopback SSH server bound to a privileged port. The
+connect-rejection, capacity, origin, and slot-accounting paths fully cover the
+"connect / capacity / disconnect" acceptance criterion without mocking the
+channel layer or patching ``SSHConsumer`` / ``connect_terminal`` /
+``SSHConnection``.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from channels.testing import WebsocketCommunicator
+
+from mission_control.terminal_sessions import session_registry
+from shared.enums import WebSocketCloseCode
+
+TERMINAL_PATH = "/ws/terminal/{instance}/"
+
+
+def _terminal_url() -> str:
+    return TERMINAL_PATH.format(instance=uuid.uuid4().hex)
+
+
+@pytest.mark.django_db(transaction=True)
+class TestTerminalWebsocketRealStack:
+    """SSHConsumer reached through the real composed ASGI application."""
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_connection_closed_not_authenticated(self, asgi_application, anon_headers):
+        """An anonymous handshake is closed with NOT_AUTHENTICATED (4001)."""
+        communicator = WebsocketCommunicator(asgi_application, _terminal_url(), headers=anon_headers)
+        connected, code = await communicator.connect()
+
+        assert connected is False
+        assert code == WebSocketCloseCode.NOT_AUTHENTICATED
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_disallowed_origin_rejected_before_consumer(self, asgi_application, ws_cookie_value):
+        """A cross-origin handshake is rejected by AllowedHostsOriginValidator.
+
+        The validator wraps the terminal route, so even an authenticated user
+        with a valid session is rejected before SSHConsumer runs.
+        """
+        from .conftest import DISALLOWED_ORIGIN, handshake_headers
+
+        headers = handshake_headers(ws_cookie_value, origin=DISALLOWED_ORIGIN)
+        communicator = WebsocketCommunicator(asgi_application, _terminal_url(), headers=headers)
+        connected, code = await communicator.connect()
+
+        assert connected is False
+        # AllowedHostsOriginValidator denies the handshake itself with a plain
+        # close (default code 1000), never reaching the consumer's explicit
+        # auth close codes (e.g. 4001). The positive origin control lives in
+        # the notification suite, where an authenticated allowed-origin connect
+        # is accepted.
+        assert code == 1000
+        assert code != WebSocketCloseCode.NOT_AUTHENTICATED
+        await communicator.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_capacity_cap_rejects_when_saturated(self, asgi_application, ws_user, ws_headers, settings):
+        """When the per-process session cap is full, connect → SERVICE_UNAVAILABLE."""
+        settings.TERMINAL_MAX_SESSIONS = 1
+        settings.TERMINAL_MAX_SESSIONS_PER_USER = 1
+
+        # Saturate the single global slot so the consumer's pre-SSH cap check
+        # rejects the new connection cheaply.
+        acquired = await session_registry.try_acquire(ws_user.id, 1, 1)
+        assert acquired
+        try:
+            communicator = WebsocketCommunicator(asgi_application, _terminal_url(), headers=ws_headers)
+            connected, code = await communicator.connect()
+
+            assert connected is False
+            assert code == WebSocketCloseCode.SERVICE_UNAVAILABLE
+            await communicator.disconnect()
+        finally:
+            await session_registry.release(ws_user.id)
+
+    @pytest.mark.asyncio
+    async def test_connect_storm_does_not_leak_session_slots(self, asgi_application, ws_user, ws_headers):
+        """A burst of failing connects returns the registry to its baseline.
+
+        Each authenticated connect acquires a session slot, then fails in
+        ``SSHConsumer._open_ssh`` (no provisioned range for the instance) and
+        must release the slot on the failure path. After the storm — including
+        an abnormal client close — no slots may remain held.
+        """
+        baseline = session_registry.snapshot()["active_sessions"]
+
+        for index in range(5):
+            communicator = WebsocketCommunicator(asgi_application, _terminal_url(), headers=ws_headers)
+            connected, _code = await communicator.connect()
+            # The engine authorization / lookup runs for real and rejects the
+            # connection; it must not be accepted.
+            assert connected is False
+            # Alternate a normal and an abnormal (1006) client disconnect.
+            await communicator.disconnect(code=1006 if index % 2 else 1000)
+
+        assert session_registry.snapshot()["active_sessions"] == baseline

--- a/shifter/shifter_platform/tests/integration/mission_control/test_page_renders.py
+++ b/shifter/shifter_platform/tests/integration/mission_control/test_page_renders.py
@@ -1,0 +1,150 @@
+"""Authenticated page-render query-budget tests (#924, TEST-7).
+
+These render the authenticated pages that carry the event load through the real
+Django request/response stack with ``django.test.Client`` and count the actual
+SQL queries with ``CaptureQueriesContext`` — no ``render`` patching, no mocked
+context processors. Each budget is an exact, named integer: a regression that
+adds a query (the #898 / #852 per-render cost concern) fails the assertion and
+must be justified by bumping the number deliberately.
+
+Every authenticated Mission Control render runs the four context processors
+(``active_range``, ``terminal_cdn_assets``, ``user_permissions``,
+``ctf_navigation``); the dashboard/terminal budgets pin that shared cost, the
+active-range case pins the range-projection overhead, and the CTF case pins a
+real participant page.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.db import connection
+from django.test import Client
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+User = get_user_model()
+
+# Exact per-page query budgets. Bump deliberately (with justification) when a
+# real change adds queries; an accidental regression must fail here first.
+DASHBOARD_NO_RANGE_BUDGET = 7
+DASHBOARD_ACTIVE_RANGE_BUDGET = 11
+TERMINAL_BUDGET = 7
+CTF_PARTICIPANT_DASHBOARD_BUDGET = 21
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="render-user@example.com",
+        email="render-user@example.com",
+        password="render-pass-123",
+    )
+
+
+@pytest.fixture
+def client_for(db):
+    """Factory: a logged-in client (with OIDC session) for a given user."""
+
+    def _client(user) -> Client:
+        client = Client()
+        client.force_login(user)
+        session = client.session
+        session["oidc_id_token_expiration"] = time.time() + 3600
+        session.save()
+        return client
+
+    return _client
+
+
+@pytest.fixture
+def active_range(db, user):
+    """Seed a non-deleted CMS range so ``get_active_range`` returns a context."""
+    from cms.models import RangeInstance
+    from cms.models import Request as CMSRequest
+    from shared.enums import RequestType
+
+    request = CMSRequest.objects.create(
+        request_id=uuid.uuid4(),
+        request_type=RequestType.RANGE.value,
+        user=user,
+    )
+    return RangeInstance.objects.create(
+        request=request,
+        scenario_id="test_scenario",
+        user_id=user.id,
+        status="ready",
+    )
+
+
+@pytest.fixture
+def ctf_participant(db, user):
+    """Make ``user`` an active CTF participant with an active event selected."""
+    from ctf.enums import ParticipantStatus
+    from ctf.models import CTFEvent, CTFParticipant
+    from management.services import set_active_ctf_event
+    from shared.auth import CTF_PARTICIPANT_GROUP
+
+    event = CTFEvent.objects.create(
+        name="Render Test Event",
+        created_by=user,
+        event_start=timezone.now() - timedelta(hours=1),
+        event_end=timezone.now() + timedelta(hours=2),
+    )
+    participant = CTFParticipant.objects.create(
+        event=event,
+        user=user,
+        email=user.email,
+        name="Render Participant",
+        status=ParticipantStatus.ACTIVE.value,
+        registered_at=timezone.now(),
+    )
+    group, _ = Group.objects.get_or_create(name=CTF_PARTICIPANT_GROUP)
+    user.groups.add(group)
+    set_active_ctf_event(user, event.id)
+    return participant
+
+
+def _render_query_count(client: Client, url: str):
+    """Return (response, query_count) for a GET, capturing only the render."""
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(url)
+    return response, len(ctx.captured_queries)
+
+
+@pytest.mark.django_db
+class TestPageRenderQueryBudgets:
+    """Numeric per-render query budgets for authenticated pages."""
+
+    def test_dashboard_no_active_range_budget(self, user, client_for):
+        client = client_for(user)
+        response, queries = _render_query_count(client, "/mission-control/")
+
+        assert response.status_code == 200
+        assert queries == DASHBOARD_NO_RANGE_BUDGET
+
+    def test_dashboard_active_range_budget(self, user, client_for, active_range):
+        client = client_for(user)
+        response, queries = _render_query_count(client, "/mission-control/")
+
+        assert response.status_code == 200
+        assert queries == DASHBOARD_ACTIVE_RANGE_BUDGET
+
+    def test_terminal_budget(self, user, client_for):
+        client = client_for(user)
+        response, queries = _render_query_count(client, "/mission-control/terminal/")
+
+        assert response.status_code == 200
+        assert queries == TERMINAL_BUDGET
+
+    def test_ctf_participant_dashboard_budget(self, user, client_for, ctf_participant):
+        client = client_for(user)
+        response, queries = _render_query_count(client, "/ctf/")
+
+        assert response.status_code == 200
+        assert queries == CTF_PARTICIPANT_DASHBOARD_BUDGET


### PR DESCRIPTION
## Summary

Adds the two in-process integration suites called for by #911 review findings **TEST-6** and **TEST-7**.

Websocket coverage drives the composed `config.asgi.application` through `WebsocketCommunicator` — the full `ProtocolTypeRouter` → `AllowedHostsOriginValidator` → `AuthMiddlewareStack` → routing stack — with real session-cookie authentication and **no channel-layer mocking** (the gap the prior consumer tests left, since they used `AsyncMock()` channel layers and called consumers directly):

- **Terminal** (`SSHConsumer`): unauthenticated → `4001`, cross-origin handshake rejected at `AllowedHostsOriginValidator`, capacity cap → `4503`, and a connect storm (including abnormal close) that leaves the real `session_registry` with zero leaked slots.
- **Notifications** (`SharedNotificationConsumer`): unauthenticated → `4001`, subscribe ack / authorization-denied (`4003`) / invalid-topic (`4005`), **live fan-out through the real channel layer under both the in-memory and Redis postures**, pending-notification replay on subscribe, and clean-disconnect group cleanup.
- **Cross-process fan-out**: a genuinely separate spawned worker publishes through Redis and the parent's websocket receives it — the property a same-process communicator cannot prove.

Authenticated page renders go through the real Django request/response stack with `Client` + `CaptureQueriesContext`, asserting **exact, named per-page query budgets** (the #898 / #852 per-render cost concern) so a regression that adds a query fails the assertion.

No production code changes.

## Changes

- `tests/integration/asgi/` — real-stack websocket suites (`test_terminal_ws.py`, `test_notifications_ws.py`, `test_notifications_multiprocess.py`) and shared fixtures (`conftest.py`) that swap channel-layer posture through `config._channels` and authenticate with a real session cookie. `_redis_fanout_child.py` is the light spawn-child entrypoint.
- `tests/integration/mission_control/test_page_renders.py` — query budgets for the dashboard (with and without an active range), terminal, and CTF participant pages as exact integers (7 / 11 / 7 / 21).
- `pyproject.toml` — register the `redis` pytest marker.
- `.github/workflows/_quality.yml` — add a `redis:7` service and a dedicated `-n0` redis test step to `shifter-platform-tests`; the main step runs `-m "not redis"` so default test ergonomics stay in-memory (Redis is added only to the targeted evidence path).
- `docs/architecture/asgi-render-integration-preflight-924.md` — architecture preflight note (binding guardrails).

## Scope note

Per the preflight, a fully **accepted interactive SSH terminal session** is out of scope: `engine.services.get_ssh_connection_info` hardcodes port 22, so an accepted session would need either a production change (forbidden for this verification issue) or root to bind a privileged port in CI. The connect-rejection, capacity, origin, and slot-accounting paths fully cover the "connect / capacity / disconnect" acceptance criterion without mocking the channel layer or patching `SSHConsumer` / `connect_terminal` / `SSHConnection`.

## Traceability

- AC1 (terminal connect/capacity/disconnect, no channel-layer mocking) ← `tests/integration/asgi/test_terminal_ws.py`
- AC1 (notification fan-out, no channel-layer mocking) ← `tests/integration/asgi/test_notifications_ws.py`
- AC1 (multi-process notification delivery) ← `tests/integration/asgi/test_notifications_multiprocess.py`
- AC2 (numeric page query budgets) ← `tests/integration/mission_control/test_page_renders.py`

ADR context: ADR-021 (gated agentic development loop), ADR-018 (channel-layer posture), ADR-019 (boundary-mock policy).

## Test plan

- In-memory slice runs green under the default xdist config: `pytest tests/integration/asgi tests/integration/mission_control/test_page_renders.py -m "not redis"`.
- Redis slice runs green against a local Redis container: `CHANNEL_LAYER_BACKEND=redis REDIS_HOST=localhost pytest tests/integration/asgi -m redis -n0` (live fan-out + cross-process delivery).
- Page-render budgets are deterministic across repeated runs.
- `ruff check` / `ruff format --check`, `lint-imports`, `actionlint`, `adr_guard --all --level ci`, and `pre-commit run` all pass. Both AI reviewers (codex pre-push, test-quality) returned clean.

Changelog: no fragment — test + CI + config change with no user-facing behavior (per the repo plan rules' CI-only / non-user-visible carve-out).

Closes #924
