### PR TITLE
test(cms): rewrite model + scenario-hydrator suites to behavior tests

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -253,7 +253,19 @@ entries. Completed so far:
   the engine-error path driven by a real engine NGFW instance with an attached
   range. Impossible-state defensive tests (the ORM returning `None` / a
   wrong-typed object / a list of dicts) and generic unexpected-exception re-raise
-  tests are dropped per the boundary-mock-policy intent (ADR-019).
+  tests are dropped per the boundary-mock-policy intent (ADR-019). The model and
+  scenario-hydrator suites (`test_models`, `test_credentials`,
+  `test_models_agent_config`, `test_models_asset`, `test_models_operating_system`,
+  `test_models_range_instance`, `test_models_subnet`, `test_scenario_hydrator`)
+  drive real rows for the ORM-dependent cases — Credential/CredentialType
+  create/uniqueness/cascade/PROTECT, `active_for_user` soft-delete filtering,
+  `RangeInstance` create/query/`select_related`, `OperatingSystem.get_for_extension`,
+  and the `Subnet` terminal soft-delete invariant — keeping the field-inspection
+  and in-memory property tests as-is. `test_scenario_hydrator` drives the real
+  `hydrate_scenario` against real DB `Scenario` rows (loaded through the real
+  registry) and real `AgentConfig` rows, exercising `from_agent` OS resolution and
+  agent embedding. With these the `cms` core area carries no remaining ADR-019
+  baseline entries.
 
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -1466,61 +1466,6 @@
       "target": "cms.scenarios.registry.load_scenario_template"
     },
     {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/cms/test_credentials.py",
-      "target": "cms.models.Credential.objects.create"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/test_credentials.py",
-      "target": "cms.models.CredentialType.objects.create"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/cms/test_models.py",
-      "target": "cms.models.Credential.objects.create"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/test_models.py",
-      "target": "cms.models.Credential.objects.filter"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/test_models.py",
-      "target": "cms.models.CredentialType.objects.create"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/test_models_agent_config.py",
-      "target": "cms.models.AgentConfig.objects.filter"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/test_models_asset.py",
-      "target": "cms.models.AgentConfig.objects.filter"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/test_models_operating_system.py",
-      "target": "cms.models.OperatingSystem.objects.for_extension"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/test_models_range_instance.py",
-      "target": "cms.models.RangeInstance.objects"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/test_models_subnet.py",
-      "target": "cms.models.Subnet.validate_data"
-    },
-    {
-      "count": 23,
-      "path": "shifter/shifter_platform/tests/cms/test_scenario_hydrator.py",
-      "target": "cms.scenarios.hydrator.load_scenario"
-    },
-    {
       "count": 2,
       "path": "shifter/shifter_platform/tests/config/test_logout.py",
       "target": "config.views.logout"

--- a/shifter/shifter_platform/tests/cms/test_credentials.py
+++ b/shifter/shifter_platform/tests/cms/test_credentials.py
@@ -1,7 +1,6 @@
 """Tests for CMS Credential and CredentialType models."""
 
 from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
@@ -91,6 +90,18 @@ def _make_credential(user, name, credential_type, data, **kwargs):
     return cred
 
 
+def _real_user(suffix):
+    from django.contrib.auth import get_user_model
+
+    return get_user_model().objects.create_user(username=f"cred-{suffix}@e.com", email=f"cred-{suffix}@e.com")
+
+
+def _real_ct(slug, spec):
+    from cms.models import CredentialType
+
+    return CredentialType.objects.get_or_create(slug=slug, defaults={"name": slug, "spec_class": spec})[0]
+
+
 # ---------------------------------------------------------------------------
 # TestCredentialType
 # ---------------------------------------------------------------------------
@@ -99,30 +110,19 @@ def _make_credential(user, name, credential_type, data, **kwargs):
 class TestCredentialType:
     """Tests for the CredentialType model."""
 
+    @pytest.mark.django_db
     def test_create_credential_type(self):
         """CredentialType can be created with required fields."""
         from cms.models import CredentialType
 
-        ct = CredentialType.__new__(CredentialType)
-        ct.__dict__.update(
-            {
-                "id": 99,
-                "name": "Test Type",
-                "slug": "test",
-                "spec_class": "shared.schemas.SCMCredentialSpec",
-            }
+        cred_type = CredentialType.objects.create(
+            name="Test Type", slug="test-cred-type", spec_class="shared.schemas.SCMCredentialSpec"
         )
 
-        with patch.object(CredentialType.objects, "create", return_value=ct):
-            cred_type = CredentialType.objects.create(
-                name="Test Type",
-                slug="test",
-                spec_class="shared.schemas.SCMCredentialSpec",
-            )
-
-        assert cred_type.name == "Test Type"
-        assert cred_type.slug == "test"
-        assert cred_type.spec_class == "shared.schemas.SCMCredentialSpec"
+        persisted = CredentialType.objects.get(pk=cred_type.pk)
+        assert persisted.name == "Test Type"
+        assert persisted.slug == "test-cred-type"
+        assert persisted.spec_class == "shared.schemas.SCMCredentialSpec"
 
     def test_get_spec_class_loads_scm_spec(self, scm_credential_type):
         """get_spec_class() should load SCMCredentialSpec."""
@@ -186,10 +186,13 @@ class TestCredentialType:
 class TestCredential:
     """Tests for the Credential model."""
 
-    def test_create_credential_with_type(self, mock_user, scm_credential_type):
+    @pytest.mark.django_db
+    def test_create_credential_with_type(self):
         """Credential can be created with a CredentialType FK."""
         from cms.models import Credential
 
+        user = _real_user("with-type")
+        ct = _real_ct("scm", "shared.schemas.SCMCredentialSpec")
         data = {
             "scm_folder_name": "folder",
             "scm_pin_id": "PIN123",
@@ -197,25 +200,13 @@ class TestCredential:
             "sls_region": "americas",
         }
 
-        mock_instance = _make_credential(
-            user=mock_user,
-            name="My Credential",
-            credential_type=scm_credential_type,
-            data=data,
-        )
+        cred = Credential.objects.create(user=user, name="My Credential", credential_type=ct, data=data)
 
-        with patch.object(Credential.objects, "create", return_value=mock_instance):
-            cred = Credential.objects.create(
-                user=mock_user,
-                name="My Credential",
-                credential_type=scm_credential_type,
-                data=data,
-            )
-
-        assert cred.name == "My Credential"
-        assert cred.credential_type == scm_credential_type
-        assert cred.credential_type.slug == "scm"
-        assert cred.data["scm_folder_name"] == "folder"
+        persisted = Credential.objects.get(pk=cred.pk)
+        assert persisted.name == "My Credential"
+        assert persisted.credential_type == ct
+        assert persisted.credential_type.slug == "scm"
+        assert persisted.data["scm_folder_name"] == "folder"
 
     def test_is_deleted_property(self, mock_user, deployment_profile_type):
         """is_deleted reflects deleted_at state."""
@@ -273,67 +264,33 @@ class TestCredential:
         cred.expires_at = timezone.now() + timedelta(days=60)
         assert cred.expires_soon is False
 
-    def test_unique_name_per_user_constraint(self, mock_user, deployment_profile_type):
+    @pytest.mark.django_db
+    def test_unique_name_per_user_constraint(self):
         """User cannot have two active credentials with the same name."""
-        from django.db import IntegrityError
+        from django.db import IntegrityError, transaction
 
         from cms.models import Credential
 
-        first_cred = _make_credential(
-            user=mock_user,
-            name="Duplicate Name",
-            credential_type=deployment_profile_type,
-            data={},
-        )
+        user = _real_user("unique")
+        ct = _real_ct("deployment_profile", "shared.schemas.DeploymentProfileSpec")
+        Credential.objects.create(user=user, name="Duplicate Name", credential_type=ct, data={})
 
-        with patch.object(Credential.objects, "create") as mock_create:
-            # First create succeeds
-            mock_create.return_value = first_cred
-            Credential.objects.create(
-                user=mock_user,
-                name="Duplicate Name",
-                credential_type=deployment_profile_type,
-                data={},
-            )
+        with pytest.raises(IntegrityError), transaction.atomic():
+            Credential.objects.create(user=user, name="Duplicate Name", credential_type=ct, data={})
 
-            # Second create raises IntegrityError (unique constraint)
-            mock_create.side_effect = IntegrityError
-            with pytest.raises(IntegrityError):
-                Credential.objects.create(
-                    user=mock_user,
-                    name="Duplicate Name",
-                    credential_type=deployment_profile_type,
-                    data={},
-                )
-
-    def test_deleted_credential_allows_same_name(self, mock_user, deployment_profile_type):
+    @pytest.mark.django_db
+    def test_deleted_credential_allows_same_name(self):
         """Deleted credential should allow creating new one with same name."""
         from cms.models import Credential
 
-        # Create and soft-delete
-        cred1 = _make_credential(
-            user=mock_user,
-            name="Reusable Name",
-            credential_type=deployment_profile_type,
-            data={},
-        )
+        user = _real_user("reuse")
+        ct = _real_ct("deployment_profile", "shared.schemas.DeploymentProfileSpec")
+
+        cred1 = Credential.objects.create(user=user, name="Reusable Name", credential_type=ct, data={})
         cred1.deleted_at = timezone.now()
+        cred1.save(update_fields=["deleted_at"])
 
-        # New credential with same name succeeds
-        cred2 = _make_credential(
-            user=mock_user,
-            name="Reusable Name",
-            credential_type=deployment_profile_type,
-            data={},
-        )
-
-        with patch.object(Credential.objects, "create", return_value=cred2):
-            result = Credential.objects.create(
-                user=mock_user,
-                name="Reusable Name",
-                credential_type=deployment_profile_type,
-                data={},
-            )
-
+        result = Credential.objects.create(user=user, name="Reusable Name", credential_type=ct, data={})
         assert result.name == "Reusable Name"
+        assert result.deleted_at is None
         assert result.is_deleted is False

--- a/shifter/shifter_platform/tests/cms/test_models.py
+++ b/shifter/shifter_platform/tests/cms/test_models.py
@@ -1,18 +1,20 @@
 """Tests for cms.models module - CMS Django models.
 
-These are unit tests for the Django model layer. They test:
+Tests the Django model layer:
 - Model structure (fields, constraints, relationships)
-- Model properties and methods
-- Model behavior (soft delete, ordering)
+- Model properties and methods (in-memory, no DB)
+- Model behavior (real DB: create, ordering, uniqueness, cascade, PROTECT)
 
-All ORM operations are mocked - no database access required.
+Property/structure tests build in-memory instances; behavior tests that depend
+on ORM semantics (uniqueness, cascade, PROTECT, ordering) run against a real DB
+rather than patching ``Credential.objects`` / ``CredentialType.objects``.
 """
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
 
 import pytest
-from django.db import IntegrityError
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError, transaction
 from django.db.models import ProtectedError
 from django.utils import timezone
 
@@ -20,8 +22,34 @@ from cms.models import Credential, CredentialType
 
 from .conftest import make_credential
 
+User = get_user_model()
+
+
+def _real_ct():
+    """Get or create a real (saved) deployment-profile CredentialType."""
+    ct, _ = CredentialType.objects.get_or_create(
+        slug="deployment_profile",
+        defaults={"name": "Deployment Profile", "spec_class": "shared.schemas.DeploymentProfileSpec"},
+    )
+    return ct
+
+
+def _real_cred(user, name, *, ct=None, deleted_at=None):
+    cred = Credential.objects.create(
+        user=user, name=name, credential_type=ct or _real_ct(), data={"authcode": "D1234567"}
+    )
+    if deleted_at is not None:
+        cred.deleted_at = deleted_at
+        cred.save(update_fields=["deleted_at"])
+    return cred
+
+
+def _user(suffix):
+    return User.objects.create_user(username=f"cred-{suffix}@e.com", email=f"cred-{suffix}@e.com")
+
+
 # -----------------------------------------------------------------------------
-# CatalogBase Tests
+# CatalogBase Tests (in-memory via the credential_type_obj fixture)
 # -----------------------------------------------------------------------------
 
 
@@ -29,33 +57,20 @@ class TestCatalogBase:
     """Tests for CatalogBase abstract model (via CredentialType)."""
 
     def test_str_returns_name(self, credential_type_obj):
-        """__str__ returns the name field."""
         assert str(credential_type_obj) == "Deployment Profile"
 
     def test_get_spec_class_loads_pydantic_model(self, credential_type_obj):
-        """get_spec_class loads and returns the Pydantic spec class."""
-        spec_class = credential_type_obj.get_spec_class()
-
         from shared.schemas import DeploymentProfileSpec
 
-        assert spec_class is DeploymentProfileSpec
+        assert credential_type_obj.get_spec_class() is DeploymentProfileSpec
 
     def test_validate_data_returns_validated_dict(self, credential_type_obj):
-        """validate_data validates against spec and returns dict."""
-        data = {
-            "name": "Test Cred",
-            "user_id": 1,
-            "authcode": "D1234567",
-        }
-
-        result = credential_type_obj.validate_data(data)
-
+        result = credential_type_obj.validate_data({"name": "Test Cred", "user_id": 1, "authcode": "D1234567"})
         assert isinstance(result, dict)
         assert result["name"] == "Test Cred"
         assert result["authcode"] == "D1234567"
 
     def test_validate_data_raises_on_invalid_data(self, credential_type_obj):
-        """validate_data raises ValidationError for invalid data."""
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError):
@@ -63,46 +78,20 @@ class TestCatalogBase:
 
 
 # -----------------------------------------------------------------------------
-# Credential Model Tests
+# Credential model properties (in-memory)
 # -----------------------------------------------------------------------------
 
 
-class TestCredentialModel:
-    """Tests for Credential model."""
-
-    def test_create_credential(self, credential_type_obj):
-        """Can create a credential with required fields."""
-        cred = make_credential(credential_type_obj, name="My Credential")
-
-        with patch.object(Credential.objects, "create", return_value=cred):
-            result = Credential.objects.create(
-                user_id=1,
-                name="My Credential",
-                credential_type=credential_type_obj,
-                data={"authcode": "D1234567"},
-            )
-
-        assert result.id is not None
-        assert result.user_id == 1
-        assert result.name == "My Credential"
-        assert result.credential_type == credential_type_obj
-        assert result.data == {"authcode": "D1234567"}
-        assert result.deleted_at is None
-
+class TestCredentialProperties:
     def test_str_returns_name(self, credential_type_obj):
-        """__str__ returns the credential name."""
         cred = make_credential(credential_type_obj, name="My Test Credential")
         assert str(cred) == "My Test Credential"
 
     @pytest.mark.parametrize(
         "deleted_at,expected",
-        [
-            pytest.param(None, False, id="not-deleted"),
-            pytest.param("now", True, id="deleted"),
-        ],
+        [pytest.param(None, False, id="not-deleted"), pytest.param("now", True, id="deleted")],
     )
     def test_is_deleted(self, credential_type_obj, deleted_at, expected):
-        """is_deleted reflects whether deleted_at is set."""
         actual_deleted_at = timezone.now() if deleted_at == "now" else None
         cred = make_credential(credential_type_obj, deleted_at=actual_deleted_at)
         assert cred.is_deleted is expected
@@ -116,7 +105,6 @@ class TestCredentialModel:
         ],
     )
     def test_is_expired(self, credential_type_obj, expires_at_offset, expected):
