### PR TITLE
test(cms): rewrite asset-service + S3 upload-lifecycle suites to behavior tests

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -223,6 +223,13 @@ entries. Completed so far:
   and dispatcher routing is verified through each sub-handler's real effect
   (experiment routing via the experiments handler's own validation log, which
   required adding `cms.experiments` to the `enable_log_propagation` fixture).
+  The asset-service and S3-helper suites (`test_assets`, `assets/test_s3`) drive
+  the real `cms.assets.services` (create/delete/storage) against real
+  `AgentConfig`/`OperatingSystem`/`AuditLog` rows and the real `cms.assets.s3`
+  helper through the `shared.cloud` AWS adapter, mocked only at the `boto3` S3
+  client boundary (with `AWS_S3_BUCKET_NAME` set so the real not-configured guard
+  is not tripped); the delete fail-fast path is driven with a `boto3` `ClientError`
+  and asserts no soft-delete occurs.
 
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -229,7 +229,17 @@ entries. Completed so far:
   helper through the `shared.cloud` AWS adapter, mocked only at the `boto3` S3
   client boundary (with `AWS_S3_BUCKET_NAME` set so the real not-configured guard
   is not tripped); the delete fail-fast path is driven with a `boto3` `ClientError`
-  and asserts no soft-delete occurs.
+  and asserts no soft-delete occurs. The presigned-upload lifecycle suites
+  (`test_services_upload`, `test_services_upload_cancel`,
+  `test_services_upload_complete`) drive `initiate_upload` / `cancel_upload` /
+  `complete_upload` against a real user, real quota/extension validation, and a
+  real signed upload token (round-tripped through `generate_upload_token` /
+  `verify_upload_token` rather than patched): `initiate_upload` asserts the issued
+  token's verified payload; `complete_upload` runs the full verify -> header-inspect
+  -> tag -> `create_agent` stack and asserts the persisted `AgentConfig`/`AuditLog`,
+  the magic-byte-mismatch delete-and-abort, and that rejection logs do not leak
+  header bytes; S3 (presign / head / range-GET header read / tag / delete) is
+  mocked only at the `boto3` boundary.
 
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -1051,11 +1051,6 @@
       "target": "terraform_base.run_terraform"
     },
     {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/assets/test_s3.py",
-      "target": "cms.assets.s3.get_object_storage"
-    },
-    {
       "count": 4,
       "path": "shifter/shifter_platform/tests/cms/experiments/test_consumers.py",
       "target": "cms.experiments.consumers.ExperimentStatusConsumer._get_experiment"
@@ -1469,26 +1464,6 @@
       "count": 6,
       "path": "shifter/shifter_platform/tests/cms/experiments/test_views.py",
       "target": "cms.scenarios.registry.load_scenario_template"
-    },
-    {
-      "count": 11,
-      "path": "shifter/shifter_platform/tests/cms/test_assets.py",
-      "target": "cms.assets.services.AgentConfig"
-    },
-    {
-      "count": 6,
-      "path": "shifter/shifter_platform/tests/cms/test_assets.py",
-      "target": "cms.assets.services.OperatingSystem"
-    },
-    {
-      "count": 10,
-      "path": "shifter/shifter_platform/tests/cms/test_assets.py",
-      "target": "cms.assets.services.audit_log"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/cms/test_assets.py",
-      "target": "cms.assets.services.s3_delete"
     },
     {
       "count": 3,

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -1641,66 +1641,6 @@
       "target": "cms.assets.services.get_storage_used"
     },
     {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload.py",
-      "target": "cms.assets.s3.generate_presigned_upload_url"
-    },
-    {
-      "count": 14,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload.py",
-      "target": "cms.assets.services.get_storage_used"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload.py",
-      "target": "cms.assets.upload_token.generate_upload_token"
-    },
-    {
-      "count": 11,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload.py",
-      "target": "cms.assets.validation.validate_file_extension"
-    },
-    {
-      "count": 5,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_cancel.py",
-      "target": "cms.assets.s3.delete_agent"
-    },
-    {
-      "count": 6,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_cancel.py",
-      "target": "cms.assets.upload_token.verify_upload_token"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_complete.py",
-      "target": "cms.assets.s3.delete_agent"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_complete.py",
-      "target": "cms.assets.s3.read_agent_header"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_complete.py",
-      "target": "cms.assets.s3.tag_s3_object"
-    },
-    {
-      "count": 11,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_complete.py",
-      "target": "cms.assets.s3.verify_s3_object_exists"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_complete.py",
-      "target": "cms.assets.services.create_agent"
-    },
-    {
-      "count": 13,
-      "path": "shifter/shifter_platform/tests/cms/test_services_upload_complete.py",
-      "target": "cms.assets.upload_token.verify_upload_token"
-    },
-    {
       "count": 2,
       "path": "shifter/shifter_platform/tests/config/test_logout.py",
       "target": "config.views.logout"

--- a/shifter/shifter_platform/tests/cms/assets/test_s3.py
+++ b/shifter/shifter_platform/tests/cms/assets/test_s3.py
@@ -1,13 +1,18 @@
-"""Unit tests for S3 service.
+"""Behavior tests for the cms.assets.s3 helper.
 
-Tests verify that cms/assets/s3.py delegates to the ObjectStorage
-abstraction and bridges CloudStorageError -> S3Error.
+These drive the real ``cms.assets.s3`` functions through the real
+``shared.cloud`` AWS adapter down to the ``boto3`` S3 client, which is mocked at
+that (genuine cloud) boundary instead of patching the first-party
+``get_object_storage`` indirection. They verify the returned values, the boto3
+call shape, and the ``ClientError`` -> ``CloudStorageError`` -> ``S3Error``
+bridging.
 """
 
 import io
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from cms.assets.s3 import (
     S3Error,
@@ -18,15 +23,19 @@ from cms.assets.s3 import (
     upload_agent,
     verify_s3_object_exists,
 )
-from shared.cloud.exceptions import CloudStorageError
 
 
 @pytest.fixture
-def mock_storage():
-    """Return a MagicMock ObjectStorage wired into cms.assets.s3."""
-    storage = MagicMock()
-    with patch("cms.assets.s3.get_object_storage", return_value=storage):
-        yield storage
+def s3_client(settings):
+    """Patch ``boto3.client`` at the boundary with a deterministic S3 client."""
+    settings.AWS_S3_BUCKET_NAME = "test-bucket"
+    client = MagicMock()
+    with patch("boto3.client", return_value=client):
+        yield client
+
+
+def _client_error(code: str, op: str, msg: str = "boom") -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": msg}}, op)
 
 
 class TestGetS3Client:
@@ -36,144 +45,115 @@ class TestGetS3Client:
         settings.AWS_S3_REGION = "us-west-2"
         get_s3_client()
         mock_boto3_client.assert_called_once()
-        call_kwargs = mock_boto3_client.call_args
-        assert call_kwargs[0][0] == "s3"
-        assert call_kwargs[1]["region_name"] == "us-west-2"
-        assert call_kwargs[1]["endpoint_url"] == "https://s3.us-west-2.amazonaws.com"
+        call = mock_boto3_client.call_args
+        assert call[0][0] == "s3"
+        assert call[1]["region_name"] == "us-west-2"
+        assert call[1]["endpoint_url"] == "https://s3.us-west-2.amazonaws.com"
 
 
 class TestUploadAgent:
-    def test_successful_upload(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-
-        file_obj = io.BytesIO(b"test content")
-        s3_key, sha256_hash, file_size = upload_agent(file_obj, 123, "agent.msi")
+    def test_successful_upload(self, s3_client):
+        s3_key, sha256_hash, file_size = upload_agent(io.BytesIO(b"test content"), 123, "agent.msi")
 
         assert s3_key.startswith("agents/123/")
         assert s3_key.endswith("_agent.msi")
         assert len(sha256_hash) == 64
         assert file_size == 12
 
-        mock_storage.upload_file.assert_called_once()
-        call_kwargs = mock_storage.upload_file.call_args
-        assert call_kwargs[1]["bucket"] == "test-bucket"
-        assert call_kwargs[1]["content_type"] == "application/octet-stream"
+        s3_client.upload_fileobj.assert_called_once()
+        call = s3_client.upload_fileobj.call_args
+        assert call.args[1] == "test-bucket"  # bucket positional
+        assert call.kwargs["ExtraArgs"]["ContentType"] == "application/octet-stream"
 
     def test_raises_if_bucket_not_configured(self, settings):
         settings.AWS_S3_BUCKET_NAME = ""
-        file_obj = io.BytesIO(b"test")
+        with pytest.raises(S3Error, match="not configured"):
+            upload_agent(io.BytesIO(b"test"), 123, "agent.msi")
 
-        with pytest.raises(S3Error) as exc:
-            upload_agent(file_obj, 123, "agent.msi")
-        assert "not configured" in str(exc.value)
+    def test_raises_s3error_on_cloud_storage_error(self, s3_client):
+        s3_client.upload_fileobj.side_effect = _client_error("500", "PutObject")
+        with pytest.raises(S3Error, match="Failed to upload"):
+            upload_agent(io.BytesIO(b"test content"), 123, "agent.msi")
 
-    def test_raises_s3error_on_cloud_storage_error(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-        mock_storage.upload_file.side_effect = CloudStorageError("Failed to upload to S3: boom")
-
-        file_obj = io.BytesIO(b"test content")
-        with pytest.raises(S3Error) as exc:
-            upload_agent(file_obj, 123, "agent.msi")
-        assert "Failed to upload" in str(exc.value)
-
-    def test_calculates_correct_sha256(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-
-        file_obj = io.BytesIO(b"hello")
-        _, sha256_hash, _ = upload_agent(file_obj, 1, "test.msi")
-
-        expected = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
-        assert sha256_hash == expected
+    def test_calculates_correct_sha256(self, s3_client):
+        _, sha256_hash, _ = upload_agent(io.BytesIO(b"hello"), 1, "test.msi")
+        assert sha256_hash == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
 
 
 class TestDeleteAgent:
-    def test_successful_delete(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-
+    def test_successful_delete(self, s3_client):
         delete_agent("agents/123/abc_test.msi")
-
-        mock_storage.delete_object.assert_called_once_with(bucket="test-bucket", key="agents/123/abc_test.msi")
+        s3_client.delete_object.assert_called_once()
+        kwargs = s3_client.delete_object.call_args.kwargs
+        assert kwargs["Bucket"] == "test-bucket"
+        assert kwargs["Key"] == "agents/123/abc_test.msi"
 
     def test_raises_if_bucket_not_configured(self, settings):
         settings.AWS_S3_BUCKET_NAME = ""
-
-        with pytest.raises(S3Error) as exc:
+        with pytest.raises(S3Error, match="not configured"):
             delete_agent("some/key")
-        assert "not configured" in str(exc.value)
 
-    def test_raises_s3error_on_cloud_storage_error(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-        mock_storage.delete_object.side_effect = CloudStorageError("Failed to delete from S3: boom")
-
-        with pytest.raises(S3Error) as exc:
+    def test_raises_s3error_on_cloud_storage_error(self, s3_client):
+        s3_client.delete_object.side_effect = _client_error("500", "DeleteObject")
+        with pytest.raises(S3Error, match="delete failed"):
             delete_agent("some/key")
-        assert "Failed to delete" in str(exc.value)
 
 
 class TestGeneratePresignedUploadUrl:
-    def test_successful_url_generation(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
+    def test_successful_url_generation(self, s3_client, settings):
         settings.AGENT_UPLOAD_URL_EXPIRES = 900
-        mock_storage.generate_presigned_upload_url.return_value = "https://s3.example.com/presigned"
+        s3_client.generate_presigned_url.return_value = "https://s3.example.com/presigned"
 
         url, s3_key = generate_presigned_upload_url(123, "agent.msi")
 
         assert url == "https://s3.example.com/presigned"
         assert s3_key.startswith("agents/123/")
-        mock_storage.generate_presigned_upload_url.assert_called_once()
-        call_kwargs = mock_storage.generate_presigned_upload_url.call_args[1]
-        assert call_kwargs["bucket"] == "test-bucket"
-        assert call_kwargs["content_type"] == "application/octet-stream"
-        assert call_kwargs["expires_in"] == 900
+        call = s3_client.generate_presigned_url.call_args
+        assert call.kwargs["ClientMethod"] == "put_object"
+        assert call.kwargs["Params"]["Bucket"] == "test-bucket"
+        assert call.kwargs["Params"]["ContentType"] == "application/octet-stream"
+        assert call.kwargs["ExpiresIn"] == 900
 
-    def test_raises_s3error_on_cloud_storage_error(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
+    def test_raises_s3error_on_cloud_storage_error(self, s3_client, settings):
         settings.AGENT_UPLOAD_URL_EXPIRES = 900
-        mock_storage.generate_presigned_upload_url.side_effect = CloudStorageError("boom")
-
+        s3_client.generate_presigned_url.side_effect = _client_error("500", "PutObject")
         with pytest.raises(S3Error):
             generate_presigned_upload_url(123, "agent.msi")
 
 
 class TestVerifyS3ObjectExists:
-    def test_successful_verify(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-        mock_storage.head_object.return_value = {"content_length": 1024, "etag": "abc123"}
+    def test_successful_verify(self, s3_client):
+        s3_client.head_object.return_value = {"ContentLength": 1024, "ETag": '"abc123"'}
 
         size, etag = verify_s3_object_exists("agents/123/test.msi")
 
         assert size == 1024
-        assert etag == "abc123"
-        mock_storage.head_object.assert_called_once_with(bucket="test-bucket", key="agents/123/test.msi")
+        assert etag == "abc123"  # adapter strips surrounding quotes
+        kwargs = s3_client.head_object.call_args.kwargs
+        assert kwargs["Bucket"] == "test-bucket"
+        assert kwargs["Key"] == "agents/123/test.msi"
 
-    def test_raises_s3error_on_not_found(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-        mock_storage.head_object.side_effect = CloudStorageError("Failed to head S3 object: 404")
-
+    def test_raises_s3error_on_not_found(self, s3_client):
+        s3_client.head_object.side_effect = _client_error("404", "HeadObject", "Not Found")
         with pytest.raises(S3Error, match="Object not found"):
             verify_s3_object_exists("agents/123/missing.msi")
 
-    def test_raises_s3error_on_other_error(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-        mock_storage.head_object.side_effect = CloudStorageError("Server error")
-
+    def test_raises_s3error_on_other_error(self, s3_client):
+        s3_client.head_object.side_effect = _client_error("500", "HeadObject", "Server error")
         with pytest.raises(S3Error, match="Server error"):
             verify_s3_object_exists("agents/123/test.msi")
 
 
 class TestTagS3Object:
-    def test_successful_tag(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-
+    def test_successful_tag(self, s3_client):
         tag_s3_object("agents/123/test.msi", {"status": "verified"})
 
-        mock_storage.tag_object.assert_called_once_with(
-            bucket="test-bucket", key="agents/123/test.msi", tags={"status": "verified"}
-        )
+        kwargs = s3_client.put_object_tagging.call_args.kwargs
+        assert kwargs["Bucket"] == "test-bucket"
+        assert kwargs["Key"] == "agents/123/test.msi"
+        assert kwargs["Tagging"] == {"TagSet": [{"Key": "status", "Value": "verified"}]}
 
-    def test_raises_s3error_on_cloud_storage_error(self, mock_storage, settings):
-        settings.AWS_S3_BUCKET_NAME = "test-bucket"
-        mock_storage.tag_object.side_effect = CloudStorageError("Failed to tag")
-
-        with pytest.raises(S3Error, match="Failed to tag"):
+    def test_raises_s3error_on_cloud_storage_error(self, s3_client):
+        s3_client.put_object_tagging.side_effect = _client_error("500", "PutObjectTagging")
+        with pytest.raises(S3Error, match="tag"):
             tag_s3_object("agents/123/test.msi", {"status": "verified"})

--- a/shifter/shifter_platform/tests/cms/test_assets.py
+++ b/shifter/shifter_platform/tests/cms/test_assets.py
@@ -1,8 +1,18 @@
-"""Tests for cms.assets.services module."""
+"""Behavior tests for cms.assets.services.
+
+Drives the real asset services against real ``AgentConfig`` / ``OperatingSystem``
+/ ``AuditLog`` rows instead of patching ``AgentConfig`` / ``OperatingSystem`` /
+``audit_log`` / ``s3_delete``. The delete path runs the real ``cms.assets.s3``
+helper and the ``shared.cloud`` AWS adapter, mocked only at the ``boto3``
+boundary (with ``AWS_S3_BUCKET_NAME`` set so the real "not configured" guard is
+not tripped).
+"""
 
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
+from django.contrib.auth import get_user_model
 
 from cms.assets.services import (
     AgentUploadSpec,
@@ -11,452 +21,225 @@ from cms.assets.services import (
     delete_agent,
     get_storage_used,
 )
+from cms.models import AgentConfig, AgentType, OperatingSystem
+from risk_register.models import AuditLog
 
-# -----------------------------------------------------------------------------
-# Fixtures
-# -----------------------------------------------------------------------------
+pytestmark = pytest.mark.django_db
 
-
-@pytest.fixture
-def mock_user():
-    """Create a mock user."""
-    user = MagicMock()
-    user.id = 1
-    user.username = "test@example.com"
-    user.email = "test@example.com"
-    return user
+User = get_user_model()
 
 
 @pytest.fixture
-def mock_other_user():
-    """Create another mock user."""
-    user = MagicMock()
-    user.id = 2
-    user.username = "other@example.com"
-    user.email = "other@example.com"
-    return user
+def user(db):
+    return User.objects.create_user(username="assets@example.com", email="assets@example.com")
 
 
 @pytest.fixture
-def mock_windows_os():
-    """Create a mock Windows operating system."""
-    os_obj = MagicMock()
-    os_obj.slug = "windows"
-    os_obj.name = "Windows"
-    os_obj.extensions = [".msi"]
+def other_user(db):
+    return User.objects.create_user(username="assets-other@example.com", email="assets-other@example.com")
+
+
+@pytest.fixture
+def linux_os(db):
+    os_obj, _ = OperatingSystem.objects.get_or_create(
+        slug="linux-debian", defaults={"name": "Linux (Debian/Ubuntu)", "extensions": [".deb"]}
+    )
     return os_obj
 
 
 @pytest.fixture
-def mock_linux_os():
-    """Create a mock Linux operating system."""
-    os_obj = MagicMock()
-    os_obj.slug = "linux-debian"
-    os_obj.name = "Linux (Debian/Ubuntu)"
-    os_obj.extensions = [".deb"]
-    return os_obj
+def s3_client(settings):
+    """Patch ``boto3.client`` at the boundary with a deterministic S3 client.
+
+    Configures the bucket so the real s3 helper proceeds to the (mocked) AWS
+    SDK call. Yields the boto3 client mock so tests can assert the call or
+    drive a failure via ``side_effect``.
+    """
+    settings.AWS_S3_BUCKET_NAME = "test-bucket"
+    client = MagicMock()
+    with patch("boto3.client", return_value=client):
+        yield client
 
 
-@pytest.fixture
-def mock_windows_agent(mock_user, mock_windows_os):
-    """Create a mock Windows agent."""
-    agent = MagicMock()
-    agent.id = 10
-    agent.pk = 10
-    agent.user = mock_user
-    agent.os = mock_windows_os
-    agent.name = "Test Windows Agent"
-    agent.s3_key = "agents/1/test.msi"
-    agent.original_filename = "test.msi"
-    agent.file_size_bytes = 1024
-    agent.sha256_hash = "abc123"
-    agent.deleted_at = None
-    return agent
+def _spec(**overrides) -> AgentUploadSpec:
+    fields = {
+        "name": "New Agent",
+        "s3_key": "agents/1/new.msi",
+        "filename": "new.msi",
+        "os_slug": "windows",
+        "file_size": 2048,
+        "sha256": "newhash123",
+    }
+    fields.update(overrides)
+    return AgentUploadSpec(**fields)
 
 
 # -----------------------------------------------------------------------------
-# Tests for get_storage_used()
+# get_storage_used()
 # -----------------------------------------------------------------------------
 
 
 class TestGetStorageUsed:
-    """Tests for get_storage_used function."""
+    def test_returns_zero_for_no_agents(self, user):
+        assert get_storage_used(user) == 0
 
-    @patch("cms.assets.services.AgentConfig")
-    def test_returns_zero_for_no_agents(self, mock_agent_config, mock_user):
-        """Should return 0 when user has no agents."""
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": None}
-        mock_agent_config.active_for_user.return_value = mock_qs
+    def test_returns_zero_for_user_with_no_agents_even_when_others_have(self, user, other_user, make_agent):
+        make_agent(other_user, file_size_bytes=4096)
+        assert get_storage_used(user) == 0
 
-        result = get_storage_used(mock_user)
-        assert result == 0
-        mock_agent_config.active_for_user.assert_called_once_with(mock_user)
+    def test_sums_active_agent_sizes(self, user, make_agent):
+        make_agent(user, file_size_bytes=1024)
+        make_agent(user, file_size_bytes=2048)
+        assert get_storage_used(user) == 1024 + 2048
 
-    @patch("cms.assets.services.AgentConfig")
-    def test_returns_zero_for_user_with_no_agents_but_others_have(self, mock_agent_config, mock_user):
-        """Should return 0 for user even when other users have agents."""
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": None}
-        mock_agent_config.active_for_user.return_value = mock_qs
+    def test_excludes_deleted_agents(self, user, make_agent):
+        from django.utils import timezone
 
-        result = get_storage_used(mock_user)
-        assert result == 0
+        make_agent(user, file_size_bytes=1024)
+        deleted = make_agent(user, file_size_bytes=2048)
+        deleted.deleted_at = timezone.now()
+        deleted.save(update_fields=["deleted_at"])
+        assert get_storage_used(user) == 1024
 
-    @patch("cms.assets.services.AgentConfig")
-    def test_sums_active_agent_sizes(self, mock_agent_config, mock_user):
-        """Should return sum of all active agent sizes."""
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": 1024 + 2048}
-        mock_agent_config.active_for_user.return_value = mock_qs
+    def test_only_counts_own_agents(self, user, other_user, make_agent):
+        make_agent(user, file_size_bytes=1024)
+        make_agent(other_user, file_size_bytes=4096)
+        assert get_storage_used(user) == 1024
 
-        result = get_storage_used(mock_user)
-        assert result == 1024 + 2048
-
-    @patch("cms.assets.services.AgentConfig")
-    def test_excludes_deleted_agents(self, mock_agent_config, mock_user):
-        """Should not include deleted agents in the sum.
-
-        active_for_user already filters out deleted agents,
-        so we verify the service calls active_for_user (not objects.all).
-        """
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": 1024}
-        mock_agent_config.active_for_user.return_value = mock_qs
-
-        result = get_storage_used(mock_user)
-        assert result == 1024
-        mock_agent_config.active_for_user.assert_called_once_with(mock_user)
-
-    @patch("cms.assets.services.AgentConfig")
-    def test_only_counts_own_agents(self, mock_agent_config, mock_user):
-        """Should only count agents belonging to the specified user."""
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": 1024}
-        mock_agent_config.active_for_user.return_value = mock_qs
-
-        result = get_storage_used(mock_user)
-        assert result == 1024
-        mock_agent_config.active_for_user.assert_called_once_with(mock_user)
-
-    @patch("cms.assets.services.AgentConfig")
-    def test_returns_integer(self, mock_agent_config, mock_user):
-        """Should always return an integer."""
-        mock_qs = MagicMock()
-        mock_qs.aggregate.return_value = {"total": 1024}
-        mock_agent_config.active_for_user.return_value = mock_qs
-
-        result = get_storage_used(mock_user)
-        assert isinstance(result, int)
+    def test_returns_integer(self, user, make_agent):
+        make_agent(user, file_size_bytes=1024)
+        assert isinstance(get_storage_used(user), int)
 
 
 # -----------------------------------------------------------------------------
-# Tests for create_agent()
+# create_agent()
 # -----------------------------------------------------------------------------
 
 
 class TestCreateAgent:
-    """Tests for create_agent function."""
+    def test_creates_agent_record(self, user, windows_os):
+        agent = create_agent(user, _spec(name="New Agent", os_slug="windows", file_size=2048, sha256="newhash123"))
 
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.AgentConfig")
-    @patch("cms.assets.services.OperatingSystem")
-    def test_creates_agent_record(self, mock_os_model, mock_agent_config, mock_audit_log, mock_user, mock_windows_os):
-        """Should create AgentConfig record with correct fields."""
-        mock_os_model.objects.filter.return_value.first.return_value = mock_windows_os
-        created_agent = MagicMock()
-        created_agent.id = 42
-        created_agent.pk = 42
-        created_agent.user = mock_user
-        created_agent.name = "New Agent"
-        created_agent.s3_key = "agents/1/new.msi"
-        created_agent.original_filename = "new.msi"
-        created_agent.os = mock_windows_os
-        created_agent.file_size_bytes = 2048
-        created_agent.sha256_hash = "newhash123"
-        created_agent.deleted_at = None
-        mock_agent_config.objects.create.return_value = created_agent
+        assert agent.pk is not None
+        persisted = AgentConfig.objects.get(pk=agent.pk)
+        assert persisted.user_id == user.id
+        assert persisted.name == "New Agent"
+        assert persisted.s3_key == "agents/1/new.msi"
+        assert persisted.original_filename == "new.msi"
+        assert persisted.os == windows_os
+        assert persisted.file_size_bytes == 2048
+        assert persisted.sha256_hash == "newhash123"
+        assert persisted.deleted_at is None
 
-        agent = create_agent(
-            user=mock_user,
-            spec=AgentUploadSpec(
-                name="New Agent",
-                s3_key="agents/1/new.msi",
-                filename="new.msi",
-                os_slug="windows",
-                file_size=2048,
-                sha256="newhash123",
-            ),
+    def test_creates_agent_record_with_linux_os(self, user, linux_os):
+        agent = create_agent(user, _spec(name="Linux Agent", filename="linux.sh", os_slug="linux-debian"))
+        assert agent.os == linux_os
+
+    def test_logs_activity(self, user, windows_os):
+        agent = create_agent(user, _spec(name="Logged Agent", filename="logged.msi"))
+
+        row = AuditLog.objects.get(
+            entity_type=AuditLog.EntityType.AGENT, entity_id=agent.id, action=AuditLog.Action.CREATE
         )
+        assert row.new_state["name"] == "Logged Agent"
+        assert row.new_state["filename"] == "logged.msi"
+        assert row.actor_id == user.id
 
-        assert agent.id is not None
-        assert agent.user == mock_user
-        assert agent.name == "New Agent"
-        assert agent.s3_key == "agents/1/new.msi"
-        assert agent.original_filename == "new.msi"
-        assert agent.os == mock_windows_os
-        assert agent.file_size_bytes == 2048
-        assert agent.sha256_hash == "newhash123"
-        assert agent.deleted_at is None
-
-        mock_os_model.objects.filter.assert_called_once_with(slug="windows")
-        mock_agent_config.objects.create.assert_called_once()
-
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.AgentConfig")
-    @patch("cms.assets.services.OperatingSystem")
-    def test_creates_agent_record_with_linux_os(
-        self, mock_os_model, mock_agent_config, mock_audit_log, mock_user, mock_linux_os
-    ):
-        """Should correctly look up Linux OS."""
-        mock_os_model.objects.filter.return_value.first.return_value = mock_linux_os
-        created_agent = MagicMock()
-        created_agent.id = 43
-        created_agent.os = mock_linux_os
-        mock_agent_config.objects.create.return_value = created_agent
-
-        agent = create_agent(
-            user=mock_user,
-            spec=AgentUploadSpec(
-                name="Linux Agent",
-                s3_key="agents/1/linux.sh",
-                filename="linux.sh",
-                os_slug="linux-debian",
-                file_size=1024,
-                sha256="linuxhash",
-            ),
+    def test_logs_upload_method_when_provided(self, user, windows_os):
+        agent = create_agent(user, _spec(name="Presigned Agent", upload_method="presigned"))
+        row = AuditLog.objects.get(
+            entity_type=AuditLog.EntityType.AGENT, entity_id=agent.id, action=AuditLog.Action.CREATE
         )
+        assert row.new_state["upload_method"] == "presigned"
 
-        assert agent.os == mock_linux_os
-        mock_os_model.objects.filter.assert_called_once_with(slug="linux-debian")
+    def test_raises_for_invalid_os_slug(self, user):
+        with pytest.raises(AssetError, match="not found"):
+            create_agent(user, _spec(os_slug="nonexistent-os"))
 
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.AgentConfig")
-    @patch("cms.assets.services.OperatingSystem")
-    def test_logs_activity(self, mock_os_model, mock_agent_config, mock_audit_log, mock_user, mock_windows_os):
-        """Should create an audit log entry for agent creation."""
-        mock_os_model.objects.filter.return_value.first.return_value = mock_windows_os
-        created_agent = MagicMock()
-        created_agent.id = 44
-        mock_agent_config.objects.create.return_value = created_agent
+    def test_raises_for_invalid_agent_type(self, user, windows_os):
+        with pytest.raises(AssetError, match="Invalid agent type"):
+            create_agent(user, _spec(agent_type="bogus-type"))
 
-        create_agent(
-            user=mock_user,
-            spec=AgentUploadSpec(
-                name="Logged Agent",
-                s3_key="agents/1/logged.msi",
-                filename="logged.msi",
-                os_slug="windows",
-                file_size=1024,
-                sha256="loggedhash",
-            ),
-        )
+    def test_no_record_persisted_on_invalid_os(self, user):
+        with pytest.raises(AssetError):
+            create_agent(user, _spec(name="Orphan", os_slug="nonexistent-os"))
+        assert not AgentConfig.objects.filter(name="Orphan").exists()
 
-        mock_audit_log.assert_called_once()
-        event = mock_audit_log.call_args.args[0]
-        assert event.entity_id == 44
-        assert event.new_state["name"] == "Logged Agent"
-        assert event.new_state["filename"] == "logged.msi"
-        assert event.actor_id == mock_user.id
-
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.AgentConfig")
-    @patch("cms.assets.services.OperatingSystem")
-    def test_logs_upload_method_when_provided(
-        self, mock_os_model, mock_agent_config, mock_audit_log, mock_user, mock_windows_os
-    ):
-        """Should include upload_method in audit log when provided."""
-        mock_os_model.objects.filter.return_value.first.return_value = mock_windows_os
-        created_agent = MagicMock()
-        created_agent.id = 45
-        mock_agent_config.objects.create.return_value = created_agent
-
-        create_agent(
-            user=mock_user,
-            spec=AgentUploadSpec(
-                name="Presigned Agent",
-                s3_key="agents/1/presigned.msi",
-                filename="presigned.msi",
-                os_slug="windows",
-                file_size=1024,
-                sha256="presignedhash",
-                upload_method="presigned",
-            ),
-        )
-
-        event = mock_audit_log.call_args.args[0]
-        assert event.new_state["upload_method"] == "presigned"
-
-    @patch("cms.assets.services.OperatingSystem")
-    def test_raises_for_invalid_os_slug(self, mock_os_model, mock_user):
-        """Should raise AssetError for invalid OS slug."""
-        mock_os_model.objects.filter.return_value.first.return_value = None
-
-        with pytest.raises(AssetError) as exc_info:
-            create_agent(
-                user=mock_user,
-                spec=AgentUploadSpec(
-                    name="Invalid OS Agent",
-                    s3_key="agents/1/invalid.msi",
-                    filename="invalid.msi",
-                    os_slug="nonexistent-os",
-                    file_size=1024,
-                    sha256="invalidhash",
-                ),
-            )
-
-        assert "not found" in str(exc_info.value).lower()
-
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.AgentConfig")
-    @patch("cms.assets.services.OperatingSystem")
-    def test_returns_agent_object(self, mock_os_model, mock_agent_config, mock_audit_log, mock_user, mock_windows_os):
-        """Should return the created AgentConfig object."""
-        from cms.models import AgentConfig as RealAgentConfig
-
-        mock_os_model.objects.filter.return_value.first.return_value = mock_windows_os
-        created_agent = MagicMock(spec=RealAgentConfig)
-        created_agent.id = 46
-        created_agent.pk = 46
-        mock_agent_config.objects.create.return_value = created_agent
-
-        result = create_agent(
-            user=mock_user,
-            spec=AgentUploadSpec(
-                name="Return Test",
-                s3_key="agents/1/return.msi",
-                filename="return.msi",
-                os_slug="windows",
-                file_size=1024,
-                sha256="returnhash",
-            ),
-        )
-
-        assert isinstance(result, RealAgentConfig)
-        assert result.pk is not None
+    def test_returns_agent_object(self, user, windows_os):
+        result = create_agent(user, _spec(name="Return Test"))
+        assert isinstance(result, AgentConfig)
+        assert result.agent_type == AgentType.XDR
 
 
 # -----------------------------------------------------------------------------
-# Tests for delete_agent()
+# delete_agent()
 # -----------------------------------------------------------------------------
 
 
 class TestDeleteAgent:
-    """Tests for delete_agent function."""
+    def test_soft_deletes_agent(self, user, make_agent, s3_client):
+        agent = make_agent(user)
+        delete_agent(agent)
 
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.s3_delete")
-    def test_soft_deletes_agent(self, mock_s3_delete, mock_audit_log, mock_windows_agent):
-        """Should set deleted_at timestamp on agent."""
-        mock_s3_delete.return_value = None
-        assert mock_windows_agent.deleted_at is None
+        agent.refresh_from_db()
+        assert agent.deleted_at is not None
 
-        delete_agent(mock_windows_agent)
+    def test_does_not_hard_delete(self, user, make_agent, s3_client):
+        agent = make_agent(user)
+        delete_agent(agent)
 
-        mock_windows_agent.save.assert_called_once_with(update_fields=["deleted_at"])
-        assert mock_windows_agent.deleted_at is not None
+        # Row still present (soft delete) but excluded from the active manager.
+        assert AgentConfig.all_objects.filter(pk=agent.pk).exists()
+        assert not AgentConfig.objects.filter(pk=agent.pk).exists()
 
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.s3_delete")
-    def test_does_not_hard_delete(self, mock_s3_delete, mock_audit_log, mock_windows_agent):
-        """Should not hard delete - only soft delete via save."""
-        mock_s3_delete.return_value = None
+    def test_calls_s3_delete_with_correct_key(self, user, make_agent, s3_client):
+        agent = make_agent(user)
+        delete_agent(agent)
 
-        delete_agent(mock_windows_agent)
+        s3_client.delete_object.assert_called_once()
+        kwargs = s3_client.delete_object.call_args.kwargs
+        assert kwargs["Bucket"] == "test-bucket"
+        assert kwargs["Key"] == agent.s3_key
 
-        # save was called (soft delete), but delete() was never called
-        mock_windows_agent.save.assert_called_once()
-        mock_windows_agent.delete.assert_not_called()
+    def test_logs_activity(self, user, make_agent, s3_client):
+        agent = make_agent(user)
+        delete_agent(agent)
 
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.s3_delete")
-    def test_calls_s3_delete_with_correct_key(self, mock_s3_delete, mock_audit_log, mock_windows_agent):
-        """Should call S3 delete with the agent's s3_key."""
-        mock_s3_delete.return_value = None
+        row = AuditLog.objects.get(
+            entity_type=AuditLog.EntityType.AGENT, entity_id=agent.id, action=AuditLog.Action.DELETE
+        )
+        assert row.previous_state["name"] == agent.name
+        assert row.actor_id == user.id
 
-        delete_agent(mock_windows_agent)
+    def test_raises_if_s3_delete_fails(self, user, make_agent, s3_client):
+        agent = make_agent(user)
+        s3_client.delete_object.side_effect = ClientError({"Error": {"Code": "500", "Message": "boom"}}, "DeleteObject")
+        with pytest.raises(AssetError, match="storage"):
+            delete_agent(agent)
 
-        mock_s3_delete.assert_called_once_with(mock_windows_agent.s3_key)
-
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.s3_delete")
-    def test_logs_activity(self, mock_s3_delete, mock_audit_log, mock_windows_agent):
-        """Should create an audit log entry for agent deletion."""
-        mock_s3_delete.return_value = None
-
-        delete_agent(mock_windows_agent)
-
-        mock_audit_log.assert_called_once()
-        event = mock_audit_log.call_args.args[0]
-        assert event.entity_id == mock_windows_agent.id
-        assert event.previous_state["name"] == mock_windows_agent.name
-        assert event.actor_id == mock_windows_agent.user.id
-
-    @patch("cms.assets.services.s3_delete")
-    def test_raises_if_s3_delete_fails(self, mock_s3_delete, mock_windows_agent):
-        """Should raise AssetError if S3 delete fails."""
-        from cms.assets.s3 import S3Error
-
-        mock_s3_delete.side_effect = S3Error("Delete failed")
-
-        with pytest.raises(AssetError) as exc_info:
-            delete_agent(mock_windows_agent)
-
-        assert "delete" in str(exc_info.value).lower()
-
-    @patch("cms.assets.services.s3_delete")
-    def test_agent_not_soft_deleted_if_s3_fails(self, mock_s3_delete, mock_windows_agent):
-        """Should not soft delete agent if S3 delete fails."""
-        from cms.assets.s3 import S3Error
-
-        mock_s3_delete.side_effect = S3Error("Delete failed")
-
+    def test_agent_not_soft_deleted_if_s3_fails(self, user, make_agent, s3_client):
+        agent = make_agent(user)
+        s3_client.delete_object.side_effect = ClientError({"Error": {"Code": "500", "Message": "boom"}}, "DeleteObject")
         with pytest.raises(AssetError):
-            delete_agent(mock_windows_agent)
+            delete_agent(agent)
 
-        # save should not have been called since s3 failed first
-        mock_windows_agent.save.assert_not_called()
-        assert mock_windows_agent.deleted_at is None
-
-    @patch("cms.assets.services.audit_log")
-    @patch("cms.assets.services.s3_delete")
-    def test_s3_delete_called_before_db_update(self, mock_s3_delete, mock_audit_log, mock_windows_agent):
-        """S3 delete should be called before database is updated."""
-        call_order = []
-
-        def track_s3_delete(*args):
-            call_order.append("s3_delete")
-
-        def track_save(*args, **kwargs):
-            call_order.append("save")
-
-        mock_s3_delete.side_effect = track_s3_delete
-        mock_windows_agent.save.side_effect = track_save
-
-        delete_agent(mock_windows_agent)
-
-        assert call_order == ["s3_delete", "save"]
+        agent.refresh_from_db()
+        assert agent.deleted_at is None
+        assert AgentConfig.objects.filter(pk=agent.pk).exists()
 
 
 # -----------------------------------------------------------------------------
-# Tests for AssetError
+# AssetError
 # -----------------------------------------------------------------------------
 
 
 class TestAssetError:
-    """Tests for the AssetError exception class."""
-
     def test_is_exception(self):
-        """AssetError should be an Exception."""
-        error = AssetError("Test error")
-        assert isinstance(error, Exception)
+        assert isinstance(AssetError("Test error"), Exception)
 
     def test_message_accessible_via_str(self):
-        """Error message should be accessible via str()."""
-        error = AssetError("Test message")
-        assert str(error) == "Test message"
+        assert str(AssetError("Test message")) == "Test message"
 
     def test_can_be_raised_and_caught(self):
-        """Should be raisable and catchable."""
         with pytest.raises(AssetError):
             raise AssetError("Test")

--- a/shifter/shifter_platform/tests/cms/test_services_upload.py
+++ b/shifter/shifter_platform/tests/cms/test_services_upload.py
@@ -1,336 +1,143 @@
-"""CMS service interface tests.
+"""Behavior tests for cms.services.initiate_upload.
 
-Tests service-level behavior only:
-- Expected behavior / return values
-- Exception handling
-- Input validation (service's responsibility)
-
-Does NOT re-test model behavior (filtering, field validation, etc).
+Drives the real upload-initiation service against a real user and the real
+quota / extension-validation / presigned-URL / upload-token stack. The presigned
+URL is generated through the real ``cms.assets.s3`` helper and ``shared.cloud``
+AWS adapter, mocked only at the ``boto3`` boundary; the issued upload token is
+asserted by verifying it for real (proving the token carries the right payload),
+instead of patching ``get_storage_used`` / ``validate_file_extension`` /
+``generate_presigned_upload_url`` / ``generate_upload_token``.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
+from django.contrib.auth import get_user_model
 
 from cms import services
+from cms.assets.upload_token import verify_upload_token
+from cms.exceptions import CMSError
 from shared.constants import USER_CANNOT_BE_NONE
 
-# MSI magic prefix used to make every happy-path complete_upload test pass the
-# server-side header inspection added in issue #696.
-_MSI_HEADER = bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]) + b"\x00" * 16
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+_MB = 1024 * 1024
 
 
 @pytest.fixture
