### PR TITLE
test(cms/experiments): rewrite foundational suites to behavior tests

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -267,6 +267,21 @@ entries. Completed so far:
   agent embedding. With these the `cms` core area carries no remaining ADR-019
   baseline entries.
 
+- `cms/experiments` (non-orchestrator): the foundational data/event suites
+  (`test_models`, `test_events`, `test_notifications`, `test_s3_tokens`,
+  `test_range_bridge`) drive real `Experiment`/`ExperimentRun`/`ScriptAsset` rows
+  for model save/transition/`active_for_user`; the upload-token HMAC round-trip
+  against the real `SECRET_KEY` (only `SCRIPT_UPLOAD_URL_EXPIRES` tuned via the
+  `settings` fixture); event publishing through the real `shared.cloud` SQS
+  publisher mocked at the `boto3` boundary; notification authorization against a
+  real owned `Experiment` and notification publishing asserted on the persisted
+  `WebSocketNotification` row; and the range->experiment bridge end-to-end
+  (`notify_experiment_on_range_ready` / `process_range_event`) against real
+  linked `RangeInstance`/`Request`/`ExperimentRun` rows with the SQS publish at
+  the `boto3` boundary (a `boto3` `ClientError` drives the run-marked-FAILED path).
+  The `cms/experiments/test_orchestrator*` suites stay out of scope (decomposition,
+  below).
+
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`
 (#885, #886, #889-#891), and `cms/scenario_editor/**` (#887, #888).

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -1061,16 +1061,6 @@
       "target": "cms.experiments.consumers.ExperimentStatusConsumer._get_runs"
     },
     {
-      "count": 6,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_events.py",
-      "target": "cms.experiments.events.get_queue_publisher"
-    },
-    {
-      "count": 8,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_events.py",
-      "target": "cms.experiments.events.settings"
-    },
-    {
       "count": 2,
       "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
       "target": "channels.layers.get_channel_layer"
@@ -1181,31 +1171,6 @@
       "target": "cms.experiments.services.start_experiment"
     },
     {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_models.py",
-      "target": "cms.experiments.models.Experiment.save"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_models.py",
-      "target": "cms.experiments.models.ExperimentRun.save"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_models.py",
-      "target": "cms.experiments.models.ScriptAsset.objects.filter"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_notifications.py",
-      "target": "cms.experiments.notifications.Experiment.objects.filter"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_notifications.py",
-      "target": "cms.experiments.notifications.publish_notification"
-    },
-    {
       "count": 16,
       "path": "shifter/shifter_platform/tests/cms/experiments/test_orchestrator.py",
       "target": "cms.experiments.orchestrator.Experiment"
@@ -1259,31 +1224,6 @@
       "count": 11,
       "path": "shifter/shifter_platform/tests/cms/experiments/test_orchestrator_dispatch.py",
       "target": "cms.experiments.orchestrator.start_experiment_task"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_range_bridge.py",
-      "target": "cms.handlers.experiment_bridge.publish_range_provisioned_for_experiment"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_range_bridge.py",
-      "target": "cms.handlers.range_events.RangeInstance"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_range_bridge.py",
-      "target": "cms.handlers.range_events.notify_ctf_range_status"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_range_bridge.py",
-      "target": "cms.handlers.range_events.notify_experiment_on_range_ready"
-    },
-    {
-      "count": 5,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py",
-      "target": "cms.experiments.s3.settings"
     },
     {
       "count": 10,

--- a/shifter/shifter_platform/tests/cms/experiments/test_events.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_events.py
@@ -1,169 +1,113 @@
-"""Tests for experiment event publishing.
+"""Behavior tests for experiment event publishing.
 
-Tests the event publishing bridge that connects range provisioning
-to experiment execution. Verifies exception handling, configuration edge
-cases, and error chaining.
+Drives the real ``publish_experiment_event`` / ``publish_range_provisioned_for_experiment``
+through the real ``shared.cloud`` AWS queue publisher down to the ``boto3`` SQS
+client (mocked at that boundary), instead of patching ``settings`` and the
+first-party ``get_queue_publisher``. Queue config is set via the ``settings``
+fixture; failures are driven with a ``boto3`` ``ClientError``.
 """
 
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from cms.experiments.events import (
     ExperimentEventError,
     publish_experiment_event,
     publish_range_provisioned_for_experiment,
 )
-from shared.cloud.exceptions import CloudQueueError
+
+CMS_URL = "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"
+
+
+@pytest.fixture
+def sqs_client(settings):
+    """Configure the CMS SQS queue and patch boto3 with a mock SQS client."""
+    settings.CLOUD_PROVIDER = "aws"
+    settings.SQS_QUEUE_CONFIG = {"cms": {"url": CMS_URL}}
+    client = MagicMock()
+    with patch("boto3.client", return_value=client):
+        yield client
+
+
+def _sent_body(sqs_client):
+    """Return the JSON-decoded MessageBody from the single send_message call."""
+    sqs_client.send_message.assert_called_once()
+    return json.loads(sqs_client.send_message.call_args.kwargs["MessageBody"])
 
 
 class TestPublishExperimentEvent:
-    """Tests for publish_experiment_event function."""
-
-    @patch("cms.experiments.events.settings")
-    @patch("cms.experiments.events.get_queue_publisher")
-    def test_publishes_successfully(self, mock_get_publisher: MagicMock, mock_settings: MagicMock) -> None:
-        """Successfully publishes event to configured CMS queue."""
-        mock_settings.SQS_QUEUE_CONFIG = {"cms": {"url": "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"}}
-        mock_publisher = MagicMock()
-        mock_get_publisher.return_value = mock_publisher
-
+    def test_publishes_successfully(self, sqs_client):
         publish_experiment_event(
-            event_type="experiment.run.range_provisioned",
-            payload={"experiment_id": 1, "run_id": 1},
+            event_type="experiment.run.range_provisioned", payload={"experiment_id": 1, "run_id": 1}
         )
+        assert sqs_client.send_message.call_args.kwargs["QueueUrl"] == CMS_URL
+        assert _sent_body(sqs_client)["event_type"] == "experiment.run.range_provisioned"
 
-        mock_publisher.send_message.assert_called_once()
-        call_args = mock_publisher.send_message.call_args
-        assert call_args[0][0] == "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"
-
-    @patch("cms.experiments.events.settings")
-    def test_raises_when_not_configured(self, mock_settings: MagicMock) -> None:
-        """Raises ExperimentEventError when SQS queue is not configured."""
-        mock_settings.SQS_QUEUE_CONFIG = {}
-
+    def test_raises_when_not_configured(self, settings):
+        settings.SQS_QUEUE_CONFIG = {}
         with pytest.raises(ExperimentEventError, match="publisher not configured"):
-            publish_experiment_event(
-                event_type="test.event",
-                payload={"data": "value"},
-            )
+            publish_experiment_event(event_type="test.event", payload={"data": "value"})
 
-    @patch("cms.experiments.events.settings")
-    def test_raises_when_url_empty(self, mock_settings: MagicMock) -> None:
-        """Raises ExperimentEventError when queue URL is empty string."""
-        mock_settings.SQS_QUEUE_CONFIG = {"cms": {"url": ""}}
-
+    def test_raises_when_url_empty(self, settings):
+        settings.SQS_QUEUE_CONFIG = {"cms": {"url": ""}}
         with pytest.raises(ExperimentEventError, match="publisher not configured"):
-            publish_experiment_event(
-                event_type="test.event",
-                payload={"data": "value"},
-            )
+            publish_experiment_event(event_type="test.event", payload={"data": "value"})
 
-    @patch("cms.experiments.events.settings")
-    @patch("cms.experiments.events.get_queue_publisher")
-    def test_prefers_publisher_id_when_present(self, mock_get_publisher: MagicMock, mock_settings: MagicMock) -> None:
-        """Uses publisher_id so Pub/Sub topics can differ from worker subscriptions."""
-        mock_settings.SQS_QUEUE_CONFIG = {
+    def test_prefers_publisher_id_when_present(self, sqs_client, settings):
+        settings.SQS_QUEUE_CONFIG = {
             "cms": {
                 "url": "projects/test/subscriptions/shifter-gcp-dev-cms",
                 "publisher_id": "projects/test/topics/shifter-gcp-dev-events",
             }
         }
-        mock_publisher = MagicMock()
-        mock_get_publisher.return_value = mock_publisher
-
         publish_experiment_event(
-            event_type="experiment.run.range_provisioned",
-            payload={"experiment_id": 1, "run_id": 1},
+            event_type="experiment.run.range_provisioned", payload={"experiment_id": 1, "run_id": 1}
         )
+        assert sqs_client.send_message.call_args.kwargs["QueueUrl"] == "projects/test/topics/shifter-gcp-dev-events"
 
-        call_args = mock_publisher.send_message.call_args
-        assert call_args[0][0] == "projects/test/topics/shifter-gcp-dev-events"
-
-    @patch("cms.experiments.events.settings")
-    @patch("cms.experiments.events.get_queue_publisher")
-    def test_raises_on_cloud_queue_failure(self, mock_get_publisher: MagicMock, mock_settings: MagicMock) -> None:
-        """Raises ExperimentEventError when publisher raises CloudQueueError."""
-        mock_settings.SQS_QUEUE_CONFIG = {"cms": {"url": "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"}}
-        mock_publisher = MagicMock()
-        mock_get_publisher.return_value = mock_publisher
-
-        cloud_error = CloudQueueError("Service unavailable")
-        mock_publisher.send_message.side_effect = cloud_error
-
+    def test_raises_on_cloud_queue_failure(self, sqs_client):
+        sqs_client.send_message.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "Service unavailable"}}, "SendMessage"
+        )
         with pytest.raises(ExperimentEventError) as exc_info:
             publish_experiment_event(
-                event_type="experiment.run.range_provisioned",
-                payload={"experiment_id": 1, "run_id": 1},
+                event_type="experiment.run.range_provisioned", payload={"experiment_id": 1, "run_id": 1}
             )
-
         assert "experiment.run.range_provisioned" in str(exc_info.value)
-        assert exc_info.value.__cause__ is cloud_error
+        from shared.cloud.exceptions import CloudQueueError
 
-    @patch("cms.experiments.events.settings")
-    @patch("cms.experiments.events.get_queue_publisher")
-    def test_exception_message_includes_event_type(
-        self, mock_get_publisher: MagicMock, mock_settings: MagicMock
-    ) -> None:
-        """Exception message includes the event type for debugging."""
-        mock_settings.SQS_QUEUE_CONFIG = {"cms": {"url": "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"}}
-        mock_publisher = MagicMock()
-        mock_get_publisher.return_value = mock_publisher
-        mock_publisher.send_message.side_effect = CloudQueueError("Network error")
+        assert isinstance(exc_info.value.__cause__, CloudQueueError)
 
-        with pytest.raises(ExperimentEventError) as exc_info:
-            publish_experiment_event(
-                event_type="experiment.run.custom_event",
-                payload={"data": "test"},
-            )
-
-        assert "experiment.run.custom_event" in str(exc_info.value)
+    def test_exception_message_includes_event_type(self, sqs_client):
+        sqs_client.send_message.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "Network error"}}, "SendMessage"
+        )
+        with pytest.raises(ExperimentEventError, match=r"experiment\.run\.custom_event"):
+            publish_experiment_event(event_type="experiment.run.custom_event", payload={"data": "test"})
 
 
 class TestPublishRangeProvisioned:
-    """Tests for publish_range_provisioned_for_experiment wrapper function."""
-
-    @patch("cms.experiments.events.settings")
-    @patch("cms.experiments.events.get_queue_publisher")
-    def test_publishes_with_correct_payload(self, mock_get_publisher: MagicMock, mock_settings: MagicMock) -> None:
-        """Publishes range_provisioned event with correct structure."""
-        mock_settings.SQS_QUEUE_CONFIG = {"cms": {"url": "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"}}
-        mock_publisher = MagicMock()
-        mock_get_publisher.return_value = mock_publisher
-
+    def test_publishes_with_correct_payload(self, sqs_client):
         provisioned_instances = {
             "Workstation": {"instance_id": "i-abc123"},
             "Server": {"instance_id": "i-def456"},
         }
-
         publish_range_provisioned_for_experiment(
-            experiment_id=42,
-            run_id=7,
-            provisioned_instances=provisioned_instances,
+            experiment_id=42, run_id=7, provisioned_instances=provisioned_instances
         )
 
-        mock_publisher.send_message.assert_called_once()
-        call_args = mock_publisher.send_message.call_args
-        message_body = json.loads(call_args[0][1])
+        body = _sent_body(sqs_client)
+        assert body["event_type"] == "experiment.run.range_provisioned"
+        assert body["experiment_id"] == 42
+        assert body["run_id"] == 7
+        assert body["provisioned_instances"] == provisioned_instances
 
-        assert message_body["event_type"] == "experiment.run.range_provisioned"
-        assert message_body["experiment_id"] == 42
-        assert message_body["run_id"] == 7
-        assert message_body["provisioned_instances"] == provisioned_instances
-
-    @patch("cms.experiments.events.settings")
-    @patch("cms.experiments.events.get_queue_publisher")
-    def test_raises_on_publish_failure(self, mock_get_publisher: MagicMock, mock_settings: MagicMock) -> None:
-        """Propagates ExperimentEventError from publish_experiment_event."""
-        mock_settings.SQS_QUEUE_CONFIG = {"cms": {"url": "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"}}
-        mock_publisher = MagicMock()
-        mock_get_publisher.return_value = mock_publisher
-        mock_publisher.send_message.side_effect = CloudQueueError("Queue failure")
-
+    def test_raises_on_publish_failure(self, sqs_client):
+        sqs_client.send_message.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "Queue failure"}}, "SendMessage"
+        )
         with pytest.raises(ExperimentEventError):
-            publish_range_provisioned_for_experiment(
-                experiment_id=1,
-                run_id=1,
-                provisioned_instances={},
-            )
+            publish_range_provisioned_for_experiment(experiment_id=1, run_id=1, provisioned_instances={})

--- a/shifter/shifter_platform/tests/cms/experiments/test_models.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_models.py
@@ -1,6 +1,5 @@
 """Tests for experiment models -- pure unit tests, no DB access."""
 
-from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -131,6 +130,39 @@ def _make_experiment_script(experiment=None, **kwargs):
 
 
 # ---------------------------------------------------------------------------
+# Real-DB helpers (for behavior tests of save()/transition_to/active_for_user)
+# ---------------------------------------------------------------------------
+
+
+def _db_user(user_model):
+    suffix = uuid4().hex[:8]
+    return user_model.objects.create_user(username=f"exp-{suffix}@e.com", email=f"exp-{suffix}@e.com")
+
+
+def _db_experiment(user_model, **kwargs):
+    fields = {"name": "Test Exp", "scenario_id": "basic", "total_runs": 5, "max_parallel_runs": 3}
+    fields.update(kwargs)
+    return Experiment.objects.create(user=_db_user(user_model), **fields)
+
+
+def _db_run(experiment, **kwargs):
+    fields = {"run_number": 1}
+    fields.update(kwargs)
+    return ExperimentRun.objects.create(experiment=experiment, **fields)
+
+
+def _db_script_asset(user, **kwargs):
+    fields = {
+        "name": "Active",
+        "s3_key": "scripts/1/abc123_attack.py",
+        "original_filename": "attack.py",
+        "file_size_bytes": 512,
+    }
+    fields.update(kwargs)
+    return ScriptAsset.objects.create(user=user, **fields)
+
+
+# ---------------------------------------------------------------------------
 # ScriptAsset
 # ---------------------------------------------------------------------------
 
@@ -152,18 +184,20 @@ class TestScriptAssetModel:
         script = _make_script_asset(deleted_at=timezone.now())
         assert script.is_deleted
 
-    def test_active_for_user(self):
-        """active_for_user filters ScriptAsset.objects (SoftDeleteManager, active-only)."""
-        user = _make_user()
-        first_item = _make_script_asset(name="Active")
-        fake_qs = MagicMock()
-        fake_qs.count.return_value = 1
-        fake_qs.first.return_value = first_item
-        with patch.object(ScriptAsset.objects, "filter", return_value=fake_qs) as mock_filter:
-            result = ScriptAsset.active_for_user(user)
-            mock_filter.assert_called_once_with(user=user)
-            assert result.count() == 1
-            assert result.first().name == "Active"
+    @pytest.mark.django_db
+    def test_active_for_user(self, django_user_model):
+        """active_for_user (a SoftDeleteManager) returns the user's active scripts."""
+        from django.utils import timezone
+
+        user = django_user_model.objects.create_user(username="sa-active@e.com", email="sa-active@e.com")
+        _db_script_asset(user, name="Active", s3_key="scripts/1/active.py")
+        deleted = _db_script_asset(user, name="Deleted", s3_key="scripts/1/deleted.py")
+        deleted.deleted_at = timezone.now()
+        deleted.save(update_fields=["deleted_at"])
+
+        result = ScriptAsset.active_for_user(user)
+        assert result.count() == 1
+        assert result.first().name == "Active"
 
     def test_file_size_mb(self):
         script = _make_script_asset(file_size_bytes=1048576)
@@ -186,24 +220,28 @@ class TestExperimentModel:
         exp = _make_experiment()
         assert exp.uuid is not None
 
-    @patch.object(Experiment, "save")
-    def test_transition_draft_to_queued(self, mock_save):
-        exp = _make_experiment(status=ExperimentStatus.DRAFT.value)
+    @pytest.mark.django_db
+    def test_transition_draft_to_queued(self, django_user_model):
+        exp = _db_experiment(django_user_model, status=ExperimentStatus.DRAFT.value)
         exp.transition_to(ExperimentStatus.QUEUED)
+        exp.refresh_from_db()
         assert exp.status == ExperimentStatus.QUEUED.value
-        mock_save.assert_called_once()
 
-    @patch.object(Experiment, "save")
-    def test_transition_running_sets_started_at(self, mock_save):
-        exp = _make_experiment(status=ExperimentStatus.QUEUED.value)
+    @pytest.mark.django_db
+    def test_transition_running_sets_started_at(self, django_user_model):
+        exp = _db_experiment(django_user_model, status=ExperimentStatus.QUEUED.value)
         exp.transition_to(ExperimentStatus.RUNNING)
+        exp.refresh_from_db()
         assert exp.started_at is not None
         assert exp.status == ExperimentStatus.RUNNING.value
 
-    @patch.object(Experiment, "save")
-    def test_transition_completed_sets_completed_at(self, mock_save):
-        exp = _make_experiment(status=ExperimentStatus.RUNNING.value, started_at="2024-01-01")
+    @pytest.mark.django_db
+    def test_transition_completed_sets_completed_at(self, django_user_model):
+        from django.utils import timezone
+
+        exp = _db_experiment(django_user_model, status=ExperimentStatus.RUNNING.value, started_at=timezone.now())
         exp.transition_to(ExperimentStatus.COMPLETED)
+        exp.refresh_from_db()
         assert exp.completed_at is not None
         assert exp.status == ExperimentStatus.COMPLETED.value
 
@@ -295,23 +333,25 @@ class TestExperimentRunModel:
         run = _make_experiment_run()
         assert run.uuid is not None
 
-    @patch.object(ExperimentRun, "save")
-    def test_transition_happy_path(self, mock_save):
-        run = _make_experiment_run()
+    @pytest.mark.django_db
+    def test_transition_happy_path(self, django_user_model):
+        run = _db_run(_db_experiment(django_user_model))
         run.transition_to(RunStatus.PROVISIONING)
         assert run.started_at is not None
         run.transition_to(RunStatus.EXECUTING_VICTIMS)
         run.transition_to(RunStatus.EXECUTING_ATTACKER)
         run.transition_to(RunStatus.COLLECTING)
         run.transition_to(RunStatus.COMPLETED)
+        run.refresh_from_db()
         assert run.completed_at is not None
         assert run.status == RunStatus.COMPLETED.value
 
-    @patch.object(ExperimentRun, "save")
-    def test_transition_to_failed(self, mock_save):
-        run = _make_experiment_run()
+    @pytest.mark.django_db
+    def test_transition_to_failed(self, django_user_model):
+        run = _db_run(_db_experiment(django_user_model))
         run.transition_to(RunStatus.PROVISIONING)
         run.transition_to(RunStatus.FAILED)
+        run.refresh_from_db()
         assert run.completed_at is not None
         assert run.status == RunStatus.FAILED.value
 

--- a/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_notifications.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,19 +26,24 @@ def clear_notification_registry():
     clear_notification_registry()
 
 
+@pytest.mark.django_db
 def test_register_experiment_notifications_authorizes_staff_owner() -> None:
-    """Experiment topics use the existing staff-owner access rule."""
+    """Experiment topics use the existing staff-owner access rule (real Experiment row)."""
+    from django.contrib.auth import get_user_model
+
+    from cms.experiments.models import Experiment
+    from shared.notifications import authorize_subscription
+
     register_experiment_notifications()
-    staff_owner = MagicMock(id=7, is_staff=True, is_authenticated=True)
+    owner = get_user_model().objects.create_user(username="exp-owner@e.com", email="exp-owner@e.com", is_staff=True)
+    other_staff = get_user_model().objects.create_user(
+        username="exp-other@e.com", email="exp-other@e.com", is_staff=True
+    )
+    experiment = Experiment.objects.create(user=owner, name="Owned", scenario_id="basic")
 
-    with patch("cms.experiments.notifications.Experiment.objects.filter") as mock_filter:
-        mock_filter.return_value.exists.return_value = True
-
-        from shared.notifications import authorize_subscription
-
-        assert authorize_subscription(staff_owner, experiment_topic(100)) is True
-
-    mock_filter.assert_called_once_with(pk=100, user=staff_owner)
+    # The owner is authorized; a different staff user (non-owner) is not.
+    assert authorize_subscription(owner, experiment_topic(experiment.pk)) is True
+    assert authorize_subscription(other_staff, experiment_topic(experiment.pk)) is False
 
 
 def test_register_experiment_notifications_rejects_non_staff() -> None:
@@ -97,28 +102,30 @@ def test_notification_payload_projectors_return_browser_safe_fields() -> None:
     }
 
 
-def test_publish_experiment_run_status_notification_projects_safe_payload() -> None:
-    """Experiment publishers pass only the browser-safe payload to shared notifications."""
-    with patch("cms.experiments.notifications.publish_notification") as mock_publish:
-        publish_experiment_run_status_notification(
-            experiment_id=100,
-            recipient_id=7,
-            run_id=5,
-            run_number=2,
-            status="completed",
-            error_message="",
-        )
+@pytest.mark.django_db
+def test_publish_experiment_run_status_notification_persists_safe_payload() -> None:
+    """Publishing persists a browser-safe WebSocketNotification for the recipient/topic."""
+    from django.contrib.auth import get_user_model
 
-    mock_publish.assert_called_once_with(
-        "experiment.run_status",
-        topic=experiment_topic(100),
-        payload={
-            "experiment_id": 100,
-            "run_id": 5,
-            "run_number": 2,
-            "status": "completed",
-            "error_message": "",
-        },
-        recipient_ids=[7],
-        event_id=None,
+    from shared.models import WebSocketNotification
+
+    register_experiment_notifications()
+    recipient = get_user_model().objects.create_user(username="notif-rcpt@e.com", email="notif-rcpt@e.com")
+    publish_experiment_run_status_notification(
+        experiment_id=100,
+        recipient_id=recipient.id,
+        run_id=5,
+        run_number=2,
+        status="completed",
+        error_message="",
     )
+
+    notif = WebSocketNotification.objects.get(recipient_id=recipient.id, topic=experiment_topic(100))
+    assert notif.notification_type == "experiment.run_status"
+    assert notif.payload == {
+        "experiment_id": 100,
+        "run_id": 5,
+        "run_number": 2,
+        "status": "completed",
+        "error_message": "",
+    }

--- a/shifter/shifter_platform/tests/cms/experiments/test_range_bridge.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_range_bridge.py
@@ -1,183 +1,142 @@
-"""Tests for the range-to-experiment event bridge.
+"""Behavior tests for the range-to-experiment event bridge.
 
-When a range's status transitions to READY and that range is linked to
-an experiment run, the CMS handler should publish an experiment event
-to trigger the next phase (script execution).
-
-Logic under test:
-- Detects when a provisioned range is linked to an experiment run
-- Publishes experiment.run.range_provisioned event with correct context
-- Does nothing when range is not linked to an experiment
-- Does nothing for non-READY status transitions
-- Handles missing experiment run gracefully
+When a range becomes READY and is linked to an experiment run, the CMS handler
+publishes an ``experiment.run.range_provisioned`` event to continue execution.
+These tests drive the real ``notify_experiment_on_range_ready`` /
+``process_range_event`` against real ``RangeInstance``/``Request``/``Experiment``/
+``ExperimentRun`` rows, with the SQS publish exercised through the real
+``shared.cloud`` queue publisher mocked only at the ``boto3`` boundary — instead
+of patching ``ExperimentRun`` / ``publish_range_provisioned_for_experiment`` /
+``RangeInstance`` / the bridge functions.
 """
 
+import json
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pytest
+from botocore.exceptions import ClientError
+from django.contrib.auth import get_user_model
+
+from cms.experiments.models import Experiment, ExperimentRun
 from cms.experiments.schemas import RunStatus
-from shared.enums import ResourceStatus
+from cms.handlers import notify_experiment_on_range_ready, process_range_event
+from cms.models import RangeInstance, Request
+from shared.enums import RequestType, ResourceStatus
 
-# experiment_bridge imports ExperimentRun at its module top, so patches must
-# target the bridge module's binding (where the name is looked up at call time)
-# rather than the source module.
-PATCH_EXP_RUN = "cms.handlers.experiment_bridge.ExperimentRun"
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+CMS_URL = "https://sqs.us-east-2.amazonaws.com/123/cms-tasks"
 
 
-class TestRangeToExperimentBridge:
-    """Tests for notify_experiment_on_range_ready bridge function."""
+@pytest.fixture
+def sqs_client(settings):
+    """Configure the CMS SQS queue and patch boto3 with a mock SQS client."""
+    settings.CLOUD_PROVIDER = "aws"
+    settings.SQS_QUEUE_CONFIG = {"cms": {"url": CMS_URL}}
+    client = MagicMock()
+    with patch("boto3.client", return_value=client):
+        yield client
 
-    @patch("cms.handlers.experiment_bridge.publish_range_provisioned_for_experiment")
-    @patch(PATCH_EXP_RUN)
-    def test_publishes_event_when_range_ready_for_experiment(self, mock_run_model, mock_publish):
-        """When range status becomes READY and linked to experiment, publishes event."""
-        mock_publish.return_value = True
-        request_id = uuid4()
 
-        # Mock the range instance
-        ri = MagicMock()
-        ri.request.request_id = request_id
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="bridge@example.com", email="bridge@example.com")
 
-        # Mock ExperimentRun.objects.select_related().get() to return a matching run
-        mock_run = MagicMock()
-        mock_run.experiment_id = 10
-        mock_run.pk = 5
-        mock_run_model.objects.select_related.return_value.get.return_value = mock_run
-        mock_run_model.DoesNotExist = Exception
 
-        from cms.handlers import notify_experiment_on_range_ready
+def _request(user):
+    return Request.objects.create(request_id=uuid4(), request_type=RequestType.RANGE.value, user=user)
 
-        provisioned_instances = {"Workstation": {"instance_id": "i-abc123"}}
-        notify_experiment_on_range_ready(ri, provisioned_instances)
 
-        mock_publish.assert_called_once_with(
-            experiment_id=10,
-            run_id=5,
-            provisioned_instances=provisioned_instances,
+def _range_instance(user, *, request=None, range_id=None, status=ResourceStatus.PROVISIONING.value):
+    return RangeInstance.objects.create(
+        user_id=user.id, request=request, range_id=range_id, status=status, scenario_id="basic"
+    )
+
+
+def _experiment_run(user, request, *, status=RunStatus.PENDING.value):
+    experiment = Experiment.objects.create(user=user, name="Exp", scenario_id="basic")
+    return ExperimentRun.objects.create(
+        experiment=experiment, run_number=1, request_id=request.request_id, status=status
+    )
+
+
+def _sent_body(sqs_client):
+    sqs_client.send_message.assert_called_once()
+    return json.loads(sqs_client.send_message.call_args.kwargs["MessageBody"])
+
+
+class TestNotifyExperimentOnRangeReady:
+    def test_publishes_event_when_linked_to_experiment(self, user, sqs_client):
+        req = _request(user)
+        run = _experiment_run(user, req)
+        ri = _range_instance(user, request=req)
+
+        provisioned = {"Workstation": {"instance_id": "i-abc123"}}
+        notify_experiment_on_range_ready(ri, provisioned)
+
+        body = _sent_body(sqs_client)
+        assert body["event_type"] == "experiment.run.range_provisioned"
+        assert body["experiment_id"] == run.experiment_id
+        assert body["run_id"] == run.pk
+        assert body["provisioned_instances"] == provisioned
+
+    def test_does_nothing_for_range_without_experiment(self, user, sqs_client):
+        req = _request(user)  # no ExperimentRun links to this request
+        ri = _range_instance(user, request=req)
+        notify_experiment_on_range_ready(ri, {})
+        sqs_client.send_message.assert_not_called()
+
+    def test_handles_missing_request_gracefully(self, user, sqs_client):
+        ri = _range_instance(user, request=None)
+        notify_experiment_on_range_ready(ri, {})  # must not raise
+        sqs_client.send_message.assert_not_called()
+
+    def test_marks_run_failed_on_sqs_error(self, user, sqs_client):
+        req = _request(user)
+        run = _experiment_run(user, req)
+        ri = _range_instance(user, request=req)
+        sqs_client.send_message.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "SQS unavailable"}}, "SendMessage"
         )
 
-    @patch("cms.handlers.experiment_bridge.publish_range_provisioned_for_experiment")
-    @patch(PATCH_EXP_RUN)
-    def test_does_nothing_for_range_without_experiment(self, mock_run_model, mock_publish):
-        """Range not linked to any experiment run -> no event published."""
-        request_id = uuid4()
+        notify_experiment_on_range_ready(ri, {"Workstation": {"instance_id": "i-abc123"}})
 
-        ri = MagicMock()
-        ri.request.request_id = request_id
-
-        # ExperimentRun not found
-        mock_run_model.DoesNotExist = Exception
-        mock_run_model.objects.select_related.return_value.get.side_effect = mock_run_model.DoesNotExist
-
-        from cms.handlers import notify_experiment_on_range_ready
-
-        notify_experiment_on_range_ready(ri, {})
-
-        mock_publish.assert_not_called()
-
-    @patch("cms.handlers.experiment_bridge.publish_range_provisioned_for_experiment")
-    @patch(PATCH_EXP_RUN)
-    def test_handles_deleted_request_gracefully(self, mock_run_model, mock_publish):
-        """If range_instance has no request, no crash."""
-        ri = MagicMock()
-        ri.request = None
-
-        from cms.handlers import notify_experiment_on_range_ready
-
-        # Should not raise
-        notify_experiment_on_range_ready(ri, {})
-        mock_publish.assert_not_called()
+        run.refresh_from_db()
+        assert run.status == RunStatus.FAILED.value
+        assert run.error_message == "Failed to publish range provisioning notification"
 
 
-class TestCmsHandlerBridgeIntegration:
-    """Tests for process_range_event calling the bridge on READY status."""
-
-    @patch("cms.handlers.range_events.notify_experiment_on_range_ready")
-    @patch("cms.handlers.range_events.notify_ctf_range_status")
-    @patch("cms.handlers.range_events.RangeInstance")
-    def test_process_range_event_calls_bridge_on_ready(self, mock_ri_model, mock_ctf, mock_bridge):
-        """process_range_event calls bridge with the resolved instance + provisioned_instances on READY."""
-        request_id = str(uuid4())
-
-        mock_instance = MagicMock()
-        mock_instance.user_id = 1
-        mock_instance.status = "provisioning"
-        mock_instance.range_id = None
-        mock_instance.pk = 99
-        mock_ri_model.objects.get.return_value = mock_instance
-        mock_ri_model.DoesNotExist = Exception
-
-        provisioned_instances = {"Workstation": {"instance_id": "i-abc123"}}
-        event = {
+class TestProcessRangeEventBridgeIntegration:
+    def _event(self, req, user, *, new_status, **extra):
+        return {
             "event_type": "range.status.updated",
-            "request_id": request_id,
+            "request_id": str(req.request_id),
             "range_id": 1,
-            "user_id": 1,
-            "new_status": ResourceStatus.READY.value,
-            "instances": provisioned_instances,
+            "user_id": user.id,
+            "new_status": new_status,
+            **extra,
         }
 
-        from cms.handlers import process_range_event
+    def test_calls_bridge_on_ready(self, user, sqs_client):
+        req = _request(user)
+        run = _experiment_run(user, req)
+        _range_instance(user, request=req, range_id=None)
 
-        process_range_event(event)
+        provisioned = {"Workstation": {"instance_id": "i-abc123"}}
+        process_range_event(self._event(req, user, new_status=ResourceStatus.READY.value, instances=provisioned))
 
-        # Pin both args so a regression that swapped arguments or dropped the
-        # instances payload is caught.
-        mock_bridge.assert_called_once_with(mock_instance, provisioned_instances)
+        body = _sent_body(sqs_client)
+        assert body["experiment_id"] == run.experiment_id
+        assert body["run_id"] == run.pk
+        assert body["provisioned_instances"] == provisioned
 
-    @patch("cms.handlers.range_events.notify_experiment_on_range_ready")
-    @patch("cms.handlers.range_events.notify_ctf_range_status")
-    @patch("cms.handlers.range_events.RangeInstance")
-    def test_process_range_event_no_bridge_on_non_ready(self, mock_ri_model, mock_ctf, mock_bridge):
-        """Bridge is NOT called for non-READY status transitions."""
-        request_id = str(uuid4())
+    def test_no_bridge_on_non_ready(self, user, sqs_client):
+        req = _request(user)
+        _experiment_run(user, req)
+        _range_instance(user, request=req)
 
-        mock_instance = MagicMock()
-        mock_instance.user_id = 1
-        mock_instance.status = "provisioning"
-        mock_instance.range_id = None
-        mock_instance.pk = 99
-        mock_ri_model.objects.get.return_value = mock_instance
-        mock_ri_model.DoesNotExist = Exception
-
-        event = {
-            "event_type": "range.status.updated",
-            "request_id": request_id,
-            "range_id": 1,
-            "user_id": 1,
-            "new_status": ResourceStatus.PROVISIONING.value,
-        }
-
-        from cms.handlers import process_range_event
-
-        process_range_event(event)
-
-        mock_bridge.assert_not_called()
-
-    @patch("cms.handlers.experiment_bridge.publish_range_provisioned_for_experiment")
-    @patch(PATCH_EXP_RUN)
-    def test_bridge_marks_run_failed_on_sqs_error(self, mock_run_model, mock_publish):
-        """When SQS publish fails, the experiment run is marked FAILED."""
-        from cms.experiments.events import ExperimentEventError
-
-        request_id = uuid4()
-        ri = MagicMock()
-        ri.request.request_id = request_id
-
-        mock_run = MagicMock()
-        mock_run.experiment_id = 10
-        mock_run.pk = 5
-        mock_run_model.objects.select_related.return_value.get.return_value = mock_run
-        mock_run_model.DoesNotExist = Exception
-
-        mock_publish.side_effect = ExperimentEventError("SQS unavailable")
-
-        from cms.handlers import notify_experiment_on_range_ready
-
-        provisioned_instances = {"Workstation": {"instance_id": "i-abc123"}}
-        notify_experiment_on_range_ready(ri, provisioned_instances)
-
-        # Run should be marked FAILED with error message
-        assert mock_run.error_message == "Failed to publish range provisioning notification"
-        mock_run.save.assert_called_once()
-        mock_run.transition_to.assert_called_once_with(RunStatus.FAILED)
+        process_range_event(self._event(req, user, new_status=ResourceStatus.PROVISIONING.value))
+        sqs_client.send_message.assert_not_called()

--- a/shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py
@@ -3,8 +3,6 @@
 Tests the HMAC token logic -- no real S3 calls needed.
 """
 
-from unittest.mock import patch
-
 import pytest
 from cyberscript.script_context import ScriptExecutionContext
 
@@ -17,11 +15,14 @@ from cms.experiments.s3 import (
 
 
 class TestUploadToken:
-    @patch("cms.experiments.s3.settings")
-    def test_roundtrip(self, mock_settings):
-        mock_settings.SECRET_KEY = "test-secret-key"
-        mock_settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
+    """HMAC token round-trip against the real ``settings.SECRET_KEY``.
 
+    Only ``SCRIPT_UPLOAD_URL_EXPIRES`` is tuned (via the ``settings`` fixture);
+    the signing key is the real test key, so generate/verify share it.
+    """
+
+    def test_roundtrip(self, settings):
+        settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
         token = generate_upload_token(
             user_id=1,
             s3_key="scripts/1/abc_test.py",
@@ -36,57 +37,27 @@ class TestUploadToken:
         assert payload["filename"] == "test.py"
         assert payload["file_size"] == 1024
 
-    @patch("cms.experiments.s3.settings")
-    def test_wrong_user_raises(self, mock_settings):
-        mock_settings.SECRET_KEY = "test-secret-key"
-        mock_settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
-
-        token = generate_upload_token(
-            user_id=1,
-            s3_key="scripts/1/x.py",
-            name="Test",
-            filename="x.py",
-            file_size=100,
-        )
+    def test_wrong_user_raises(self, settings):
+        settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
+        token = generate_upload_token(user_id=1, s3_key="scripts/1/x.py", name="Test", filename="x.py", file_size=100)
         with pytest.raises(ValueError, match="user mismatch"):
             verify_upload_token(token, user_id=2)
 
-    @patch("cms.experiments.s3.settings")
-    def test_tampered_token_raises(self, mock_settings):
-        mock_settings.SECRET_KEY = "test-secret-key"
-        mock_settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
-
-        token = generate_upload_token(
-            user_id=1,
-            s3_key="scripts/1/x.py",
-            name="Test",
-            filename="x.py",
-            file_size=100,
-        )
+    def test_tampered_token_raises(self, settings):
+        settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
+        token = generate_upload_token(user_id=1, s3_key="scripts/1/x.py", name="Test", filename="x.py", file_size=100)
         tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
         with pytest.raises(ValueError, match="signature"):
             verify_upload_token(tampered, user_id=1)
 
-    @patch("cms.experiments.s3.settings")
-    def test_invalid_format_raises(self, mock_settings):
-        mock_settings.SECRET_KEY = "test-secret-key"
-        mock_settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
-
+    def test_invalid_format_raises(self, settings):
+        settings.SCRIPT_UPLOAD_URL_EXPIRES = 600
         with pytest.raises(ValueError, match="format"):
             verify_upload_token("no-dot-separator", user_id=1)
 
-    @patch("cms.experiments.s3.settings")
-    def test_expired_token_raises(self, mock_settings):
-        mock_settings.SECRET_KEY = "test-secret-key"
-        mock_settings.SCRIPT_UPLOAD_URL_EXPIRES = -1
-
-        token = generate_upload_token(
-            user_id=1,
-            s3_key="scripts/1/x.py",
-            name="Test",
-            filename="x.py",
-            file_size=100,
-        )
+    def test_expired_token_raises(self, settings):
+        settings.SCRIPT_UPLOAD_URL_EXPIRES = -1
+        token = generate_upload_token(user_id=1, s3_key="scripts/1/x.py", name="Test", filename="x.py", file_size=100)
         with pytest.raises(ValueError, match="expired"):
             verify_upload_token(token, user_id=1)
 


### PR DESCRIPTION
Start Group 4 (cms/experiments, non-orchestrator) of #957. Rewrite the foundational data/event suites to drive real rows and real cloud/notification paths, instead of patching `Experiment`/`ExperimentRun.save`, `ScriptAsset.objects`, `cms.experiments.{events,s3,notifications}` internals (`settings` / `get_queue_publisher` / `publish_notification` / `Experiment.objects`), and the range-bridge functions.

## Changes (5 suites)

- **`test_models`** — `ScriptAsset.active_for_user` + `Experiment`/`ExperimentRun` `transition_to` run against real rows (assert persisted status/timestamps); the in-memory logic/field-shape tests stay.
- **`test_events`** — `publish_experiment_event` / `publish_range_provisioned_for_experiment` drive the real `shared.cloud` SQS publisher down to the `boto3` boundary (queue config via the `settings` fixture; a `boto3` `ClientError` drives the failure path).
- **`test_s3_tokens`** — HMAC upload-token round-trip against the real `SECRET_KEY`, only `SCRIPT_UPLOAD_URL_EXPIRES` tuned via the `settings` fixture; the pure filename/normalization tests stay.
- **`test_notifications`** — subscription authorization against a real owned `Experiment` (owner allowed, non-owner staff rejected); publishing asserted on the persisted `WebSocketNotification` row.
- **`test_range_bridge`** — `notify_experiment_on_range_ready` / `process_range_event` drive the real bridge against real linked `RangeInstance`/`Request`/`Experiment`/`ExperimentRun` rows; the SQS publish runs at the `boto3` boundary and a `ClientError` drives the run-marked-FAILED path.

Shrink `boundary_mock_baseline.json` by 12 entries (37 internal-patch allowances removed); update `docs/adr/README.md`. The `cms/experiments/test_orchestrator*` suites stay out of scope (decomposition, #885/#886/#889–891).

## Verification

- All 5 suites green individually and together; `tests/cms/experiments` green under `-n auto` (xdist).
- `adr_guard.py` full run green; full `pytest (shifter_platform)` suite green via pre-commit hook.

Refs #957.