-        """is_expired reflects expiry state."""
         expires_at = None if expires_at_offset is None else timezone.now() + expires_at_offset
         cred = make_credential(credential_type_obj, expires_at=expires_at)
         assert cred.is_expired is expected
@@ -130,178 +118,89 @@ class TestCredentialModel:
         ],
     )
     def test_expires_soon(self, credential_type_obj, expires_at_offset, expected):
-        """expires_soon reflects whether expiry is within 30 days."""
         expires_at = None if expires_at_offset is None else timezone.now() + expires_at_offset
         cred = make_credential(credential_type_obj, expires_at=expires_at)
         assert cred.expires_soon is expected
 
-    def test_ordering_by_created_at_descending(self, credential_type_obj):
-        """Credentials are ordered by created_at descending."""
-        cred1 = make_credential(credential_type_obj, pk=1, name="First")
-        cred2 = make_credential(credential_type_obj, pk=2, name="Second")
-
-        mock_qs = MagicMock()
-        mock_qs.__iter__ = MagicMock(return_value=iter([cred2, cred1]))
-
-        with patch.object(Credential.objects, "filter", return_value=mock_qs):
-            credentials = list(Credential.objects.filter(user_id=1))
-
-        # Newest first
-        assert credentials[0] == cred2
-        assert credentials[1] == cred1
-
 
 # -----------------------------------------------------------------------------