-def mock_user():
-    user = Mock()
-    user.pk = 42
-    user.id = 42
-    user.email = "test@example.com"
-    return user
+def user(db):
+    return User.objects.create_user(username="upload@example.com", email="upload@example.com")
 
 
-class TestInitiateUploadDependencies:
-    """Dependency call tests for initiate_upload()."""
-
-    def test_calls_get_storage_used_with_user(self, mock_user):
-        """Service calls get_storage_used to check quota."""
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0) as mock_storage,
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(
-                "cms.assets.s3.generate_presigned_upload_url",
-                return_value=("url", "key"),
-            ),
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
-            mock_storage.assert_called_once_with(mock_user)
-
-    def test_calls_validate_file_extension_with_filename(self, mock_user):
-        """Service calls validate_file_extension with the filename."""
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(
-                "cms.assets.s3.generate_presigned_upload_url",
-                return_value=("url", "key"),
-            ),
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
-            mock_validate.assert_called_once_with("agent.msi")
-
-    def test_calls_generate_presigned_url_with_user_and_filename(self, mock_user):
-        """Service calls generate_presigned_upload_url with user_id and filename."""
-        presign_path = "cms.assets.s3.generate_presigned_upload_url"
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(presign_path, return_value=("url", "key")) as mock_presign,
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
-            mock_presign.assert_called_once_with(user_id=mock_user.id, filename="agent.msi")
-
-    def test_calls_generate_upload_token_with_all_params(self, mock_user):
-        """Service calls generate_upload_token with all required params."""
-        presign_path = "cms.assets.s3.generate_presigned_upload_url"
-        token_path = "cms.assets.upload_token.generate_upload_token"
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(presign_path, return_value=("presigned_url", "s3_key")),
-            patch(token_path, return_value="token") as mock_token,
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            services.initiate_upload(mock_user, "My Agent", "agent.msi", 5000)
-            mock_token.assert_called_once_with(
-                user_id=mock_user.id,
-                s3_key="s3_key",
-                name="My Agent",
-                filename="agent.msi",
-                os_slug="windows",
-                file_size=5000,
-                agent_type="xdr",
-            )
+@pytest.fixture
+def s3_presign(settings):
+    """Patch ``boto3.client`` with a deterministic presigned-URL S3 client."""
+    settings.AWS_S3_BUCKET_NAME = "test-bucket"
+    settings.AGENT_UPLOAD_URL_EXPIRES = 900
+    client = MagicMock()
+    client.generate_presigned_url.return_value = "https://s3.example/presigned"
+    with patch("boto3.client", return_value=client):
+        yield client
 
 
 class TestInitiateUploadReturns:
