### PR TITLE
docs: record range isolation and single-AZ placement as ADRs

### DIFF
--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -825,5 +825,70 @@
       "docs/adr/README.md",
       "shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md"
     ]
+  },
+  {
+    "id": "ADR-020",
+    "title": "Range internet isolation is enforced by routing and Network Firewall default-deny, not security-group egress",
+    "status": "accepted",
+    "scope": "repository",
+    "decision": "All concurrent per-user ranges share one stable range VPC, each range in its own ephemeral subnet. Range network isolation splits responsibility across two layers by design: per-subnet security groups (`aws_security_group.subnet` in shifter/engine/provisioner/terraform/modules/range/main.tf) own local L4 reachability and gate only ingress (the subnet's own CIDR, `connected_to` peers, and portal SSH/RDP), while the route table plus AWS Network Firewall own internet egress containment. The security groups intentionally allow all egress (`0.0.0.0/0`, protocol -1) because security groups cannot express the domain/SNI allowlists, direct-IP-SNI rejection, and all-protocol default-deny the range needs; encoding a partial egress allowlist there would be redundant with and weaker than the firewall. The all-egress security group is acceptable only because every range route table sends `0.0.0.0/0` to the firewall endpoint (`aws_route.private_to_firewall` in platform/terraform/modules/range/vpc/firewall.tf; runtime `aws_route.firewall`) and the firewall STRICT_ORDER policy drops all unmatched egress at priority 100 (`drop_all`), with narrow allow lanes for victim IPs/domains, DNS to 8.8.8.8, and NTP. Blast radius: a compromised range host cannot reach another range (target security-group ingress denies it) and cannot reach the internet except through the firewall's allowlisted lanes. Cross-range and participant internet isolation therefore relies on the Network Firewall default-deny, not on security groups (review finding NET-7). The rationale and live model are recorded in docs/architecture/range-isolation-model.md; the configurable egress allowlist layered on this base is ADR-017.",
+    "rules": [
+      {
+        "id": "ADR-020-R1",
+        "description": "Per-range security groups gate ingress only (own subnet CIDR, `connected_to` peers, and portal SSH/RDP) and intentionally allow all egress. Security groups must not be documented or relied upon as the control for range internet-egress isolation.",
+        "checks": []
+      },
+      {
+        "id": "ADR-020-R2",
+        "description": "Range internet-egress isolation is owned by the route table (user-subnet `0.0.0.0/0` to the firewall endpoint) plus the AWS Network Firewall STRICT_ORDER default-deny (`drop_all`, priority 100). The all-egress security groups are acceptable only while that route-table-to-firewall path and default-deny remain intact; weakening either is a security-posture change requiring a matching ADR update.",
+        "checks": []
+      },
+      {
+        "id": "ADR-020-R3",
+        "description": "`enable_network_firewall = false` routes user subnets straight to NAT (`aws_route.private_to_nat`) and removes the default-deny, leaving the all-egress security groups unrestricted; it is an explicit dev-only opt-out. Making the firewall optional in any production profile requires its own ADR and guardrail.",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": ["agent-policy"],
+    "evidence": [
+      "shifter/engine/provisioner/terraform/modules/range/main.tf",
+      "platform/terraform/modules/range/vpc/main.tf",
+      "platform/terraform/modules/range/vpc/firewall.tf",
+      "platform/terraform/modules/range/vpc/nat.tf",
+      "docs/architecture/range-isolation-model.md",
+      "docs/architecture/range-egress-ip-allowlist.md"
+    ]
+  },
+  {
+    "id": "ADR-021",
+    "title": "Range placement is single-AZ; multi-AZ is deferred",
+    "status": "accepted",
+    "scope": "repository",
+    "decision": "The stable range VPC and every concurrent range placed in it are pinned to a single availability zone, the first AZ the account exposes (`local.primary_az = data.aws_availability_zones.available.names[0]` in platform/terraform/modules/range/vpc/nat.tf). The NAT, firewall, persistent-NGFW, and SSM-endpoint subnets are placed in that AZ; the AZ is published as the module `availability_zone` output, bound into the provisioner as `RANGE_AVAILABILITY_ZONE` (platform/terraform/modules/engine-provisioner/task_definition.tf, shifter/engine/provisioner/config.py), and applied to runtime range subnets and instances (shifter/engine/provisioner/terraform/modules/range/main.tf). `ec2:RunInstances` is IAM-constrained to that AZ (platform/terraform/modules/engine-provisioner/iam.tf). This is a deliberate cost-and-simplicity decision for ephemeral ranges: one NAT Gateway and one firewall endpoint serve all ranges, inter-AZ data-transfer charges are avoided, and routing/endpoint placement stays single-target. It accepts a concentrated failure domain (a single-AZ impairment takes out all concurrent ranges) and a capacity ceiling bounded by one AZ. Explicit decision: multi-AZ range placement is not warranted now (review finding NET-8); it is revisited if ranges gain non-reprovisionable durable state, an availability SLO is placed on individual active ranges, or one AZ's capacity becomes the binding constraint. The rationale, trade-offs, and future placement seam are recorded in docs/architecture/range-single-az-placement.md.",
+    "rules": [
+      {
+        "id": "ADR-021-R1",
+        "description": "The range VPC and all concurrent ranges are placed in a single availability zone, selected once as the account's first AZ and propagated through the `availability_zone` output, `RANGE_AVAILABILITY_ZONE`, and the `ec2:AvailabilityZone` IAM condition. This is the accepted posture for ephemeral ranges and trades availability and per-AZ capacity for cost and simplicity.",
+        "checks": []
+      },
+      {
+        "id": "ADR-021-R2",
+        "description": "Multi-AZ range placement is deferred. If later warranted it must be introduced as an explicit placement contract -- an environment-owned ordered zone list, a per-range placement selector feeding both stable and runtime modules, and a deterministic per-AZ egress target (firewall endpoint per AZ) so the ADR-020 default-deny holds in every AZ -- not as an ad-hoc `multi_az` boolean or a stray `data.aws_availability_zones` lookup in the runtime module.",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": ["agent-policy"],
+    "evidence": [
+      "platform/terraform/modules/range/vpc/nat.tf",
+      "platform/terraform/modules/range/vpc/outputs.tf",
+      "platform/terraform/modules/engine-provisioner/task_definition.tf",
+      "platform/terraform/modules/engine-provisioner/iam.tf",
+      "shifter/engine/provisioner/config.py",
+      "shifter/engine/provisioner/terraform_vars.py",
+      "shifter/engine/provisioner/terraform/modules/range/main.tf",
+      "docs/architecture/range-single-az-placement.md"
+    ]
   }
 ]

--- a/docs/architecture/range-isolation-model.md
+++ b/docs/architecture/range-isolation-model.md
@@ -1,0 +1,156 @@
+# Range Network Isolation Model
+
+Scope: #959 (review finding NET-7). This document records the *existing* AWS
+range network isolation model and the blast-radius rationale for two design
+choices that were defensible but undocumented: per-range security groups allow
+all egress, and cross-range / participant containment is owned by the AWS
+Network Firewall default-deny rather than by security groups. ADR-020 records
+the binding decision; this document is its rationale and live-model reference.
+The preflight artifact is
+[range-isolation-placement-preflight-959.md](range-isolation-placement-preflight-959.md).
+The configurable egress allowlist layered on top of this base is ADR-017 /
+[range-egress-ip-allowlist.md](range-egress-ip-allowlist.md); this document does
+not duplicate that contract.
+
+This is documentation of the current posture. It changes no Terraform, security
+group, firewall policy, route table, or IAM behavior.
+
+## Topology in one paragraph
+
+All concurrent per-user ranges share **one** stable range VPC
+(`platform/terraform/modules/range/vpc/`). Each range gets its own ephemeral
+subnets carved from the VPC CIDR by the runtime provisioner module
+(`shifter/engine/provisioner/terraform/modules/range/main.tf`). Internet-bound
+traffic flows **user subnet → AWS Network Firewall → NAT Gateway → IGW**. The
+firewall runs a STRICT_ORDER stateful policy whose last rule drops all unmatched
+egress (default-deny). Two layers therefore do two different jobs, and the
+split is the whole point of the design:
+
+| Layer | Owns | Where |
+| --- | --- | --- |
+| Per-subnet security group | Local L4 **reachability** (ingress) | `modules/range/main.tf` `aws_security_group.subnet` |
+| Route table + Network Firewall | Internet **egress** containment | `modules/range/vpc/firewall.tf`, runtime `aws_route.firewall` |
+
+## Security groups gate ingress, not egress
+
+Each range subnet gets exactly one security group
+(`aws_security_group.subnet`, one per subnet). Its rules are:
+
+- **Intra-subnet ingress:** allow all protocols from the subnet's own CIDR.
+- **Connected-peer ingress:** for each `connected_to` entry in the scenario
+  topology, allow all protocols from the peer subnet's CIDR
+  (`aws_security_group_rule.connected_subnet`). The comment notes the NGFW does
+  the actual filtering between connected subnets when present.
+- **Portal management ingress:** TCP 22 (SSH) and TCP 3389 (RDP) from the
+  portal VPC CIDR only (`aws_security_group_rule.portal_ssh` /
+  `portal_rdp`), reachable over VPC peering.
+- **All egress:** protocol `-1`, `0.0.0.0/0` ("Allow all outbound traffic").
+
+So the security group is an **ingress** allowlist: a range subnet accepts L4
+traffic only from its own range (its subnet plus declared `connected_to` peers)
+and from the portal's management ports. It deliberately does **not** restrict
+egress.
+
+### Why egress is left wide open
+
+Security groups are stateful L4 (protocol/port/CIDR) filters. They cannot
+express the controls the range actually needs on egress: TLS-SNI / HTTP-Host
+domain allowlists, direct-IP-as-SNI rejection, or a default-deny that also
+covers non-HTTP protocols. Encoding a partial IP-based egress allowlist in the
+security group would be **redundant with, and weaker than**, the firewall, and
+would split the egress policy across two control planes. The design therefore
+makes the AWS Network Firewall the single egress control plane and leaves the
+security group egress open. **The all-egress security group is safe only
+because** every range route table sends `0.0.0.0/0` to the firewall endpoint and
+the firewall's final rule drops everything not explicitly allowlisted.
+
+## The Network Firewall default-deny is the egress control plane
+
+The stable range VPC pins user-subnet egress to the firewall and the firewall
+enforces default-deny:
+
+- **Routing:** the private route table sends user-subnet `0.0.0.0/0` to the
+  firewall endpoint (`firewall.tf` `aws_route.private_to_firewall`); the runtime
+  module attaches each range subnet to a route table whose `0.0.0.0/0` target is
+  the firewall endpoint (`main.tf` `aws_route.firewall`, gated on
+  `var.firewall_endpoint_id`). The firewall subnet routes onward to NAT, and NAT
+  to the IGW.
+- **Policy (STRICT_ORDER, lower priority evaluated first):** NGFW-subnet bypass
+  (priority 1, only with persistent NGFW infrastructure); victim IP allowlist on
+  TCP 443 to PANW/GCP CIDRs (chunked); victim domain SNI/Host allowlist; optional
+  Kali domain allowlist; NTP (priority 98); DNS to `8.8.8.8` only (priority 99);
+  and **`drop ip $HOME_NET any -> $EXTERNAL_NET any` at priority 100, dropping
+  all unmatched egress** across all protocols and ports. A separate stateful rule
+  rejects TLS connections whose SNI is a literal IP address, so the domain
+  allowlist cannot be bypassed by dialing an IP directly.
+- The default SG of the range VPC is adopted and stripped to deny-all
+  (`modules/range/vpc/main.tf` `aws_default_security_group.this`) so no workload
+  can fall back to a permissive default.
+
+## Cross-range and participant isolation
+
+Because all ranges share one VPC, the VPC's implicit local route makes every
+range subnet CIDR reachable at the IP layer. Isolation is the composition of the
+two layers above:
+
+- **Lateral (within the shared VPC):** a range subnet's security group admits
+  ingress only from its own range (own CIDR + `connected_to` peers) and the
+  portal's management ports. Another range's subnet CIDR is **not** in that
+  ingress allowlist, so a host in range A cannot open L4 connections into range
+  B. Security-group *ingress* is what segments ranges from each other locally.
+- **Internet (egress / exfiltration / C2):** a compromised range host has open
+  security-group egress, but the route-table-to-firewall path plus the
+  default-deny means it can only reach the narrow allowlisted destinations
+  (victim XDR/XSIAM endpoints, DNS, NTP). It cannot reach an arbitrary internet
+  host to exfiltrate data, stage C2, or pivot out of the range. **This internet
+  containment relies on the Network Firewall default-deny, not on security
+  groups.**
+
+That division is the finding NET-7 documents: security groups own local
+reachability; the firewall owns internet egress. Neither layer provides VPC-level
+isolation between ranges, and the design does not claim it does: ranges are
+co-tenant subnets in one VPC by deliberate choice (see the single-AZ placement
+decision, ADR-021 / [range-single-az-placement.md](range-single-az-placement.md)).
+
+## Blast radius
+
+- A compromise contained to one range instance cannot reach another range's
+  hosts (target security-group ingress denies it) and cannot reach the internet
+  except through the firewall's allowlisted lanes (default-deny drops the rest).
+- The failure mode that would widen the blast radius is loss of the firewall
+  egress path, because the security groups would then impose no egress limit at
+  all. That is exactly the NAT-bypass hazard below.
+
+## The `enable_network_firewall = false` NAT-bypass hazard
+
+When `enable_network_firewall = false`, the private route table's `0.0.0.0/0`
+target becomes the NAT Gateway directly (`firewall.tf`
+`aws_route.private_to_nat`) and the runtime module's firewall route is not
+created (it is gated on a non-empty `firewall_endpoint_id`). In that mode there
+is **no default-deny**: the all-egress security groups now allow unrestricted
+outbound internet access from every range host. This is acceptable only as an
+explicit, dev-only opt-out. Making the firewall optional in any production
+profile is a security-posture change that requires its own ADR and guardrail; it
+is out of scope for this documentation issue.
+
+## Evidence
+
+| Concern | File |
+| --- | --- |
+| Per-subnet SG (all egress, ingress allowlist) | `shifter/engine/provisioner/terraform/modules/range/main.tf` |
+| Default SG lockdown | `platform/terraform/modules/range/vpc/main.tf` |
+| Firewall policy, default-deny, IP-SNI reject, routing | `platform/terraform/modules/range/vpc/firewall.tf` |
+| NAT path | `platform/terraform/modules/range/vpc/nat.tf` |
+| Configurable egress allowlist (layered on this base) | ADR-017, `docs/architecture/range-egress-ip-allowlist.md` |
+
+## Non-goals
+
+- No change to security groups, firewall policy, routing, NAT, or the
+  `enable_network_firewall` default.
+- No claim that security groups enforce cross-range internet isolation, and no
+  claim that all-egress security groups are safe independent of the route-table
+  and default-deny dependency.
+- No multi-VPC-per-range redesign; that is a placement question handled by
+  ADR-021.
+- This document does not restate the ADR-017 egress allowlist contract; it
+  documents the base posture that contract configures.

--- a/docs/architecture/range-isolation-placement-preflight-959.md
+++ b/docs/architecture/range-isolation-placement-preflight-959.md
@@ -1,0 +1,149 @@
+# Range Isolation And Placement ADR Preflight (#959)
+
+Status: pre-implementation guidance
+
+Date: 2026-06-15
+
+Tracking issue: GitHub #959, "network: document range isolation and single-AZ
+placement as ADRs".
+
+This is a requirement-free preflight. The issue body is the shipping contract:
+record the AWS range isolation model and the single-AZ placement decision as
+ADRs, including blast-radius rationale and any explicit decision to change
+placement. This note is not itself the ADR and does not implement the issue.
+
+## Architecture Decisions
+
+- Keep the two decisions separate. The isolation model is a reachability and
+  inspection decision: per-range security groups intentionally allow broad
+  outbound traffic while internet egress is forced through AWS Network
+  Firewall default-deny policy. Single-AZ placement is a failure-domain,
+  capacity, and cost decision: stable range infrastructure and runtime range
+  subnets are currently pinned to one AZ.
+- Reuse the existing range egress vocabulary from ADR-017 and
+  `docs/architecture/range-egress-ip-allowlist.md`. Do not create a second
+  "range isolation" schema for CIDR/domain allowlists, and do not rename the
+  public `settings.range_egress` contract while documenting the current AWS
+  posture.
+- The ADR should document the live AWS model before recommending changes:
+  `enable_network_firewall = true` sends user-subnet 0/0 traffic to the
+  firewall endpoint; the stateful policy allows NGFW bypass when enabled,
+  victim CIDR/domain lanes, optional Kali domains, DNS, NTP, then drops all
+  unmatched egress.
+- The ADR should also document the explicit opt-out hazard:
+  `enable_network_firewall = false` routes private traffic to NAT directly.
+  If future work makes the firewall optional in a production profile, that is a
+  policy change and needs its own guardrail.
+- For single-AZ placement, prefer documenting the current decision unless the
+  issue is explicitly expanded to implement multi-AZ. A real multi-AZ range
+  design would affect stable range VPC subnets, runtime subnet placement,
+  Network Firewall endpoint mapping, NAT routing, S3/SSM endpoint placement,
+  engine-provisioner environment variables, IAM conditions, and tests.
+- Multi-AZ placement, if later warranted, needs a provider-neutral placement
+  seam such as an ordered zone list plus a per-range placement selector. It
+  should not be introduced as ad hoc use of `data.aws_availability_zones` in
+  the runtime module only.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #959 |
+| --- | --- | --- |
+| ADR registry | `docs/adr/index.yaml`, `docs/adr/README.md`, `docs/adr/exceptions.yaml` | Add accepted decision records through the machine-readable ADR registry. If a new enforceable rule or exception is added, update evidence and exception metadata there. |
+| ADR enforcement | `scripts/adr_guard/adr_guard.py`, `.gc/plan-rules.md`, `shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md` | ADR/guardrail-file changes must pass `adr_guard`; new enforcement belongs in `adr_guard`, not prose only. |
+| Range egress decision | ADR-017 in `docs/adr/index.yaml`, `docs/architecture/range-egress-ip-allowlist.md`, `shifter/installation/range_egress.py` | Extend or reference this contract for egress policy language instead of duplicating CIDR/domain schema or validation rules. |
+| AWS range VPC | `platform/terraform/modules/range/vpc/{main,nat,firewall,variables,outputs}.tf`, env roots under `platform/terraform/environments/{dev,prod}/range/` | These own stable VPC, default SG lockdown, NAT, Network Firewall, S3/SSM endpoints, outputs, and current `local.primary_az`. |
+| Runtime range module | `shifter/engine/provisioner/terraform/modules/range/{variables,main,outputs}.tf` | Per-range subnets, per-subnet SGs, routes, and EC2 placement are runtime Terraform, not stable platform Terraform. |
+| Env binding | `platform/terraform/modules/engine-provisioner/task_definition.tf`, `platform/terraform/environments/{dev,prod}/portal/main.tf`, `shifter/engine/provisioner/config.py`, `terraform_vars.py` | Range VPC outputs flow into the provisioner as `RANGE_VPC_*`, `RANGE_AVAILABILITY_ZONE`, and `FIREWALL_ENDPOINT_ID`. Preserve the contract unless the ADR explicitly records a migration. |
+| IAM placement guard | `platform/terraform/modules/engine-provisioner/iam.tf` | `ec2:RunInstances` volume creation is constrained to `var.range_availability_zone`; multi-AZ changes must update IAM intentionally. |
+| Live networking docs | `shifter/shifter_platform/documentation/docs/technical/platform_infrastructure/networking.md` | User-facing platform docs should match the ADR once the ADR lands. Deprecated docs are not the source of truth. |
+
+## Cross-Cutting Layers
+
+- Auth surface: the ADR should not change Cognito/OIDC, CTF participant auth,
+  terminal access auth, or Guacamole broker behavior. Range reachability from
+  the portal remains the existing peering plus SSH/RDP path.
+- Secret-handling surface: CIDRs, AZ names, subnet IDs, route table IDs,
+  firewall endpoint IDs, and ADR text are non-secret configuration. Do not move
+  them into Secrets Manager, SSM SecureString, Kubernetes Secrets, or runtime
+  secret env vars. Existing SSH keys and guest passwords remain in the current
+  Secrets Manager paths.
+- Env-binding shape: keep range placement and firewall endpoint data flowing
+  through Terraform outputs into typed module variables and task env vars. Do
+  not add a parallel YAML parser, Django setting, or workflow variable for the
+  ADR-only change.
+- Terraform validation and policy gates: stable range VPC changes must keep
+  Terraform typing/validation, Checkov exceptions, TFLint, and `adr_guard`
+  intact. If new Checkov skips appear, they require `docs/adr/exceptions.yaml`
+  entries with owner and expiry.
+- Routing/security policy: per-range SG all-egress is acceptable only because
+  route tables send 0/0 to the firewall endpoint and the firewall policy drops
+  unmatched egress. Document that SGs decide local reachability while Network
+  Firewall owns internet egress filtering; do not claim SGs enforce cross-range
+  internet isolation.
+- OS/process exposure: an ADR-only change should not add shell commands. If a
+  future migration script is added, use existing argv-array subprocess patterns
+  and keep credentials out of process arguments.
+- Error envelope: expected failures for future infrastructure changes should
+  surface through Terraform validate/plan/apply, Checkov/TFLint, and ADR guard.
+  Do not add Django exceptions, API DTOs, repositories, or user-facing error
+  envelopes for a documentation-only ADR.
+- Observability/logging: Network Firewall FLOW/ALERT logs and optional VPC flow
+  logs are the evidence surfaces. Do not make application logs the source of
+  truth for range isolation.
+
+## Extensibility Seam
+
+The immediate seam is documentation plus existing Terraform outputs. The next
+reasonable change is multi-AZ placement. That needs an environment-owned zone
+list and a per-range placement selector that can feed both stable range
+infrastructure and runtime range Terraform. It must also return firewall
+endpoint IDs by AZ or otherwise define a deterministic route target for each
+runtime subnet. Avoid a boolean `multi_az` flag without an explicit placement
+contract; it will hide routing, endpoint, IAM, and capacity semantics behind a
+single overloaded knob.
+
+## Gotchas And Anti-Patterns
+
+- Do not conflate AWS Network Firewall, persistent VM-Series NGFW, portal VPC
+  inspection, security groups, GCP VPC firewall rules, Kubernetes
+  NetworkPolicy, and Cyberscript `connected_to`. They are distinct layers.
+- Do not treat `connected_to` as cross-range or participant isolation. It is a
+  scenario topology contract for within-range subnet reachability.
+- Do not document "all-egress SGs are safe" without the matching route-table
+  and Network Firewall default-deny dependency.
+- Do not change `enable_network_firewall`, firewall rule order, DNS/NTP lanes,
+  NGFW bypass, NAT routing, or endpoint outputs as part of the ADR-only issue.
+- Do not copy the portal per-AZ inspection design into the range VPC by
+  analogy. Portal inspection has ALB cross-zone and east-west visibility goals;
+  range egress has per-range runtime subnet placement and default-deny egress
+  goals.
+- Do not rely on the stale `docs/architecture/gcp-vpc-firewall-preflight.md`
+  issue-number reference for this work. Use the current issue title/body and
+  acceptance criteria as the contract.
+- Do not add a changelog fragment for a pure ADR/preflight-only change unless
+  the final PR makes a user-visible documentation release note worthwhile.
+
+## Non-Goals
+
+- No Terraform implementation, runtime placement change, SG rule change,
+  firewall policy change, NAT/endpoint redesign, or multi-AZ migration.
+- No root `shifter.yaml` schema change, installation parser change, Django
+  setting, service, model, DTO, API, repository, exception hierarchy, or logging
+  framework.
+- No GCP, Kubernetes, Helm, GDC, portal VPC inspection, or persistent VM-Series
+  NGFW implementation.
+- No new ADR guard unless the implementation introduces a new enforceable rule.
+- No Ground Control requirement or traceability work; this run is
+  requirement-free and the GitHub issue is the contract.
+
+## Validation Expectations
+
+For the ADR implementation that follows, run:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+```
+
+If the implementation touches Terraform or workflows despite the ADR-only
+scope, also run the stack-native validators required by `.gc/plan-rules.md` for
+those touched surfaces.

--- a/docs/architecture/range-single-az-placement.md
+++ b/docs/architecture/range-single-az-placement.md
@@ -1,0 +1,119 @@
+# Range Single-AZ Placement
+
+Scope: #959 (review finding NET-8). This document records the *existing*
+single-availability-zone placement of the range VPC and all concurrent ranges,
+its blast-radius and capacity rationale, and the explicit decision on whether
+multi-AZ placement is warranted. ADR-021 records the binding decision; this
+document is its rationale and live-model reference. The preflight artifact is
+[range-isolation-placement-preflight-959.md](range-isolation-placement-preflight-959.md).
+
+This is documentation of the current posture. It changes no Terraform, IAM, or
+runtime behavior.
+
+## Current state: everything lands in one AZ
+
+The range VPC and every range placed in it are pinned to a single availability
+zone: the first AZ the account exposes in the region.
+
+- **Stable range VPC infrastructure** picks the AZ once:
+  `local.primary_az = data.aws_availability_zones.available.names[0]`
+  (`platform/terraform/modules/range/vpc/nat.tf`). The NAT subnet, firewall
+  subnet, persistent-NGFW subnet, and SSM/Bedrock-endpoint subnet are all placed
+  in `local.primary_az` (`nat.tf`, `firewall.tf`, `ngfw.tf`,
+  `ssm-endpoints.tf`). The chosen AZ is published as the module's
+  `availability_zone` output (`outputs.tf`).
+- **The provisioner is bound to that AZ.** The stable output flows into the
+  engine-provisioner as `RANGE_AVAILABILITY_ZONE`
+  (`platform/terraform/modules/engine-provisioner/task_definition.tf`), read by
+  `get_range_availability_zone` (`shifter/engine/provisioner/config.py`) and
+  passed to the runtime module as `availability_zone`
+  (`shifter/engine/provisioner/terraform_vars.py`).
+- **Runtime range subnets and instances** are placed in `var.availability_zone`
+  (`shifter/engine/provisioner/terraform/modules/range/main.tf`
+  `aws_subnet.range`), so every subnet of every concurrent range shares the one
+  AZ.
+- **IAM enforces the AZ.** `ec2:RunInstances` is constrained with a condition
+  `ec2:AvailabilityZone = var.range_availability_zone`
+  (`platform/terraform/modules/engine-provisioner/iam.tf`), so the provisioner
+  cannot launch range instances outside the chosen AZ even by accident.
+
+## Rationale for single-AZ
+
+Single-AZ placement is a deliberate cost-and-simplicity choice for ephemeral
+training/exercise ranges:
+
+- **Cost.** One NAT Gateway and one Network Firewall endpoint serve all ranges.
+  Per-AZ NAT and firewall endpoints would multiply two of the most expensive
+  fixed line items by the AZ count. Keeping all range traffic in one AZ also
+  avoids inter-AZ data-transfer charges between range hosts, the firewall, and
+  NAT.
+- **Simplicity.** Routing, firewall endpoint mapping, and S3/SSM endpoint
+  placement are single-target. There is no per-AZ route-target selection, no
+  per-AZ firewall endpoint, and no AZ-aware subnet allocation to maintain.
+- **Workload nature.** Ranges are short-lived and individually reprovisionable.
+  The durable state that must survive (catalog, portal, user data) lives in the
+  portal/platform tiers, which are independently multi-AZ; a range is cattle, not
+  a pet.
+
+## Trade-off accepted (blast radius and capacity)
+
+- **Concentrated failure domain.** A single-AZ impairment takes out *all*
+  concurrent ranges at once, plus the shared NAT/firewall path. There is no
+  in-AZ redundancy for active ranges; recovery is reprovisioning in a healthy AZ,
+  which today requires changing the pinned AZ.
+- **Capacity ceiling.** Total concurrent range capacity is bounded by one AZ's
+  limits: instance-type capacity in that AZ, subnet IP space, and ENI / NAT
+  port limits. Scaling out cannot borrow capacity from sibling AZs.
+
+These are the costs NET-8 flags. For the current scale and the ephemeral nature
+of ranges they are acceptable; the durable platform is unaffected.
+
+## Decision: defer multi-AZ
+
+**Multi-AZ range placement is not warranted now.** The cost and complexity of
+per-AZ NAT, per-AZ firewall endpoints, and AZ-aware placement outweigh the
+availability benefit for ephemeral ranges whose recovery path is
+reprovisioning. The decision is revisited if any of these change: ranges gain
+long-lived state that cannot be reprovisioned cheaply; an availability SLO is
+placed on individual active ranges; or one AZ's capacity becomes the binding
+constraint on concurrent ranges.
+
+## The seam a future multi-AZ change must use
+
+If multi-AZ is later warranted, it must be introduced as an explicit placement
+contract, **not** as an ad-hoc `multi_az` boolean or a stray
+`data.aws_availability_zones` lookup in the runtime module:
+
+- An environment-owned **ordered zone list** replacing the implicit
+  `names[0]` pick, so the set of usable AZs is configuration, not discovery
+  order.
+- A **per-range placement selector** that assigns each range to an AZ from that
+  list and feeds both the stable infrastructure and the runtime range module.
+- A deterministic **per-subnet route target** per AZ (either a Network Firewall
+  endpoint per AZ or another explicit egress target) so the default-deny egress
+  model (ADR-020) holds in every AZ rather than hairpinning cross-AZ to a single
+  endpoint.
+- Matching updates to the `ec2:AvailabilityZone` IAM condition, NAT placement,
+  and S3/SSM endpoint placement.
+
+A bare boolean would hide routing, endpoint, IAM, and capacity semantics behind
+one overloaded knob; the placement contract keeps them explicit.
+
+## Evidence
+
+| Concern | File |
+| --- | --- |
+| Stable AZ pick + NAT subnet | `platform/terraform/modules/range/vpc/nat.tf` |
+| Firewall / NGFW / SSM-endpoint subnet placement | `platform/terraform/modules/range/vpc/{firewall,ngfw,ssm-endpoints}.tf` |
+| AZ output | `platform/terraform/modules/range/vpc/outputs.tf` |
+| Env binding (`RANGE_AVAILABILITY_ZONE`) | `platform/terraform/modules/engine-provisioner/task_definition.tf`, `shifter/engine/provisioner/config.py`, `terraform_vars.py` |
+| Runtime subnet/instance placement | `shifter/engine/provisioner/terraform/modules/range/main.tf` |
+| IAM AZ constraint | `platform/terraform/modules/engine-provisioner/iam.tf` |
+
+## Non-goals
+
+- No multi-AZ implementation, no change to AZ selection, NAT/firewall/endpoint
+  placement, or the `ec2:AvailabilityZone` IAM condition.
+- No change to the portal/platform tiers' own (independent) AZ posture.
+- This document records the placement decision only; the egress isolation model
+  is ADR-020 / [range-isolation-model.md](range-isolation-model.md).


### PR DESCRIPTION
## Summary

Documents two already-implemented but undocumented range-network design decisions as ADRs (review findings NET-7, NET-8). ADR-020 records that per-range security groups allow all egress and gate only ingress, while range internet-egress isolation is owned by routing plus the AWS Network Firewall default-deny, including the enable_network_firewall=false NAT-bypass hazard. ADR-021 records that the range VPC and all concurrent ranges are single-AZ as a deliberate cost/simplicity trade-off, explicitly defers multi-AZ, and captures the placement seam a future change must use. Documentation-only: no Terraform, security-group, firewall-policy, or IAM behavior changes.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #959

## ADR Impact

- ADR-020
- ADR-021

## Changes

- Add ADR-020 (range internet isolation enforced by routing plus Network Firewall default-deny, not security-group egress) to docs/adr/index.yaml.
- Add ADR-021 (range placement is single-AZ; multi-AZ deferred) to docs/adr/index.yaml.
- Add docs/architecture/range-isolation-model.md and range-single-az-placement.md with the live model, blast-radius rationale, and the future multi-AZ placement seam.
- Commit the codex architecture preflight note (docs/architecture/range-isolation-placement-preflight-959.md).

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

Documentation-only change; no tests. Validated by `python3 scripts/adr_guard/adr_guard.py --all --level ci` (adr-registry structural gate) and Vale (Google style, error level) on the new docs.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