-# Credential Uniqueness Constraint Tests
+# Credential model behavior (real DB)
 # -----------------------------------------------------------------------------
 
 
+@pytest.mark.django_db
+class TestCredentialModel:
+    def test_create_credential(self):
+        user = _user("create")
+        ct = _real_ct()
+        result = Credential.objects.create(
+            user=user, name="My Credential", credential_type=ct, data={"authcode": "D1234567"}
+        )
+
+        persisted = Credential.objects.get(pk=result.pk)
+        assert persisted.user_id == user.id
+        assert persisted.name == "My Credential"
+        assert persisted.credential_type == ct
+        assert persisted.data == {"authcode": "D1234567"}
+        assert persisted.deleted_at is None
+
+    def test_ordering_by_created_at_descending(self):
+        user = _user("order")
+        first = _real_cred(user, "First")
+        Credential.objects.filter(pk=first.pk).update(created_at=timezone.now() - timedelta(hours=1))
+        _real_cred(user, "Second")
+
+        names = [c.name for c in Credential.objects.filter(user=user)]
+        assert names == ["Second", "First"]  # newest first (Meta.ordering = -created_at)
+
+
+@pytest.mark.django_db
 class TestCredentialUniqueness:
-    """Tests for credential uniqueness constraints."""
+    def test_duplicate_name_same_user_rejected(self):
+        user = _user("dup")
+        _real_cred(user, "My Credential")
+        with pytest.raises(IntegrityError), transaction.atomic():
+            _real_cred(user, "My Credential")
 
-    def test_duplicate_name_same_user_rejected(self, credential_type_obj):
-        """Rejects duplicate name for same user (active credentials)."""
-        first_cred = make_credential(credential_type_obj, pk=1, name="My Credential")
-
-        with patch.object(Credential.objects, "create") as mock_create:
-            # First create succeeds
-            mock_create.return_value = first_cred
-            Credential.objects.create(
-                user_id=1,
-                name="My Credential",
-                credential_type=credential_type_obj,
-                data={"authcode": "D1111111"},
-            )
-
-            # Second create raises IntegrityError (duplicate)
-            mock_create.side_effect = IntegrityError("duplicate key value violates unique constraint")
-            with pytest.raises(IntegrityError):
-                Credential.objects.create(
-                    user_id=1,
-                    name="My Credential",
-                    credential_type=credential_type_obj,
-                    data={"authcode": "D2222222"},
-                )
-
-    def test_same_name_different_users_allowed(self, credential_type_obj):
-        """Allows same name for different users."""
-        cred2 = make_credential(credential_type_obj, pk=2, user_id=2, name="My Credential")
-
-        with patch.object(Credential.objects, "create") as mock_create:
-            # First create for user 1
-            mock_create.return_value = make_credential(credential_type_obj, pk=1, user_id=1, name="My Credential")
-            Credential.objects.create(
-                user_id=1,
-                name="My Credential",
-                credential_type=credential_type_obj,
-                data={"authcode": "D1111111"},
-            )
-
-            # Second create for user 2 succeeds (different user)
-            mock_create.return_value = cred2
-            result = Credential.objects.create(
-                user_id=2,
-                name="My Credential",
-                credential_type=credential_type_obj,
-                data={"authcode": "D2222222"},
-            )
-
+    def test_same_name_different_users_allowed(self):
+        _real_cred(_user("u1"), "My Credential")
+        result = _real_cred(_user("u2"), "My Credential")
         assert result.id is not None
 
-    def test_deleted_credential_allows_same_name(self, credential_type_obj):
-        """Soft-deleted credential doesn't block new credential with same name."""
-        cred2 = make_credential(credential_type_obj, pk=2, name="My Credential")
-
-        with patch.object(Credential.objects, "create") as mock_create:
-            # First create is soft-deleted
-            mock_create.return_value = make_credential(
-                credential_type_obj, pk=1, name="My Credential", deleted_at=timezone.now()
-            )
-            Credential.objects.create(
-                user_id=1,
-                name="My Credential",
-                credential_type=credential_type_obj,
-                data={"authcode": "D1111111"},
-                deleted_at=timezone.now(),
-            )
-
-            # Second create succeeds (original is soft-deleted)
-            mock_create.return_value = cred2
-            result = Credential.objects.create(
-                user_id=1,
-                name="My Credential",
-                credential_type=credential_type_obj,
-                data={"authcode": "D2222222"},
-            )
-
+    def test_deleted_credential_allows_same_name(self):
+        user = _user("softdel")
+        _real_cred(user, "My Credential", deleted_at=timezone.now())
+        result = _real_cred(user, "My Credential")
         assert result.id is not None
         assert result.deleted_at is None
 
 
-# -----------------------------------------------------------------------------
-# Credential Foreign Key Tests
-# -----------------------------------------------------------------------------
-
-
+@pytest.mark.django_db
 class TestCredentialRelationships:
-    """Tests for credential foreign key relationships."""
+    def test_credential_deleted_when_user_deleted(self):
+        user = _user("cascade")
+        cred = _real_cred(user, "Temp Cred")
+        cred_id = cred.id
+        user.delete()
+        assert not Credential.all_objects.filter(id=cred_id).exists()
 