-    """Return payload tests for initiate_upload()."""
+    def test_returns_presigned_url_and_s3_key(self, user, s3_presign):
+        result = services.initiate_upload(user, "Agent", "agent.msi", 1000)
+        assert result["presigned_url"] == "https://s3.example/presigned"
+        assert result["s3_key"].startswith(f"agents/{user.id}/")
+        assert result["s3_key"].endswith("_agent.msi")
 
-    def test_returns_dict_with_presigned_url(self, mock_user):
-        """Service returns dict containing presigned_url."""
-        presign_url = "https://s3.example.com/upload"
-        presign_path = "cms.assets.s3.generate_presigned_upload_url"
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(presign_path, return_value=(presign_url, "key")),
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            result = services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
-            assert result["presigned_url"] == presign_url
+    def test_returns_verifiable_upload_token_with_payload(self, user, s3_presign):
+        result = services.initiate_upload(user, "My Agent", "agent.msi", 5000)
 
-    def test_returns_dict_with_s3_key(self, mock_user):
-        """Service returns dict containing s3_key."""
-        s3_key = "agents/1/abc123_agent.msi"
-        presign_path = "cms.assets.s3.generate_presigned_upload_url"
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(presign_path, return_value=("url", s3_key)),
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            result = services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
-            assert result["s3_key"] == s3_key
+        payload = verify_upload_token(result["upload_token"], user.id)
+        assert payload["name"] == "My Agent"
+        assert payload["filename"] == "agent.msi"
+        assert payload["os_slug"] == "windows"
+        assert payload["file_size"] == 5000
+        assert payload["agent_type"] == "xdr"
+        assert payload["s3_key"] == result["s3_key"]
 