-    def test_credential_deleted_when_user_deleted(self, credential_type_obj):
-        """Credentials cascade delete when user is deleted (on_delete=CASCADE)."""
-        cred = make_credential(credential_type_obj, pk=10, user_id=99, name="Temp Cred")
-
-        # After user deletion, credential no longer exists
-        mock_qs = MagicMock()
-        mock_qs.exists.return_value = False
-
-        with patch.object(Credential.objects, "filter", return_value=mock_qs):
-            # Simulate user.delete() cascade
-            assert not Credential.objects.filter(id=cred.id).exists()
-
-    def test_credential_protected_when_type_deleted(self, credential_type_obj):
-        """Cannot delete CredentialType with existing credentials (PROTECT)."""
-        cred = make_credential(credential_type_obj, pk=1, name="Using Type")
-
-        # Mock delete to raise ProtectedError (what PROTECT does)
-        credential_type_obj.delete = MagicMock(
-            side_effect=ProtectedError(
-                "Cannot delete CredentialType with existing credentials",
-                {cred},
-            )
+    def test_credential_protected_when_type_deleted(self):
+        user = _user("protect")
+        ct = CredentialType.objects.create(
+            name="Protected Type", slug="protected_test_type", spec_class="shared.schemas.DeploymentProfileSpec"
         )
-
-        with pytest.raises(ProtectedError):
-            credential_type_obj.delete()
-
-
-# -----------------------------------------------------------------------------
-# CredentialType Tests
-# -----------------------------------------------------------------------------
+        _real_cred(user, "Using Type", ct=ct)
+        with pytest.raises(ProtectedError), transaction.atomic():
+            ct.delete()
 
 
+@pytest.mark.django_db
 class TestCredentialType:
-    """Tests for CredentialType model."""
-
     def test_slug_unique(self):
-        """CredentialType slug must be unique."""
-        with patch.object(CredentialType.objects, "create") as mock_create:
-            # First create succeeds
-            mock_create.return_value = CredentialType(
-                name="Unique Test Type",
-                slug="unique_test_slug",
-                spec_class="shared.schemas.DeploymentProfileSpec",
-            )
+        CredentialType.objects.create(
+            name="Unique Test Type", slug="unique_test_slug_x", spec_class="shared.schemas.DeploymentProfileSpec"
+        )
+        with pytest.raises(IntegrityError), transaction.atomic():
             CredentialType.objects.create(
-                name="Unique Test Type",
-                slug="unique_test_slug",
-                spec_class="shared.schemas.DeploymentProfileSpec",
+                name="Another Test Type", slug="unique_test_slug_x", spec_class="shared.schemas.DeploymentProfileSpec"
             )
-
-            # Second create with same slug raises IntegrityError
-            mock_create.side_effect = IntegrityError("duplicate key value violates unique constraint")
-            with pytest.raises(IntegrityError):
-                CredentialType.objects.create(
-                    name="Another Test Type",
-                    slug="unique_test_slug",
-                    spec_class="shared.schemas.DeploymentProfileSpec",
-                )

--- a/shifter/shifter_platform/tests/cms/test_models_agent_config.py
+++ b/shifter/shifter_platform/tests/cms/test_models_agent_config.py
@@ -7,8 +7,7 @@ These tests verify the AgentConfig model is:
 - Has correct meta options (ordering, verbose_name)
 """
 
-from unittest.mock import MagicMock, patch
-
+import pytest
 from django.db import models
 
 # -----------------------------------------------------------------------------
@@ -177,22 +176,38 @@ class TestAgentConfigProperties:
 class TestAgentConfigBehavior:
     """Tests for AgentConfig model behavior with mocked database access."""
 
+    @pytest.mark.django_db
     def test_active_for_user_excludes_deleted(self):
-        """active_for_user filters AgentConfig.objects (SoftDeleteManager, active-only)."""
-        from cms.models import AgentConfig
+        """active_for_user (a SoftDeleteManager) returns active rows, not deleted ones."""
+        from django.contrib.auth import get_user_model
+        from django.utils import timezone
 
-        user = MagicMock(id=1, username="testuser-active")
-        active_agent = MagicMock(name="Active Agent")
+        from cms.models import AgentConfig, OperatingSystem
 
-        mock_qs = MagicMock()
-        mock_qs.__iter__ = lambda self: iter([active_agent])
-        mock_qs.__eq__ = lambda self, other: list(self) == list(other)
+        user = get_user_model().objects.create_user(username="ac-active@e.com", email="ac-active@e.com")
+        os_obj, _ = OperatingSystem.objects.get_or_create(
+            slug="windows", defaults={"name": "Windows", "extensions": [".msi"]}
+        )
 
-        with patch.object(AgentConfig.objects, "filter", return_value=mock_qs) as mock_filter:
-            result = list(AgentConfig.active_for_user(user))
+        def _agent(name, deleted=False):
+            a = AgentConfig.objects.create(
+                user=user,
+                name=name,
+                os=os_obj,
+                s3_key=f"agents/{name}.msi",
+                original_filename="a.msi",
+                file_size_bytes=1,
+            )
+            if deleted:
+                a.deleted_at = timezone.now()
+                a.save(update_fields=["deleted_at"])
+            return a
 
-        mock_filter.assert_called_once_with(user=user)
-        assert result == [active_agent]
+        _agent("Active Agent")
+        _agent("Deleted Agent", deleted=True)
+
+        result = list(AgentConfig.active_for_user(user))
+        assert [a.name for a in result] == ["Active Agent"]
 
     def test_os_foreign_key_protects_on_delete(self):
         """OS FK uses PROTECT — verified via field inspection."""

--- a/shifter/shifter_platform/tests/cms/test_models_asset.py
+++ b/shifter/shifter_platform/tests/cms/test_models_asset.py
@@ -3,12 +3,32 @@
 Tests Asset soft-delete and active_for_user behavior through concrete model.
 """
 
-from unittest.mock import MagicMock, patch
-
+import pytest
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 
 User = get_user_model()
+
+
+def _real_agent(user, *, name, deleted_at=None):
+    """Create a real AgentConfig owned by ``user``."""
+    from cms.models import AgentConfig, OperatingSystem
+
+    os_obj, _ = OperatingSystem.objects.get_or_create(
+        slug="windows", defaults={"name": "Windows", "extensions": [".msi"]}
+    )
+    agent = AgentConfig.objects.create(
+        user=user,
+        name=name,
+        os=os_obj,
+        s3_key=f"agents/{name}.msi",
+        original_filename="test.msi",
+        file_size_bytes=1024,
+    )
+    if deleted_at is not None:
+        agent.deleted_at = deleted_at
+        agent.save(update_fields=["deleted_at"])
+    return agent
 
 
 class TestAssetBehavior:
@@ -49,36 +69,27 @@ class TestAssetBehavior:
         agent.deleted_at = timezone.now()
         assert agent.is_deleted is True
 
+    @pytest.mark.django_db
     def test_active_for_user_excludes_deleted_records(self):
-        """active_for_user filters AgentConfig.objects (a SoftDeleteManager, active-only)."""
+        """active_for_user (a SoftDeleteManager) returns active rows, not deleted ones."""
         from cms.models import AgentConfig
 
-        user = MagicMock(id=1)
-        active = self._make_agent(name="Active Agent")
+        user = User.objects.create_user(username="asset-active@e.com", email="asset-active@e.com")
+        _real_agent(user, name="Active Agent")
+        _real_agent(user, name="Deleted Agent", deleted_at=timezone.now())
 
-        mock_qs = MagicMock()
-        mock_qs.__iter__ = lambda self: iter([active])
+        result = list(AgentConfig.active_for_user(user))
+        assert [a.name for a in result] == ["Active Agent"]
 
-        with patch.object(AgentConfig.objects, "filter", return_value=mock_qs) as mock_filter:
-            result = list(AgentConfig.active_for_user(user))
-
-        mock_filter.assert_called_once_with(user=user)
-        assert len(result) == 1
-        assert result[0] == active
-
+    @pytest.mark.django_db
     def test_active_for_user_filters_by_user(self):
         """active_for_user only returns records for the specified user."""
         from cms.models import AgentConfig
 
-        user = MagicMock(id=1)
-        user_agent = self._make_agent(name="User Agent")
+        user = User.objects.create_user(username="asset-u1@e.com", email="asset-u1@e.com")
+        other = User.objects.create_user(username="asset-u2@e.com", email="asset-u2@e.com")
+        _real_agent(user, name="User Agent")
+        _real_agent(other, name="Other Agent")
 
-        mock_qs = MagicMock()
-        mock_qs.__iter__ = lambda self: iter([user_agent])
-
-        with patch.object(AgentConfig.objects, "filter", return_value=mock_qs) as mock_filter:
-            result = list(AgentConfig.active_for_user(user))
-
-        mock_filter.assert_called_once_with(user=user)
-        assert len(result) == 1
-        assert result[0].name == "User Agent"
+        result = list(AgentConfig.active_for_user(user))
+        assert [a.name for a in result] == ["User Agent"]

--- a/shifter/shifter_platform/tests/cms/test_models_operating_system.py
+++ b/shifter/shifter_platform/tests/cms/test_models_operating_system.py
@@ -14,8 +14,7 @@ Lookup logic is now layered:
   queryset method and is verified via a delegation assertion.
 """
 
-from unittest.mock import patch
-
+import pytest
 from django.db import models
 
 from cms.models.catalogs import (
@@ -198,15 +197,13 @@ class TestOperatingSystemQuerySetForExtension:
 class TestGetForExtensionWrapper:
     """``OperatingSystem.get_for_extension`` delegates to the queryset method."""
 
+    @pytest.mark.django_db
     def test_delegates_to_objects_for_extension(self):
         from cms.models import OperatingSystem
 
-        sentinel = object()
-        with patch.object(OperatingSystem.objects, "for_extension", return_value=sentinel) as mock_method:
-            result = OperatingSystem.get_for_extension(".testmsi")
-
-            assert result is sentinel
-            mock_method.assert_called_once_with(".testmsi")
+        os_obj = OperatingSystem.objects.create(slug="testos", name="Test OS", extensions=[".testmsi"])
+        assert OperatingSystem.get_for_extension(".testmsi") == os_obj
+        assert OperatingSystem.get_for_extension(".no-such-ext") is None
 
 
 # -----------------------------------------------------------------------------

--- a/shifter/shifter_platform/tests/cms/test_models_range_instance.py
+++ b/shifter/shifter_platform/tests/cms/test_models_range_instance.py
@@ -15,7 +15,6 @@ This decoupled design allows CMS to track:
 """
 
 from datetime import datetime
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -106,23 +105,6 @@ def make_range_instance(RangeInstance):
     return _factory
 
 
-@pytest.fixture
-def mock_objects(RangeInstance):
-    """Patch RangeInstance.objects and return the mock manager."""
-    with patch.object(RangeInstance, "objects") as mock_mgr:
-        yield mock_mgr
-
-
-@pytest.fixture
-def mock_qs():
-    """Return a mock queryset with chainable methods."""
-    qs = MagicMock()
-    qs.filter.return_value = qs
-    qs.select_related.return_value = qs
-    qs.all.return_value = qs
-    return qs
-
-
 # ---------------------------------------------------------------------------
 # TestRangeInstanceModel
 # ---------------------------------------------------------------------------
@@ -137,17 +119,15 @@ class TestRangeInstanceModel:
 
         assert RangeInstance is not None
 
-    def test_can_create_range_instance(self, RangeInstance, mock_objects, make_range_instance):
+    @pytest.mark.django_db
+    def test_can_create_range_instance(self, RangeInstance):
         """RangeInstance can be created with required fields."""
-        ri = make_range_instance(id=10, range_id=1, scenario_id="basic", user_id=1)
-        mock_objects.create.return_value = ri
-
         result = RangeInstance.objects.create(range_id=1, scenario_id="basic", user_id=1)
         assert result.id is not None
         assert result.range_id == 1
         assert result.scenario_id == "basic"
         assert result.user_id == 1
-        mock_objects.create.assert_called_once_with(range_id=1, scenario_id="basic", user_id=1)
+        assert RangeInstance.objects.get(pk=result.pk).range_id == 1
 
     def test_range_id_is_integer_not_fk(self, make_range_instance):
         """range_id is an IntegerField, not a ForeignKey."""
@@ -217,33 +197,23 @@ class TestRangeInstanceModel:
         # Should contain scenario_id or range_id
         assert "basic" in str_repr or "123" in str_repr
 
-    def test_can_query_by_range_id(self, RangeInstance, mock_objects, mock_qs, make_range_instance):
+    @pytest.mark.django_db
+    def test_can_query_by_range_id(self, RangeInstance):
         """RangeInstance can be queried by range_id."""
-        make_range_instance(range_id=42)
-        mock_qs.count.return_value = 1
-        mock_objects.filter.return_value = mock_qs
+        RangeInstance.objects.create(range_id=42, scenario_id="basic", user_id=1)
+        assert RangeInstance.objects.filter(range_id=42).count() == 1
 
-        result = RangeInstance.objects.filter(range_id=42)
-        assert result.count() == 1
-        mock_objects.filter.assert_called_once_with(range_id=42)
-
-    def test_can_query_by_scenario_id(self, RangeInstance, mock_objects, mock_qs, make_range_instance):
+    @pytest.mark.django_db
+    def test_can_query_by_scenario_id(self, RangeInstance):
         """RangeInstance can be queried by scenario_id."""
-        mock_qs.count.return_value = 1
-        mock_objects.filter.return_value = mock_qs
+        RangeInstance.objects.create(range_id=7, scenario_id="ad_attack_lab", user_id=1)
+        assert RangeInstance.objects.filter(scenario_id="ad_attack_lab").count() == 1
 
-        result = RangeInstance.objects.filter(scenario_id="ad_attack_lab")
-        assert result.count() == 1
-        mock_objects.filter.assert_called_once_with(scenario_id="ad_attack_lab")
-
-    def test_can_query_by_user_id(self, RangeInstance, mock_objects, mock_qs, make_range_instance):
+    @pytest.mark.django_db
+    def test_can_query_by_user_id(self, RangeInstance):
         """RangeInstance can be queried by user_id."""
-        mock_qs.count.return_value = 1
-        mock_objects.filter.return_value = mock_qs
-
-        result = RangeInstance.objects.filter(user_id=99)
-        assert result.count() == 1
-        mock_objects.filter.assert_called_once_with(user_id=99)
+        RangeInstance.objects.create(range_id=8, scenario_id="basic", user_id=99)
+        assert RangeInstance.objects.filter(user_id=99).count() == 1
 
     def test_unique_range_id(self, RangeInstance):
         """Each range_id should be unique (one RangeInstance per Range)."""
@@ -304,19 +274,29 @@ class TestRangeInstanceAgentFK:
         agent_field = RangeInstance._meta.get_field("agent")
         assert agent_field.remote_field.related_name == "range_instances"
 
-    def test_agent_fk_select_related(
-        self, RangeInstance, mock_objects, mock_qs, make_range_instance, make_agent_config
-    ):
+    @pytest.mark.django_db
+    def test_agent_fk_select_related(self, RangeInstance):
         """RangeInstance.agent can be efficiently loaded with select_related."""
-        agent = make_agent_config(name="Select Related Agent")
+        from django.contrib.auth import get_user_model
 
-        ri = make_range_instance(range_id=105, agent=agent)
-        mock_qs.get.return_value = ri
-        mock_objects.select_related.return_value = mock_qs
+        from cms.models import AgentConfig, OperatingSystem
+
+        user = get_user_model().objects.create_user(username="ri-sr@e.com", email="ri-sr@e.com")
+        os_obj, _ = OperatingSystem.objects.get_or_create(
+            slug="linux-debian", defaults={"name": "Linux", "extensions": [".deb"]}
+        )
+        agent = AgentConfig.objects.create(
+            user=user,
+            os=os_obj,
+            name="Select Related Agent",
+            s3_key="agents/sr.deb",
+            original_filename="sr.deb",
+            file_size_bytes=1024,
+        )
+        RangeInstance.objects.create(range_id=105, scenario_id="basic", user_id=user.id, agent=agent)
 
         result = RangeInstance.objects.select_related("agent").get(range_id=105)
         assert result.agent.name == "Select Related Agent"
-        mock_objects.select_related.assert_called_once_with("agent")
 
 
 # ---------------------------------------------------------------------------
@@ -366,8 +346,9 @@ class TestRangeInstanceRangeSpec:
         assert len(ri.range_spec["instances"]) == 1
         assert ri.range_spec["instances"][0]["role"] == "attacker"
 
-    def test_range_spec_persists_after_refresh(self, RangeInstance, mock_objects, make_range_instance):
-        """range_spec data persists after refresh_from_db (mocked)."""
+    @pytest.mark.django_db
+    def test_range_spec_persists_after_refresh(self, RangeInstance):
+        """range_spec data round-trips through the DB (real refresh_from_db)."""
         spec = {
             "scenario_id": "ad_attack_lab",
             "user_id": 42,
@@ -378,13 +359,11 @@ class TestRangeInstanceRangeSpec:
             ],
         }
 
-        ri = make_range_instance(range_id=203, scenario_id="ad_attack_lab", user_id=42, range_spec=spec)
+        ri = RangeInstance.objects.create(range_id=203, scenario_id="ad_attack_lab", user_id=42, range_spec=spec)
 
-        # Mock refresh_from_db to be a no-op (data already set in memory)
-        with patch.object(ri, "refresh_from_db"):
-            ri.refresh_from_db()
-            assert ri.range_spec == spec
-            assert len(ri.range_spec["instances"]) == 3
+        ri.refresh_from_db()
+        assert ri.range_spec == spec
+        assert len(ri.range_spec["instances"]) == 3
 
     def test_range_spec_with_agent_details(self, make_range_instance):
         """range_spec can include agent details in instances."""

--- a/shifter/shifter_platform/tests/cms/test_models_subnet.py
+++ b/shifter/shifter_platform/tests/cms/test_models_subnet.py
@@ -4,7 +4,6 @@ All tests use in-memory model construction and mocked ORM operations.
 No database access required.
 """
 
-from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -53,6 +52,24 @@ def _make_subnet(**overrides):
         subnet.__dict__[key] = value
 
     return subnet
+
+
+def _make_real_subnet(status=ResourceStatus.PENDING.value):
+    """Create a persisted Subnet (with its owning Request) and valid SubnetSpec data."""
+    from django.contrib.auth import get_user_model
+
+    from cms.models import Request, Subnet
+    from shared.enums import RequestType
+
+    uid = uuid4().hex[:8]
+    user = get_user_model().objects.create_user(username=f"subnet-{uid}@e.com", email=f"subnet-{uid}@e.com")
+    request = Request.objects.create(request_id=uuid4(), request_type=RequestType.RANGE.value, user=user)
+    return Subnet.objects.create(
+        request=request,
+        name="test_network",
+        data={"instances": [make_instance("server1"), make_instance("server2")], "connected_to": []},
+        status=status,
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -120,31 +137,27 @@ class TestSubnetEntityBase:
 
         assert subnet.is_deleted is True
 
-    @patch("cms.models.Subnet.validate_data")
-    def test_terminal_status_auto_sets_deleted_at(self, mock_validate):
+    @pytest.mark.django_db
+    def test_terminal_status_auto_sets_deleted_at(self):
         """Terminal status automatically sets deleted_at via EntityBase.save()."""
-        subnet = _make_subnet(status=ResourceStatus.PENDING.value, deleted_at=None)
+        subnet = _make_real_subnet(status=ResourceStatus.PENDING.value)
 
-        # Transition to terminal status
         subnet.status = ResourceStatus.DESTROYED.value
+        subnet.save()
 
-        # Call save with the real EntityBase logic but mock the DB write
-        with patch("django.db.models.Model.save"):
-            subnet.save()
-
+        subnet.refresh_from_db()
         assert subnet.deleted_at is not None
         assert subnet.is_deleted is True
 
-    @patch("cms.models.Subnet.validate_data")
-    def test_failed_status_auto_sets_deleted_at(self, mock_validate):
+    @pytest.mark.django_db
+    def test_failed_status_auto_sets_deleted_at(self):
         """FAILED status automatically sets deleted_at."""
-        subnet = _make_subnet(status=ResourceStatus.PENDING.value, deleted_at=None)
+        subnet = _make_real_subnet(status=ResourceStatus.PENDING.value)
 
         subnet.status = ResourceStatus.FAILED.value
+        subnet.save()
 
-        with patch("django.db.models.Model.save"):
-            subnet.save()
-
+        subnet.refresh_from_db()
         assert subnet.deleted_at is not None
 
 

--- a/shifter/shifter_platform/tests/cms/test_scenario_hydrator.py
+++ b/shifter/shifter_platform/tests/cms/test_scenario_hydrator.py
@@ -1,356 +1,217 @@
-"""Tests for scenario hydrator.
+"""Behavior tests for the scenario hydrator.
 
-The hydrator takes a scenario template + agent info and produces
-a fully resolved RangeSpec for Engine consumption.
-
-Responsibilities:
-- Resolve os_type "from_agent" to actual OS
-- Embed agent details into instances with agent_slot
-- Return consistent RangeSpec structure
-- Input validation and error handling
+The hydrator takes a scenario template + agent info and produces a fully resolved
+RangeSpec for Engine consumption. These tests drive the real
+``hydrate_scenario`` against real DB ``Scenario`` rows (loaded through the real
+``cms.scenarios.registry.load_scenario_template``) and real ``AgentConfig`` rows,
+instead of patching ``cms.scenarios.hydrator.load_scenario`` with canned
+templates. The scenario definitions are crafted to exercise the hydrator's
+``from_agent`` OS resolution and agent embedding (``xdr_agent=True``), which the
+real loader carries through.
 """
 