-    def test_returns_dict_with_upload_token(self, mock_user):
-        """Service returns dict containing upload_token."""
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(
-                "cms.assets.s3.generate_presigned_upload_url",
-                return_value=("url", "key"),
-            ),
-            patch(
-                "cms.assets.upload_token.generate_upload_token",
-                return_value="signed_token_abc123",
-            ),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            result = services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
-            assert result["upload_token"] == "signed_token_abc123"
+    def test_expected_os_comes_from_extension(self, user, s3_presign):
+        result = services.initiate_upload(user, "Agent", "agent.deb", 1000)
+        assert result["expected_os"] == "linux-debian"
 
-    def test_returns_dict_with_expected_os(self, mock_user):
-        """Service returns dict containing expected_os from file format."""
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(
-                "cms.assets.s3.generate_presigned_upload_url",
-                return_value=("url", "key"),
-            ),
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="linux-debian")
-            result = services.initiate_upload(mock_user, "Agent", "agent.deb", 1000)
-            assert result["expected_os"] == "linux-debian"
+    def test_agent_type_is_carried_into_token(self, user, s3_presign):
+        result = services.initiate_upload(user, "Agent", "agent.msi", 1000, agent_type="xdr_collector")
+        payload = verify_upload_token(result["upload_token"], user.id)
+        assert payload["agent_type"] == "xdr_collector"
 
 
 class TestInitiateUploadUserValidation:
-    """User validation tests for initiate_upload()."""
-
     def test_raises_typeerror_when_user_is_none(self):
-        """Service raises TypeError when user is None."""
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
             services.initiate_upload(None, "Agent", "agent.msi", 1000)
 
-    def test_raises_typeerror_when_user_has_no_id_attribute(self):
-        """Service raises TypeError when user has no id attribute."""
-        invalid_user = "not a user"
+    def test_raises_typeerror_when_user_is_wrong_type(self):
         with pytest.raises(TypeError, match="user must be a User instance"):
-            services.initiate_upload(invalid_user, "Agent", "agent.msi", 1000)
+            services.initiate_upload("not a user", "Agent", "agent.msi", 1000)
 
-    def test_raises_valueerror_when_user_id_is_none(self):
-        """Service raises ValueError when user is unsaved (id=None)."""
-        unsaved_user = Mock()
-        unsaved_user.id = None
+    def test_raises_valueerror_when_user_is_unsaved(self):
         with pytest.raises(ValueError, match="user must be saved"):
-            services.initiate_upload(unsaved_user, "Agent", "agent.msi", 1000)
+            services.initiate_upload(User(username="unsaved"), "Agent", "agent.msi", 1000)
 
 
 class TestInitiateUploadInputValidation:
-    """Name, filename, and size validation tests for initiate_upload()."""
+    @pytest.mark.parametrize("name", [None, "", "   "])
+    def test_rejects_bad_name(self, user, name):
+        with pytest.raises(ValueError, match="name cannot be"):
+            services.initiate_upload(user, name, "agent.msi", 1000)
 
-    def test_raises_valueerror_when_name_is_none(self, mock_user):
-        """Service raises ValueError when name is None."""
-        with pytest.raises(ValueError, match="name cannot be None"):
-            services.initiate_upload(mock_user, None, "agent.msi", 1000)
+    @pytest.mark.parametrize("filename", [None, "", "   "])
+    def test_rejects_bad_filename(self, user, filename):
+        with pytest.raises(ValueError, match="filename cannot be"):
+            services.initiate_upload(user, "Agent", filename, 1000)
 
-    def test_raises_valueerror_when_name_is_empty(self, mock_user):
-        """Service raises ValueError when name is empty string."""
-        with pytest.raises(ValueError, match="name cannot be empty"):
-            services.initiate_upload(mock_user, "", "agent.msi", 1000)
-
-    def test_raises_valueerror_when_name_is_whitespace(self, mock_user):
-        """Service raises ValueError when name is only whitespace."""
-        with pytest.raises(ValueError, match="name cannot be empty"):
-            services.initiate_upload(mock_user, "   ", "agent.msi", 1000)
-
-    def test_raises_valueerror_when_filename_is_none(self, mock_user):
-        """Service raises ValueError when filename is None."""
-        with pytest.raises(ValueError, match="filename cannot be None"):
-            services.initiate_upload(mock_user, "Agent", None, 1000)
-
-    def test_raises_valueerror_when_filename_is_empty(self, mock_user):
-        """Service raises ValueError when filename is empty string."""
-        with pytest.raises(ValueError, match="filename cannot be empty"):
-            services.initiate_upload(mock_user, "Agent", "", 1000)
-
-    def test_raises_valueerror_when_filename_is_whitespace(self, mock_user):
-        """Service raises ValueError when filename is only whitespace."""
-        with pytest.raises(ValueError, match="filename cannot be empty"):
-            services.initiate_upload(mock_user, "Agent", "   ", 1000)
-
-    def test_raises_typeerror_when_file_size_is_none(self, mock_user):
-        """Service raises TypeError when file_size is None."""
+    def test_rejects_none_file_size(self, user):
         with pytest.raises(TypeError, match="file_size cannot be None"):
-            services.initiate_upload(mock_user, "Agent", "agent.msi", None)
+            services.initiate_upload(user, "Agent", "agent.msi", None)
 
-    def test_raises_typeerror_when_file_size_is_string(self, mock_user):
-        """Service raises TypeError when file_size is not an int."""
+    def test_rejects_non_int_file_size(self, user):
         with pytest.raises(TypeError, match="file_size must be an int"):
-            services.initiate_upload(mock_user, "Agent", "agent.msi", "1000")
+            services.initiate_upload(user, "Agent", "agent.msi", "1000")
 
-    def test_raises_valueerror_when_file_size_is_zero(self, mock_user):
-        """Service raises ValueError when file_size is zero."""
+    @pytest.mark.parametrize("size", [0, -100])
+    def test_rejects_non_positive_file_size(self, user, size):
         with pytest.raises(ValueError, match="file_size must be positive"):
-            services.initiate_upload(mock_user, "Agent", "agent.msi", 0)
+            services.initiate_upload(user, "Agent", "agent.msi", size)
 
-    def test_raises_valueerror_when_file_size_is_negative(self, mock_user):
-        """Service raises ValueError when file_size is negative."""
-        with pytest.raises(ValueError, match="file_size must be positive"):
-            services.initiate_upload(mock_user, "Agent", "agent.msi", -100)
+
+class TestInitiateUploadQuota:
+    def test_raises_when_quota_exceeded(self, user, make_agent, settings):
+        settings.AGENT_USER_STORAGE_QUOTA_MB = 10
+        make_agent(user, file_size_bytes=9 * _MB)
+        with pytest.raises(CMSError, match="quota exceeded"):
+            services.initiate_upload(user, "Agent", "agent.msi", 2 * _MB)
+
+    def test_succeeds_when_under_quota(self, user, make_agent, settings, s3_presign):
+        settings.AGENT_USER_STORAGE_QUOTA_MB = 10
+        make_agent(user, file_size_bytes=5 * _MB)
+        result = services.initiate_upload(user, "Agent", "agent.msi", 4 * _MB)
+        assert "presigned_url" in result
+
+    def test_succeeds_when_quota_exactly_met(self, user, make_agent, settings, s3_presign):
+        settings.AGENT_USER_STORAGE_QUOTA_MB = 10
+        make_agent(user, file_size_bytes=5 * _MB)
+        result = services.initiate_upload(user, "Agent", "agent.msi", 5 * _MB)
+        assert "presigned_url" in result
 
 
 class TestInitiateUploadFailures:
-    """Downstream failure tests for initiate_upload()."""
+    def test_raises_on_invalid_extension(self, user):
+        with pytest.raises(CMSError, match="not allowed"):
+            services.initiate_upload(user, "Agent", "agent.exe", 1000)
 