-from unittest.mock import Mock, patch
+import uuid
 
 import pytest
+from django.contrib.auth import get_user_model
 
-from cms.scenarios.schema import DCConfig, InstanceConfig, ScenarioTemplate
+from cms.exceptions import CMSError
+from cms.scenarios.hydrator import hydrate_scenario
 from shared.schemas import RangeSpec
 
+pytestmark = pytest.mark.django_db
 
-def _make_mock_agent(*, os_slug, s3_key, original_filename, sha256_hash):
-    """Create a mock agent with the attributes the hydrator accesses."""
-    mock_os = Mock()
-    mock_os.slug = os_slug
-    agent = Mock()
-    agent.os = mock_os
-    agent.s3_key = s3_key
-    agent.original_filename = original_filename
-    agent.sha256_hash = sha256_hash
-    return agent
+User = get_user_model()
 
-
-# --- Canned templates (pure Pydantic, no DB) ---
-
-BASIC_TEMPLATE = ScenarioTemplate(
-    id="basic",
-    name="Basic Scenario",
-    description="Basic attacker/victim scenario",
-    instances=[
-        InstanceConfig(name="Attacker", role="attacker", os_type="kali"),
-        InstanceConfig(name="Victim", role="victim", os_type="from_agent", xdr_agent=True),
+BASIC_DEF = {
+    "instances": [
+        {"name": "Attacker", "role": "attacker", "os_type": "kali", "xdr_agent": False},
+        {"name": "Victim", "role": "victim", "os_type": "from_agent", "xdr_agent": True},
     ],
-)
+    "subnets": [{"name": "core", "instances": ["Attacker", "Victim"]}],
+    "ngfw": False,
+}
 
-AD_ATTACK_LAB_TEMPLATE = ScenarioTemplate(
-    id="ad_attack_lab",
-    name="AD Attack Lab",
-    description="Active Directory attack scenario",
-    instances=[
-        InstanceConfig(name="Attacker", role="attacker", os_type="kali"),
-        InstanceConfig(
-            name="DC",
-            role="dc",
-            os_type="windows",
-            xdr_agent=True,
-            domain_controller=True,
-            dc_config=DCConfig(domain_name="lab.local", netbios_name="LAB"),
-        ),
-        InstanceConfig(
-            name="Victim",
-            role="victim",
-            os_type="from_agent",
-            xdr_agent=True,
-            join_domain=True,
-        ),
+AD_DEF = {
+    "instances": [
+        {"name": "Attacker", "role": "attacker", "os_type": "kali", "xdr_agent": False},
+        {
+            "name": "DC",
+            "role": "dc",
+            "os_type": "windows",
+            "xdr_agent": True,
+            "domain_controller": True,
+            "dc_config": {"domain_name": "lab.local", "netbios_name": "LAB"},
+        },
+        {"name": "Victim", "role": "victim", "os_type": "from_agent", "xdr_agent": True, "join_domain": True},
     ],
-)
+    "subnets": [{"name": "core", "instances": ["Attacker", "DC", "Victim"]}],
+    "ngfw": False,
+}
 
 
-@pytest.fixture
-def user():
-    mock = Mock()
-    mock.pk = 42
-    mock.id = 42
-    mock.email = "test@example.com"
-    return mock
+def _db_scenario(scenario_id, definition):
+    from cms.models import Scenario
 
-
-@pytest.fixture
-def windows_agent_obj():
-    """Windows agent mock for testing."""
-    return _make_mock_agent(
-        os_slug="windows",
-        s3_key="agents/123/agent.msi",
-        original_filename="cortex_agent.msi",
-        sha256_hash="abc123def456",
+    staff = User.objects.create_user(
+        username=f"hyd-author-{scenario_id}@e.com", email=f"hyd-author-{scenario_id}@e.com", is_staff=True
+    )
+    return Scenario.objects.create(
+        scenario_id=scenario_id,
+        name=scenario_id,
+        description="Hydrator behavior-test scenario",
+        definition=definition,
+        created_by=staff,
+        updated_by=staff,
     )
 
 
 @pytest.fixture
-def linux_agent_obj():
-    """Linux agent mock for testing."""
-    return _make_mock_agent(
-        os_slug="linux-debian",
-        s3_key="agents/456/agent.deb",
-        original_filename="cortex_agent.deb",
-        sha256_hash="def789ghi012",
+def user(db):
+    return User.objects.create_user(username="hydrator@example.com", email="hydrator@example.com")
+
+
+@pytest.fixture
+def basic_scenario(db):
+    return _db_scenario("hydrator-basic", BASIC_DEF)
+
+
+@pytest.fixture
+def ad_scenario(db):
+    return _db_scenario("hydrator-ad", AD_DEF)
+
+
+@pytest.fixture
+def windows_agent(user, make_agent):
+    """Real Windows AgentConfig keyed for the hydrator."""
+    return {"windows": make_agent(user)}
+
+
+@pytest.fixture
+def linux_agent(user, make_agent, db):
+    from cms.models import OperatingSystem
+
+    linux_os, _ = OperatingSystem.objects.get_or_create(
+        slug="linux-debian", defaults={"name": "Linux (Debian/Ubuntu)", "extensions": [".deb"]}
     )
+    return {"linux": make_agent(user, os=linux_os, name="Linux Agent")}
 
 
-@pytest.fixture
-def windows_agent(windows_agent_obj):
-    """Windows agent dict for hydrator (new format)."""
-    return {"windows": windows_agent_obj}
-
-
-@pytest.fixture
-def linux_agent(linux_agent_obj):
-    """Linux agent dict for hydrator (new format)."""
-    return {"linux": linux_agent_obj}
-
-
-def _load_scenario_side_effect(scenario_id):
-    """Return canned template or raise ValueError."""
-    templates = {
-        "basic": BASIC_TEMPLATE,
-        "ad_attack_lab": AD_ATTACK_LAB_TEMPLATE,
-    }
-    if scenario_id not in templates:
-        raise ValueError(f"Scenario '{scenario_id}' not found")
-    return templates[scenario_id]
-
-
-class TestHydrateScenario:
-    """Tests for hydrate_scenario() function."""
-
-    # --- Basic structure ---
-
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_returns_range_request(self, _mock_load, user, windows_agent):
-        """hydrate_scenario returns a RangeSpec."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+class TestHydrateScenarioStructure:
+    def test_returns_range_spec(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         assert isinstance(result, RangeSpec)
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_includes_scenario_id(self, _mock_load, user, windows_agent):
-        """Result includes scenario_id."""
-        from cms.scenarios.hydrator import hydrate_scenario
+    def test_includes_scenario_id(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
+        assert result.scenario_id == basic_scenario.scenario_id
 
-        result = hydrate_scenario("basic", user.id, windows_agent)
-        assert result.scenario_id == "basic"
-
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_includes_user_id(self, _mock_load, user, windows_agent):
-        """Result includes user_id."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_includes_user_id(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         assert result.user_id == user.id
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_includes_instances_list(self, _mock_load, user, windows_agent):
-        """Result includes all_instances list (flattened from subnets)."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_includes_instances_list(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         assert isinstance(result.all_instances, list)
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_basic_has_two_instances(self, _mock_load, user, windows_agent):
-        """Basic scenario has attacker and victim instances."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_basic_has_two_instances(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         assert len(result.all_instances) == 2
-        roles = [i.role for i in result.all_instances]
-        assert "attacker" in roles
-        assert "victim" in roles
+        assert {i.role for i in result.all_instances} == {"attacker", "victim"}
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_each_instance_has_uuid(self, _mock_load, user, windows_agent):
-        """Each instance gets a unique UUID."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_each_instance_has_unique_uuid(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         uuids = [i.uuid for i in result.all_instances]
-        assert all(uuid is not None for uuid in uuids)
-        assert len(set(uuids)) == len(uuids)  # All unique
+        assert all(u is not None for u in uuids)
+        assert len(set(uuids)) == len(uuids)
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_uuid_is_valid_format(self, _mock_load, user, windows_agent):
-        """Instance UUIDs are valid UUID4 format."""
-        import uuid
-
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_uuid_is_valid_uuid4(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         for instance in result.all_instances:
-            # Will raise ValueError if not valid UUID
-            parsed = uuid.UUID(instance.uuid)
-            assert parsed.version == 4
+            assert uuid.UUID(instance.uuid).version == 4
 
-    # --- OS resolution from agent ---
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_resolves_from_agent_to_windows(self, _mock_load, user, windows_agent):
-        """os_type 'from_agent' resolves to 'windows' for Windows agent."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+class TestHydrateScenarioOsResolution:
+    def test_resolves_from_agent_to_windows(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         victim = next(i for i in result.all_instances if i.role == "victim")
         assert victim.os_type == "windows"
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_resolves_from_agent_to_ubuntu(self, _mock_load, user, linux_agent):
-        """os_type 'from_agent' resolves to 'ubuntu' for Linux agent."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, linux_agent)
+    def test_resolves_from_agent_to_ubuntu(self, user, basic_scenario, linux_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, linux_agent)
         victim = next(i for i in result.all_instances if i.role == "victim")
         assert victim.os_type == "ubuntu"
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_attacker_remains_kali(self, _mock_load, user, windows_agent):
-        """Attacker os_type remains 'kali' (not resolved from agent)."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_attacker_remains_kali(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         attacker = next(i for i in result.all_instances if i.role == "attacker")
         assert attacker.os_type == "kali"
 
-    # --- Agent embedding ---
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_embeds_agent_in_victim(self, _mock_load, user, windows_agent):
-        """Agent details are embedded in victim instance."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+class TestHydrateScenarioAgentEmbedding:
+    def test_embeds_agent_in_victim(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         victim = next(i for i in result.all_instances if i.role == "victim")
         assert victim.agent is not None
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_agent_has_s3_key(self, _mock_load, user, windows_agent):
-        """Embedded agent has s3_key."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_agent_carries_real_file_details(self, user, basic_scenario, windows_agent):
+        agent = windows_agent["windows"]
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         victim = next(i for i in result.all_instances if i.role == "victim")
-        assert victim.agent.s3_key == "agents/123/agent.msi"
+        assert victim.agent.s3_key == agent.s3_key
+        assert victim.agent.filename == agent.original_filename
+        assert victim.agent.sha256 == agent.sha256_hash
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_agent_has_filename(self, _mock_load, user, windows_agent):
-        """Embedded agent has filename."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
-        victim = next(i for i in result.all_instances if i.role == "victim")
-        assert victim.agent.filename == "cortex_agent.msi"
-
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_agent_has_sha256(self, _mock_load, user, windows_agent):
-        """Embedded agent has sha256."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
-        victim = next(i for i in result.all_instances if i.role == "victim")
-        assert victim.agent.sha256 == "abc123def456"
-
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_attacker_has_no_agent(self, _mock_load, user, windows_agent):
-        """Attacker instance has no agent (no agent_slot)."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+    def test_attacker_has_no_agent(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         attacker = next(i for i in result.all_instances if i.role == "attacker")
         assert attacker.agent is None
 
-    # --- AD Attack Lab scenario ---
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_ad_attack_lab_has_three_instances(self, _mock_load, user, windows_agent):
-        """AD attack lab has attacker, dc, and victim instances."""
-        from cms.scenarios.hydrator import hydrate_scenario
+class TestHydrateAdAttackLab:
+    def test_has_three_instances(self, user, ad_scenario, windows_agent):
+        result = hydrate_scenario(ad_scenario.scenario_id, user.id, windows_agent)
+        assert {i.role for i in result.all_instances} == {"attacker", "dc", "victim"}
 
-        result = hydrate_scenario("ad_attack_lab", user.id, windows_agent)
-        assert len(result.all_instances) == 3
-        roles = [i.role for i in result.all_instances]
-        assert "attacker" in roles
-        assert "dc" in roles
-        assert "victim" in roles
-
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_ad_attack_lab_dc_has_dc_config(self, _mock_load, user, windows_agent):
-        """DC instance has dc_config with domain settings."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("ad_attack_lab", user.id, windows_agent)
+    def test_dc_has_dc_config(self, user, ad_scenario, windows_agent):
+        result = hydrate_scenario(ad_scenario.scenario_id, user.id, windows_agent)
         dc = next(i for i in result.all_instances if i.role == "dc")
         assert dc.dc_config is not None
-        assert dc.dc_config.domain_name is not None
-        assert dc.dc_config.netbios_name is not None
+        assert dc.dc_config.domain_name == "lab.local"
+        assert dc.dc_config.netbios_name == "LAB"
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_ad_attack_lab_victim_joins_domain(self, _mock_load, user, windows_agent):
-        """AD victim has join_domain flag."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("ad_attack_lab", user.id, windows_agent)
+    def test_victim_joins_domain(self, user, ad_scenario, windows_agent):
+        result = hydrate_scenario(ad_scenario.scenario_id, user.id, windows_agent)
         victim = next(i for i in result.all_instances if i.role == "victim")
         assert victim.join_domain is True
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_ad_attack_lab_victim_has_agent(self, _mock_load, user, windows_agent):
-        """AD victim has embedded agent."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("ad_attack_lab", user.id, windows_agent)
+    def test_victim_has_agent(self, user, ad_scenario, windows_agent):
+        result = hydrate_scenario(ad_scenario.scenario_id, user.id, windows_agent)
         victim = next(i for i in result.all_instances if i.role == "victim")
         assert victim.agent is not None
-        assert victim.agent.s3_key == "agents/123/agent.msi"
+        assert victim.agent.s3_key == windows_agent["windows"].s3_key
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_ad_attack_lab_dc_has_agent(self, _mock_load, user, windows_agent):
-        """DC instance has Windows agent (xdr_agent=true in template)."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("ad_attack_lab", user.id, windows_agent)
+    def test_dc_has_windows_agent(self, user, ad_scenario, windows_agent):
+        result = hydrate_scenario(ad_scenario.scenario_id, user.id, windows_agent)
         dc = next(i for i in result.all_instances if i.role == "dc")
         assert dc.agent is not None
         assert dc.agent.s3_key == windows_agent["windows"].s3_key
 
-    # --- Error handling ---
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_raises_for_unknown_scenario(self, _mock_load, user, windows_agent):
-        """Raises CMSError for unknown scenario_id."""
-        from cms.exceptions import CMSError
-        from cms.scenarios.hydrator import hydrate_scenario
-
+class TestHydrateScenarioErrors:
+    def test_raises_for_unknown_scenario(self, user, windows_agent):
         with pytest.raises(CMSError, match="not found"):
-            hydrate_scenario("nonexistent", user.id, windows_agent)
+            hydrate_scenario("nonexistent-scenario", user.id, windows_agent)
 
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_raises_when_agents_empty(self, _mock_load, user):
-        """Raises CMSError when agents dict is empty."""
-        from cms.exceptions import CMSError
-        from cms.scenarios.hydrator import hydrate_scenario
+    def test_raises_when_agents_empty(self, user, basic_scenario):
+        with pytest.raises(CMSError, match="requires an agent"):
+            hydrate_scenario(basic_scenario.scenario_id, user.id, {})
 
-        with pytest.raises(CMSError, match=r"requires an agent"):
-            hydrate_scenario("basic", user.id, {})
 
-    # --- Model serialization ---
-
-    @patch("cms.scenarios.hydrator.load_scenario", side_effect=_load_scenario_side_effect)
-    def test_model_dump_returns_dict(self, _mock_load, user, windows_agent):
-        """RangeSpec can be serialized to dict."""
-        from cms.scenarios.hydrator import hydrate_scenario
-
-        result = hydrate_scenario("basic", user.id, windows_agent)
+class TestHydrateScenarioSerialization:
+    def test_model_dump_returns_dict(self, user, basic_scenario, windows_agent):
+        result = hydrate_scenario(basic_scenario.scenario_id, user.id, windows_agent)
         dumped = result.model_dump()
         assert isinstance(dumped, dict)
-        assert dumped["scenario_id"] == "basic"
+        assert dumped["scenario_id"] == basic_scenario.scenario_id
         assert dumped["user_id"] == user.id


### PR DESCRIPTION
Complete Group 3 (cms core) of #957. Rewrite the remaining cms-core model and scenario-hydrator suites to drive real rows, instead of patching `Credential`/`CredentialType.objects`, `AgentConfig.objects`, `RangeInstance.objects`, `OperatingSystem.objects.for_extension`, `Subnet.validate_data`, and `cms.scenarios.hydrator.load_scenario`.

## Changes (8 suites)

- **`test_models` / `test_credentials`** — Credential & CredentialType create / uniqueness (active-name-per-user) / cascade-on-user-delete / PROTECT-on-type-delete / ordering run against real rows; the field-inspection and in-memory property tests stay.
- **`test_models_asset` / `test_models_agent_config`** — `active_for_user` soft-delete + per-user filtering against real `AgentConfig` rows.
- **`test_models_operating_system`** — `get_for_extension` drives a real `OperatingSystem` row; the pure normalization + fake-queryset `for_extension` tests stay.
- **`test_models_range_instance`** — create / query-by-field / `select_related("agent")` / `range_spec` round-trip via real `refresh_from_db`; field-shape and in-memory tests stay.
- **`test_models_subnet`** — the terminal-status soft-delete invariant runs through a real `Subnet.save()` (real `Request` + valid `SubnetSpec` data).
- **`test_scenario_hydrator`** — `hydrate_scenario` drives the real registry loader against real DB `Scenario` rows (shaped to exercise `from_agent` resolution + agent embedding via `xdr_agent=True`) and real `AgentConfig` rows.

Shrink `boundary_mock_baseline.json` by 11 entries (41 internal-patch allowances removed). **The `cms` core area now carries no remaining ADR-019 baseline entries** — Group 3 (cms core) complete. Update `docs/adr/README.md`.

## Verification

- All 8 suites green individually; `tests/cms` green under `-n auto` (xdist) across repeated runs.
- `adr_guard.py` full run green; full `pytest (shifter_platform)` suite green via pre-commit hook.

Refs #957.