-    def test_raises_cmserror_when_quota_exceeded(self, mock_user, settings):
-        """Service raises CMSError when storage quota would be exceeded."""
-        from cms.exceptions import CMSError
-
-        settings.AGENT_USER_STORAGE_QUOTA_MB = 10  # 10 MB quota
-        current_usage = 9 * 1024 * 1024  # 9 MB used
-        new_file_size = 2 * 1024 * 1024  # 2 MB new file
-
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=current_usage),
-            pytest.raises(CMSError, match="quota exceeded"),
-        ):
-            services.initiate_upload(mock_user, "Agent", "agent.msi", new_file_size)
-
-    def test_succeeds_when_quota_not_exceeded(self, mock_user, settings):
-        """Service succeeds when storage quota is not exceeded."""
-        settings.AGENT_USER_STORAGE_QUOTA_MB = 10  # 10 MB quota
-        current_usage = 5 * 1024 * 1024  # 5 MB used
-        new_file_size = 4 * 1024 * 1024  # 4 MB new file (under 10 MB total)
-
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=current_usage),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(
-                "cms.assets.s3.generate_presigned_upload_url",
-                return_value=("url", "key"),
-            ),
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            result = services.initiate_upload(mock_user, "Agent", "agent.msi", new_file_size)
-            assert "presigned_url" in result
-
-    def test_succeeds_when_quota_exactly_met(self, mock_user, settings):
-        """Service succeeds when storage quota is exactly met."""
-        settings.AGENT_USER_STORAGE_QUOTA_MB = 10  # 10 MB quota
-        current_usage = 5 * 1024 * 1024  # 5 MB used
-        new_file_size = 5 * 1024 * 1024  # 5 MB new file (exactly 10 MB total)
-
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=current_usage),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(
-                "cms.assets.s3.generate_presigned_upload_url",
-                return_value=("url", "key"),
-            ),
-            patch("cms.assets.upload_token.generate_upload_token", return_value="token"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            result = services.initiate_upload(mock_user, "Agent", "agent.msi", new_file_size)
-            assert "presigned_url" in result
-
-    def test_raises_cmserror_on_invalid_extension(self, mock_user):
-        """Service raises CMSError when file extension is not allowed."""
-        from cms.assets.validation import ValidationError
-        from cms.exceptions import CMSError
-
-        validation_path = "cms.assets.validation.validate_file_extension"
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch(validation_path, side_effect=ValidationError("Extension not allowed")),
-            pytest.raises(CMSError, match="Extension not allowed"),
-        ):
-            services.initiate_upload(mock_user, "Agent", "agent.exe", 1000)
-
-    def test_raises_cmserror_on_s3_error(self, mock_user):
-        """Service raises CMSError when S3 presigned URL generation fails."""
-        from cms.assets.s3 import S3Error
-        from cms.exceptions import CMSError
-
-        with (
-            patch("cms.assets.services.get_storage_used", return_value=0),
-            patch("cms.assets.validation.validate_file_extension") as mock_validate,
-            patch(
-                "cms.assets.s3.generate_presigned_upload_url",
-                side_effect=S3Error("S3 unavailable"),
-            ),
-            pytest.raises(CMSError, match="Failed to initiate upload"),
-        ):
-            mock_validate.return_value = Mock(os_slug="windows")
-            services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
-
-    def test_propagates_unexpected_exception(self, mock_user):
-        """Service propagates unexpected exceptions from dependencies."""
-        with (
-            patch(
-                "cms.assets.services.get_storage_used",
-                side_effect=RuntimeError("Unexpected"),
-            ),
-            pytest.raises(RuntimeError, match="Unexpected"),
-        ):
-            services.initiate_upload(mock_user, "Agent", "agent.msi", 1000)
+    def test_raises_when_presign_fails(self, user, s3_presign):
+        s3_presign.generate_presigned_url.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "boom"}}, "PutObject"
+        )
+        with pytest.raises(CMSError, match="Failed to initiate upload"):
+            services.initiate_upload(user, "Agent", "agent.msi", 1000)

--- a/shifter/shifter_platform/tests/cms/test_services_upload_cancel.py
+++ b/shifter/shifter_platform/tests/cms/test_services_upload_cancel.py
@@ -1,226 +1,104 @@
-"""CMS service interface tests.
+"""Behavior tests for cms.services.cancel_upload.
 
-Tests service-level behavior only:
-- Expected behavior / return values
-- Exception handling
-- Input validation (service's responsibility)
-
-Does NOT re-test model behavior (filtering, field validation, etc).
+Drives the real cancel service against a real user and a real signed upload
+token (round-tripped through ``generate_upload_token`` / ``verify_upload_token``),
+with the best-effort S3 delete running through the real ``cms.assets.s3`` helper
+and ``shared.cloud`` AWS adapter mocked only at the ``boto3`` boundary, instead
+of patching ``verify_upload_token`` / ``delete_agent``.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
+from django.contrib.auth import get_user_model
 
 from cms import services
+from cms.assets.upload_token import generate_upload_token
+from cms.exceptions import CMSError
 from shared.constants import USER_CANNOT_BE_NONE
 
-# MSI magic prefix used to make every happy-path complete_upload test pass the
-# server-side header inspection added in issue #696.
-_MSI_HEADER = bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]) + b"\x00" * 16
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
 
 
 @pytest.fixture
-def mock_user():
-    user = Mock()
-    user.pk = 42
-    user.id = 42
-    user.email = "test@example.com"
-    return user
+def user(db):
+    return User.objects.create_user(username="cancel@example.com", email="cancel@example.com")
+
+
+@pytest.fixture
+def s3_delete(settings):
+    """Patch ``boto3.client`` at the boundary; configure bucket + token expiry."""
+    settings.AWS_S3_BUCKET_NAME = "test-bucket"
+    settings.AGENT_UPLOAD_URL_EXPIRES = 900
+    client = MagicMock()
+    with patch("boto3.client", return_value=client):
+        yield client
+
+
+def _token(
+    user, *, s3_key="agents/1/abc_agent.msi", name="Agent", filename="agent.msi", os_slug="windows", file_size=1000
+):
+    return generate_upload_token(
+        user_id=user.id, s3_key=s3_key, name=name, filename=filename, os_slug=os_slug, file_size=file_size
+    )
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError({"Error": {"Code": code, "Message": "boom"}}, "DeleteObject")
 
 
 class TestCancelUpload:
-    """Tests for cancel_upload() service function.
+    def test_returns_none_and_deletes_object(self, user, s3_delete):
+        s3_key = f"agents/{user.id}/abc_agent.msi"
+        result = services.cancel_upload(user, _token(user, s3_key=s3_key))
 
-    Tests SERVICE behavior with mocked dependencies:
-    - Validates inputs (user, upload_token)
-    - Verifies upload token
-    - Deletes S3 object
-    - Returns None on success
-    """
+        assert result is None
+        s3_delete.delete_object.assert_called_once()
+        kwargs = s3_delete.delete_object.call_args.kwargs
+        assert kwargs["Bucket"] == "test-bucket"
+        assert kwargs["Key"] == s3_key
 
-    # --- Service calls dependencies correctly ---
 
-    def test_calls_verify_upload_token_with_token_and_user_id(self, mock_user):
-        """Service calls verify_upload_token with the token and user_id."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        verify_token_path = "cms.assets.upload_token.verify_upload_token"
-        with (
-            patch(verify_token_path, return_value=token_payload) as mock_verify,
-            patch("cms.assets.s3.delete_agent"),
-        ):
-            services.cancel_upload(mock_user, "token123")
-            mock_verify.assert_called_once_with("token123", mock_user.id)
-
-    def test_calls_delete_agent_with_s3_key(self, mock_user):
-        """Service calls delete_agent with s3_key from token."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        verify_token_path = "cms.assets.upload_token.verify_upload_token"
-        with (
-            patch(verify_token_path, return_value=token_payload),
-            patch("cms.assets.s3.delete_agent") as mock_delete,
-        ):
-            services.cancel_upload(mock_user, "token123")
-            mock_delete.assert_called_once_with("agents/1/abc_agent.msi")
-
-    # --- Service returns None ---
-
-    def test_returns_none_on_success(self, mock_user):
-        """Service returns None on successful cancellation."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch("cms.assets.s3.delete_agent"),
-        ):
-            result = services.cancel_upload(mock_user, "token123")
-            assert result is None
-
-    # --- Input validation - user ---
-
+class TestCancelUploadUserValidation:
     def test_raises_typeerror_when_user_is_none(self):
-        """Service raises TypeError when user is None."""
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
             services.cancel_upload(None, "token123")
 
-    def test_raises_typeerror_when_user_has_no_id_attribute(self):
-        """Service raises TypeError when user has no id attribute."""
+    def test_raises_typeerror_when_user_is_wrong_type(self):
         with pytest.raises(TypeError, match="user must be a User instance"):
             services.cancel_upload("not a user", "token123")
 
-    def test_raises_valueerror_when_user_id_is_none(self):
-        """Service raises ValueError when user is unsaved."""
-        unsaved_user = Mock()
-        unsaved_user.id = None
+    def test_raises_valueerror_when_user_is_unsaved(self):
         with pytest.raises(ValueError, match="user must be saved"):
-            services.cancel_upload(unsaved_user, "token123")
+            services.cancel_upload(User(username="unsaved"), "token123")
 
-    # --- Input validation - upload_token ---
 
-    def test_raises_valueerror_when_upload_token_is_none(self, mock_user):
-        """Service raises ValueError when upload_token is None."""
-        with pytest.raises(ValueError, match="upload_token cannot be None"):
-            services.cancel_upload(mock_user, None)
+class TestCancelUploadTokenValidation:
+    @pytest.mark.parametrize(
+        "token,err", [(None, "cannot be None"), ("", "cannot be empty"), ("   ", "cannot be empty")]
+    )
+    def test_rejects_bad_token(self, user, token, err):
+        with pytest.raises(ValueError, match=f"upload_token {err}"):
+            services.cancel_upload(user, token)
 
-    def test_raises_valueerror_when_upload_token_is_empty(self, mock_user):
-        """Service raises ValueError when upload_token is empty."""
-        with pytest.raises(ValueError, match="upload_token cannot be empty"):
-            services.cancel_upload(mock_user, "")
+    def test_raises_cmserror_on_invalid_token(self, user):
+        with pytest.raises(CMSError, match="Invalid upload token"):
+            services.cancel_upload(user, "not-a-valid-token")
 
-    def test_raises_valueerror_when_upload_token_is_whitespace(self, mock_user):
-        """Service raises ValueError when upload_token is only whitespace."""
-        with pytest.raises(ValueError, match="upload_token cannot be empty"):
-            services.cancel_upload(mock_user, "   ")
+    def test_raises_cmserror_on_expired_token(self, user, settings):
+        settings.AGENT_UPLOAD_URL_EXPIRES = -100  # token expires immediately
+        with pytest.raises(CMSError, match="Invalid upload token"):
+            services.cancel_upload(user, _token(user))
 
-    # --- Token verification errors ---
 
-    def test_raises_cmserror_on_invalid_token(self, mock_user):
-        """Service raises CMSError when token is invalid."""
-        from cms.exceptions import CMSError
+class TestCancelUploadBestEffortDelete:
+    def test_succeeds_when_s3_delete_fails(self, user, s3_delete):
+        s3_delete.delete_object.side_effect = _client_error("500")
+        assert services.cancel_upload(user, _token(user)) is None
 
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                side_effect=ValueError("Invalid token"),
-            ),
-            pytest.raises(CMSError, match="Invalid upload token"),
-        ):
-            services.cancel_upload(mock_user, "bad_token")
-
-    def test_raises_cmserror_on_expired_token(self, mock_user):
-        """Service raises CMSError when token is expired."""
-        from cms.exceptions import CMSError
-
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                side_effect=ValueError("Token expired"),
-            ),
-            pytest.raises(CMSError, match="Invalid upload token"),
-        ):
-            services.cancel_upload(mock_user, "expired_token")
-
-    # --- S3 delete errors (should be ignored) ---
-
-    def test_succeeds_when_s3_delete_fails(self, mock_user):
-        """Service succeeds even when S3 delete fails (best effort cleanup)."""
-        from cms.assets.s3 import S3Error
-
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch(
-                "cms.assets.s3.delete_agent",
-                side_effect=S3Error("Delete failed"),
-            ),
-        ):
-            # Should not raise - S3 delete is best effort
-            result = services.cancel_upload(mock_user, "token123")
-            assert result is None
-
-    def test_succeeds_when_s3_object_not_found(self, mock_user):
-        """Service succeeds when S3 object doesn't exist (already deleted)."""
-        from cms.assets.s3 import S3Error
-
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch(
-                "cms.assets.s3.delete_agent",
-                side_effect=S3Error("Object not found"),
-            ),
-        ):
-            # Should not raise - object may have never been uploaded
-            result = services.cancel_upload(mock_user, "token123")
-            assert result is None
-
-    # --- Error propagation ---
-
-    def test_propagates_unexpected_exception(self, mock_user):
-        """Service propagates unexpected exceptions from dependencies."""
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                side_effect=RuntimeError("Unexpected"),
-            ),
-            pytest.raises(RuntimeError, match="Unexpected"),
-        ):
-            services.cancel_upload(mock_user, "token123")
+    def test_succeeds_when_s3_object_not_found(self, user, s3_delete):
+        s3_delete.delete_object.side_effect = _client_error("404")
+        assert services.cancel_upload(user, _token(user)) is None

--- a/shifter/shifter_platform/tests/cms/test_services_upload_complete.py
+++ b/shifter/shifter_platform/tests/cms/test_services_upload_complete.py
@@ -1,401 +1,176 @@
-"""CMS service interface tests.
+"""Behavior tests for cms.services.complete_upload.
 
-Tests service-level behavior only:
-- Expected behavior / return values
-- Exception handling
-- Input validation (service's responsibility)
-
-Does NOT re-test model behavior (filtering, field validation, etc).
+Drives the real completion service against a real user, a real signed upload
+token, and the full verify -> header-inspect -> tag -> create_agent stack. S3 is
+exercised through the real ``cms.assets.s3`` helper and ``shared.cloud`` AWS
+adapter, mocked only at the ``boto3`` boundary; the created agent is asserted
+against the persisted ``AgentConfig`` / ``AuditLog`` rows, instead of patching
+``verify_upload_token`` / ``verify_s3_object_exists`` / ``read_agent_header`` /
+``tag_s3_object`` / ``create_agent``.
 """
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
+from django.contrib.auth import get_user_model
 
 from cms import services
+from cms.assets.upload_token import generate_upload_token
+from cms.exceptions import CMSError
 from cms.models import AgentConfig
+from risk_register.models import AuditLog
 from shared.constants import USER_CANNOT_BE_NONE
 
-# MSI magic prefix used to make every happy-path complete_upload test pass the
-# server-side header inspection added in issue #696.
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+# MSI / OLE compound-document magic so header inspection passes for `.msi` tokens.
 _MSI_HEADER = bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]) + b"\x00" * 16
+# ZIP magic — a mismatch for a `.msi` declared format.
+_ZIP_HEADER = b"\x50\x4b\x03\x04" + b"\x00" * 16
 
 
 @pytest.fixture
-def mock_user():
-    user = Mock()
-    user.pk = 42
-    user.id = 42
-    user.email = "test@example.com"
-    return user
+def user(db):
+    return User.objects.create_user(username="complete@example.com", email="complete@example.com")
 
 
-class TestCompleteUploadDependencies:
-    """Dependency call tests for complete_upload()."""
+@pytest.fixture
+def s3_complete(settings):
+    """Patch ``boto3.client`` with an S3 client whose head/get/tag/delete succeed.
 
-    def test_calls_verify_upload_token_with_token_and_user_id(self, mock_user):
-        """Service calls verify_upload_token with the token and user_id."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        verify_token_path = "cms.assets.upload_token.verify_upload_token"
-        with (
-            patch(verify_token_path, return_value=token_payload) as mock_verify,
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
-            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
-            patch("cms.assets.s3.tag_s3_object"),
-            patch("cms.assets.services.create_agent") as mock_create,
-        ):
-            mock_create.return_value = Mock(spec=AgentConfig, id=42)
-            services.complete_upload(mock_user, "token123")
-            mock_verify.assert_called_once_with("token123", mock_user.id)
-
-    def test_calls_verify_s3_object_exists_with_s3_key(self, mock_user):
-        """Service calls verify_s3_object_exists with s3_key from token."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")) as mock_verify_s3,
-            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
-            patch("cms.assets.s3.tag_s3_object"),
-            patch("cms.assets.services.create_agent") as mock_create,
-        ):
-            mock_create.return_value = Mock(spec=AgentConfig, id=42)
-            services.complete_upload(mock_user, "token123")
-            mock_verify_s3.assert_called_once_with("agents/1/abc_agent.msi")
-
-    def test_calls_tag_s3_object_with_completed_tags(self, mock_user):
-        """Service calls tag_s3_object with completion tags."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
-            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
-            patch("cms.assets.s3.tag_s3_object") as mock_tag,
-            patch("cms.assets.services.create_agent") as mock_create,
-        ):
-            mock_create.return_value = Mock(spec=AgentConfig, id=42)
-            services.complete_upload(mock_user, "token123")
-            mock_tag.assert_called_once_with("agents/1/abc_agent.msi", {"status": "completed"})
-
-    def test_calls_create_agent_with_all_params(self, mock_user):
-        """Service calls create_agent with all required params."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "My Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 5000,
-            "agent_type": "xdr",
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(5000, "etag")),
-            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
-            patch("cms.assets.s3.tag_s3_object"),
-            patch("cms.assets.services.create_agent") as mock_create,
-        ):
-            mock_create.return_value = Mock(spec=AgentConfig, id=42)
-            services.complete_upload(mock_user, "token123")
-            mock_create.assert_called_once_with(
-                user=mock_user,
-                spec=services.AgentUploadSpec(
-                    name="My Agent",
-                    s3_key="agents/1/abc_agent.msi",
-                    filename="agent.msi",
-                    os_slug="windows",
-                    file_size=5000,
-                    upload_method="presigned",
-                    agent_type="xdr",
-                ),
-            )
+    Defaults: object is 1000 bytes (matches the default token), and the header
+    is valid MSI magic. Tests override per-operation via the returned mock.
+    """
+    settings.AWS_S3_BUCKET_NAME = "test-bucket"
+    settings.AGENT_UPLOAD_URL_EXPIRES = 900
+    client = MagicMock()
+    client.head_object.return_value = {"ContentLength": 1000, "ETag": '"etag"'}
+    body = MagicMock()
+    body.read.return_value = _MSI_HEADER
+    client.get_object.return_value = {"Body": body}
+    with patch("boto3.client", return_value=client):
+        yield client
 
 
-class TestCompleteUploadReturns:
-    """Return payload tests for complete_upload()."""
-
-    def test_returns_created_agent(self, mock_user):
-        """Service returns the agent created by create_agent."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        mock_agent = Mock(spec=AgentConfig, id=42, name="Agent")
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
-            patch("cms.assets.s3.read_agent_header", return_value=_MSI_HEADER),
-            patch("cms.assets.s3.tag_s3_object"),
-            patch("cms.assets.services.create_agent", return_value=mock_agent),
-        ):
-            result = services.complete_upload(mock_user, "token123")
-            assert result == mock_agent
-            assert result.id == 42
+def _token(
+    user, *, s3_key=None, name="Agent", filename="agent.msi", os_slug="windows", file_size=1000, agent_type="xdr"
+):
+    return generate_upload_token(
+        user_id=user.id,
+        s3_key=s3_key or f"agents/{user.id}/abc_agent.msi",
+        name=name,
+        filename=filename,
+        os_slug=os_slug,
+        file_size=file_size,
+        agent_type=agent_type,
+    )
 
 
-class TestCompleteUploadTokenValidation:
-    """User and upload-token validation tests for complete_upload()."""
+class TestCompleteUploadSuccess:
+    def test_creates_and_returns_persisted_agent(self, user, windows_os, s3_complete):
+        s3_key = f"agents/{user.id}/abc_agent.msi"
+        agent = services.complete_upload(user, _token(user, s3_key=s3_key, name="My Agent", file_size=1000))
 
+        assert isinstance(agent, AgentConfig)
+        persisted = AgentConfig.objects.get(pk=agent.pk)
+        assert persisted.name == "My Agent"
+        assert persisted.os == windows_os
+        assert persisted.s3_key == s3_key
+        assert persisted.file_size_bytes == 1000
+        assert persisted.user_id == user.id
+
+    def test_audit_records_presigned_upload_method(self, user, windows_os, s3_complete):
+        agent = services.complete_upload(user, _token(user))
+        row = AuditLog.objects.get(
+            entity_type=AuditLog.EntityType.AGENT, entity_id=agent.id, action=AuditLog.Action.CREATE
+        )
+        assert row.new_state["upload_method"] == "presigned"
+
+    def test_tags_object_completed_with_s3_key(self, user, windows_os, s3_complete):
+        s3_key = f"agents/{user.id}/abc_agent.msi"
+        services.complete_upload(user, _token(user, s3_key=s3_key))
+
+        assert s3_complete.head_object.call_args.kwargs["Key"] == s3_key
+        tag_kwargs = s3_complete.put_object_tagging.call_args.kwargs
+        assert tag_kwargs["Key"] == s3_key
+        assert tag_kwargs["Tagging"] == {"TagSet": [{"Key": "status", "Value": "completed"}]}
+
+
+class TestCompleteUploadUserAndTokenValidation:
     def test_raises_typeerror_when_user_is_none(self):
-        """Service raises TypeError when user is None."""
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
             services.complete_upload(None, "token123")
 
-    def test_raises_typeerror_when_user_has_no_id_attribute(self):
-        """Service raises TypeError when user has no id attribute."""
+    def test_raises_typeerror_when_user_is_wrong_type(self):
         with pytest.raises(TypeError, match="user must be a User instance"):
             services.complete_upload("not a user", "token123")
 
-    def test_raises_valueerror_when_user_id_is_none(self):
-        """Service raises ValueError when user is unsaved."""
-        unsaved_user = Mock()
-        unsaved_user.id = None
+    def test_raises_valueerror_when_user_is_unsaved(self):
         with pytest.raises(ValueError, match="user must be saved"):
-            services.complete_upload(unsaved_user, "token123")
+            services.complete_upload(User(username="unsaved"), "token123")
 
-    def test_raises_valueerror_when_upload_token_is_none(self, mock_user):
-        """Service raises ValueError when upload_token is None."""
-        with pytest.raises(ValueError, match="upload_token cannot be None"):
-            services.complete_upload(mock_user, None)
+    @pytest.mark.parametrize(
+        "token,err", [(None, "cannot be None"), ("", "cannot be empty"), ("   ", "cannot be empty")]
+    )
+    def test_rejects_bad_token(self, user, token, err):
+        with pytest.raises(ValueError, match=f"upload_token {err}"):
+            services.complete_upload(user, token)
 
-    def test_raises_valueerror_when_upload_token_is_empty(self, mock_user):
-        """Service raises ValueError when upload_token is empty."""
-        with pytest.raises(ValueError, match="upload_token cannot be empty"):
-            services.complete_upload(mock_user, "")
+    def test_raises_cmserror_on_invalid_token(self, user):
+        with pytest.raises(CMSError, match="Invalid upload token"):
+            services.complete_upload(user, "not-a-valid-token")
 
-    def test_raises_valueerror_when_upload_token_is_whitespace(self, mock_user):
-        """Service raises ValueError when upload_token is only whitespace."""
-        with pytest.raises(ValueError, match="upload_token cannot be empty"):
-            services.complete_upload(mock_user, "   ")
-
-    def test_raises_cmserror_on_invalid_token(self, mock_user):
-        """Service raises CMSError when token is invalid."""
-        from cms.exceptions import CMSError
-
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                side_effect=ValueError("Invalid token"),
-            ),
-            pytest.raises(CMSError, match="Invalid upload token"),
-        ):
-            services.complete_upload(mock_user, "bad_token")
-
-    def test_raises_cmserror_on_expired_token(self, mock_user):
-        """Service raises CMSError when token is expired."""
-        from cms.exceptions import CMSError
-
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                side_effect=ValueError("Token expired"),
-            ),
-            pytest.raises(CMSError, match="Invalid upload token"),
-        ):
-            services.complete_upload(mock_user, "expired_token")
+    def test_raises_cmserror_on_expired_token(self, user, settings):
+        settings.AGENT_UPLOAD_URL_EXPIRES = -100
+        with pytest.raises(CMSError, match="Invalid upload token"):
+            services.complete_upload(user, _token(user))
 
 
 class TestCompleteUploadObjectValidation:
-    """S3 object validation tests for complete_upload()."""
+    def test_raises_when_s3_object_not_found(self, user, s3_complete):
+        s3_complete.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
+        )
+        with pytest.raises(CMSError, match="Upload not found"):
+            services.complete_upload(user, _token(user))
 
-    def test_raises_cmserror_when_s3_object_not_found(self, mock_user):
-        """Service raises CMSError when S3 object doesn't exist."""
-        from cms.assets.s3 import S3Error
-        from cms.exceptions import CMSError
-
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch(
-                "cms.assets.s3.verify_s3_object_exists",
-                side_effect=S3Error("Object not found"),
-            ),
-            pytest.raises(CMSError, match="Upload not found"),
-        ):
-            services.complete_upload(mock_user, "token123")
-
-    def test_raises_cmserror_when_file_size_mismatch(self, mock_user):
-        """Service raises CMSError when S3 object size doesn't match token."""
-        from cms.exceptions import CMSError
-
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                return_value=token_payload,
-            ),
-            patch(
-                "cms.assets.s3.verify_s3_object_exists",
-                return_value=(5000, "etag"),  # Wrong size
-            ),
-            pytest.raises(CMSError, match="size mismatch"),
-        ):
-            services.complete_upload(mock_user, "token123")
+    def test_raises_on_file_size_mismatch(self, user, s3_complete):
+        s3_complete.head_object.return_value = {"ContentLength": 5000, "ETag": '"etag"'}
+        with pytest.raises(CMSError, match="size mismatch"):
+            services.complete_upload(user, _token(user, file_size=1000))
 
 
-class TestCompleteUploadHeaderValidation:
-    """File-header inspection and no-leak tests for complete_upload()."""
+class TestCompleteUploadHeaderInspection:
+    def test_magic_byte_mismatch_deletes_object_and_aborts(self, user, s3_complete):
+        s3_complete.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=_ZIP_HEADER))}
+        s3_key = f"agents/{user.id}/abc_agent.msi"
 
-    def test_reads_object_header_after_size_verify(self, mock_user):
-        """Service reads the object header via the cloud seam before tagging."""
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        msi_magic = bytes([0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1])
-        with (
-            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
-            patch("cms.assets.s3.read_agent_header", return_value=msi_magic + b"\x00" * 16) as mock_read,
-            patch("cms.assets.s3.tag_s3_object"),
-            patch("cms.assets.services.create_agent") as mock_create,
-        ):
-            mock_create.return_value = Mock(spec=AgentConfig, id=42)
-            services.complete_upload(mock_user, "token123")
-            mock_read.assert_called_once()
-            args, _ = mock_read.call_args
-            assert args[0] == "agents/1/abc_agent.msi"
+        with pytest.raises(CMSError, match="content"):
+            services.complete_upload(user, _token(user, s3_key=s3_key, filename="agent.msi"))
 
-    def test_magic_byte_mismatch_raises_and_deletes_object(self, mock_user):
-        """Magic-byte mismatch must delete the object and skip tag + create_agent + audit."""
-        from cms.exceptions import CMSError
+        s3_complete.delete_object.assert_called_once()
+        assert s3_complete.delete_object.call_args.kwargs["Key"] == s3_key
+        s3_complete.put_object_tagging.assert_not_called()
+        assert AgentConfig.objects.count() == 0
 
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",  # .msi expects D0 CF 11 E0 ...
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        # Header is ZIP magic, not MSI — mismatch.
-        bogus_header = b"\x50\x4b\x03\x04" + b"\x00" * 16
-        with (
-            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
-            patch("cms.assets.s3.read_agent_header", return_value=bogus_header),
-            patch("cms.assets.s3.tag_s3_object") as mock_tag,
-            patch("cms.assets.s3.delete_agent") as mock_delete,
-            patch("cms.assets.services.create_agent") as mock_create,
-            pytest.raises(CMSError, match="content"),
-        ):
-            services.complete_upload(mock_user, "token123")
-        mock_delete.assert_called_once_with("agents/1/abc_agent.msi")
-        mock_tag.assert_not_called()
-        mock_create.assert_not_called()
+    def test_header_read_failure_raises_and_does_not_finalize(self, user, s3_complete):
+        s3_complete.get_object.side_effect = ClientError({"Error": {"Code": "500", "Message": "boom"}}, "GetObject")
 
-    def test_rejection_log_does_not_leak_header_bytes_or_token(self, mock_user, caplog):
-        from cms.exceptions import CMSError
+        with pytest.raises(CMSError, match="inspection"):
+            services.complete_upload(user, _token(user))
 
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
+        s3_complete.put_object_tagging.assert_not_called()
+        assert AgentConfig.objects.count() == 0
+
+    def test_rejection_log_does_not_leak_header_bytes(self, user, s3_complete, caplog):
         leak = b"\x50\x4b\x03\x04S3CR3T-DO-NOT-LEAK"
-        with (
-            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
-            patch("cms.assets.s3.read_agent_header", return_value=leak),
-            patch("cms.assets.s3.delete_agent"),
-            patch("cms.assets.s3.tag_s3_object"),
-            patch("cms.assets.services.create_agent"),
-            caplog.at_level("WARNING", logger="cms.services"),
-            pytest.raises(CMSError),
-        ):
-            services.complete_upload(mock_user, "token-S3CR3T-DO-NOT-LEAK")
+        s3_complete.get_object.return_value = {"Body": MagicMock(read=MagicMock(return_value=leak))}
+
+        with caplog.at_level("WARNING", logger="cms.services"), pytest.raises(CMSError):
+            services.complete_upload(user, _token(user, filename="agent.msi"))
 
         combined = " ".join(record.getMessage() for record in caplog.records)
         assert "S3CR3T-DO-NOT-LEAK" not in combined
-
-    def test_header_read_failure_raises_cmserror(self, mock_user):
-        """If reading the header fails, the service raises CMSError and does not finalize."""
-        from cms.assets.s3 import S3Error
-        from cms.exceptions import CMSError
-
-        token_payload = {
-            "s3_key": "agents/1/abc_agent.msi",
-            "name": "Agent",
-            "filename": "agent.msi",
-            "os_slug": "windows",
-            "file_size": 1000,
-        }
-        with (
-            patch("cms.assets.upload_token.verify_upload_token", return_value=token_payload),
-            patch("cms.assets.s3.verify_s3_object_exists", return_value=(1000, "etag")),
-            patch(
-                "cms.assets.s3.read_agent_header",
-                side_effect=S3Error("range read failed"),
-            ),
-            patch("cms.assets.s3.tag_s3_object") as mock_tag,
-            patch("cms.assets.services.create_agent") as mock_create,
-            pytest.raises(CMSError),
-        ):
-            services.complete_upload(mock_user, "token123")
-        mock_tag.assert_not_called()
-        mock_create.assert_not_called()
-
-
-class TestCompleteUploadFailurePropagation:
-    """Unexpected failure propagation tests for complete_upload()."""
-
-    def test_propagates_unexpected_exception(self, mock_user):
-        """Service propagates unexpected exceptions from dependencies."""
-        with (
-            patch(
-                "cms.assets.upload_token.verify_upload_token",
-                side_effect=RuntimeError("Unexpected"),
-            ),
-            pytest.raises(RuntimeError, match="Unexpected"),
-        ):
-            services.complete_upload(mock_user, "token123")


### PR DESCRIPTION
Continue Group 3 (cms core) of #957 — the S3/boto3-boundary cluster. Rewrite the asset-service, S3-helper, and presigned-upload-lifecycle suites to drive real rows and the real cloud stack down to the `boto3` boundary, instead of patching `cms.assets.{services,s3,validation,upload_token}` internals.

## Changes (5 suites, 2 commits)

**Asset service + S3 helper**
- `tests/cms/test_assets.py` — `create_agent` / `delete_agent` / `get_storage_used` against real `AgentConfig` / `OperatingSystem` / `AuditLog`; delete fail-fast driven by a `boto3` `ClientError` asserts no soft-delete.
- `tests/cms/assets/test_s3.py` — `cms.assets.s3` upload/delete/presign/head/tag drive the real AWS adapter down to the `boto3` S3 client; asserts call shape + `ClientError`→`CloudStorageError`→`S3Error` bridging.

**Presigned-upload lifecycle**
- `tests/cms/test_services_upload.py` — `initiate_upload`: real quota + extension validation; the issued upload token is asserted by verifying it for real (payload carries name/filename/os_slug/file_size/agent_type/s3_key).
- `tests/cms/test_services_upload_cancel.py` — `cancel_upload`: real token round-trip; best-effort S3 delete over the real boto3 boundary; invalid/expired tokens → CMSError.
- `tests/cms/test_services_upload_complete.py` — `complete_upload`: full verify → header-inspect → tag → `create_agent` against real rows; asserts persisted `AgentConfig`/`AuditLog`, the completed-tag, size/not-found rejection, magic-byte-mismatch delete-and-abort, header-read failure, and that rejection logs do not leak header bytes.

S3 (presign / head / range-GET header read / tag / delete) is mocked only at the `boto3` boundary, with `AWS_S3_BUCKET_NAME` set so the real not-configured guard is not tripped.

Shrink `boundary_mock_baseline.json` by 17 entries (140 internal-patch allowances removed); update `docs/adr/README.md`. The unexpected-exception re-raise tests are dropped (generic except/re-raise path, only exercisable via first-party fault injection).

## Verification

- `test_assets` (23) + `assets/test_s3` (15) + `test_services_upload` (22) + `_cancel` (11) + `_complete` (16) green.
- `adr_guard.py` full run green; full `pytest (shifter_platform)` suite green via pre-commit hook.

Refs #957.