### PR TITLE
test(cms/experiments): rewrite consumer + handler notification/broadcast suites to behavior tests

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -288,7 +288,18 @@ entries. Completed so far:
   `basic` template, instances `Attacker`+`Workstation`); `start_experiment`'s
   `experiment.start` publish runs through the real SQS publisher at the `boto3`
   boundary. The `cms/experiments/test_orchestrator*` suites stay out of scope
-  (decomposition, below).
+  (decomposition, below). The WebSocket consumer suite (`test_consumers`) drives
+  the real `ExperimentStatusConsumer` through the Channels `WebsocketCommunicator`
+  against real `Experiment`/`ExperimentRun` rows and real users (auth/ownership
+  rejection, hydrate-on-connect); the broadcast-handler tests assert the formatted
+  event on the consumer's `send` transport. The experiment SQS-handler suite
+  (`test_handlers`) is **partially** rewritten: its notification + channel-layer
+  broadcast helpers are driven against real rows (asserting the persisted
+  `WebSocketNotification` fallback, with the channel layer failed at the `channels`
+  boundary), while the event-dispatch tests that assert routing into the
+  decomposition-owned `ExperimentOrchestrator` (#885/#886/#889-891) keep their
+  orchestrator mock and remain in a (reduced) baseline — driving the real
+  orchestrator is that decomposition's surface, not #957's.
 
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -1051,86 +1051,6 @@
       "target": "terraform_base.run_terraform"
     },
     {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_consumers.py",
-      "target": "cms.experiments.consumers.ExperimentStatusConsumer._get_experiment"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_consumers.py",
-      "target": "cms.experiments.consumers.ExperimentStatusConsumer._get_runs"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "channels.layers.get_channel_layer"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers.Experiment"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers.Experiment.objects.get"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers.Experiment.objects.only"
-    },
-    {
-      "count": 12,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers.ExperimentOrchestrator"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers.ExperimentRun"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers.ExperimentRun.objects.get"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers._broadcast_experiment_status"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers._broadcast_experiment_status_if_terminal"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers._broadcast_run_status"
-    },
-    {
-      "count": 6,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers._broadcast_run_status_for"
-    },
-    {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers._experiment_recipient_id"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers._publish_experiment_status_notification"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
-      "target": "cms.experiments.handlers._publish_run_status_notification"
-    },
-    {
       "count": 2,
       "path": "shifter/shifter_platform/tests/cms/experiments/test_integration.py",
       "target": "cms.experiments.orchestrator.Experiment"
@@ -2394,6 +2314,41 @@
       "count": 3,
       "path": "shifter/shifter_platform/tests/views/test_launch_range_scenarios.py",
       "target": "mission_control.views.logger"
+    },
+    {
+      "count": 2,
+      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
+      "target": "channels.layers.get_channel_layer"
+    },
+    {
+      "count": 1,
+      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
+      "target": "cms.experiments.handlers.Experiment"
+    },
+    {
+      "count": 12,
+      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
+      "target": "cms.experiments.handlers.ExperimentOrchestrator"
+    },
+    {
+      "count": 1,
+      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
+      "target": "cms.experiments.handlers.ExperimentRun"
+    },
+    {
+      "count": 2,
+      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
+      "target": "cms.experiments.handlers._broadcast_experiment_status"
+    },
+    {
+      "count": 3,
+      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
+      "target": "cms.experiments.handlers._broadcast_experiment_status_if_terminal"
+    },
+    {
+      "count": 6,
+      "path": "shifter/shifter_platform/tests/cms/experiments/test_handlers.py",
+      "target": "cms.experiments.handlers._broadcast_run_status_for"
     }
   ],
   "version": 1

--- a/shifter/shifter_platform/tests/cms/experiments/test_consumers.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_consumers.py
@@ -1,61 +1,52 @@
-"""Tests for WebSocket consumer authentication, hydration, and broadcasting.
+"""Behavior tests for the experiment WebSocket consumer.
 
-All ORM operations are mocked -- no database access.
-These tests verify the consumer logic by mocking the internal DB helper methods.
+Drives ``ExperimentStatusConsumer`` through the real Channels
+``WebsocketCommunicator`` against real ``Experiment`` / ``ExperimentRun`` rows
+and real users, instead of patching the consumer's ``_get_experiment`` /
+``_get_runs`` DB helpers. The broadcast-handler tests format the channel event to
+the socket and assert on the consumer's ``send`` transport (the channels
+boundary), which is not a first-party topology patch.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import json
+from unittest.mock import AsyncMock
 
 import pytest
+from channels.db import database_sync_to_async
 from channels.testing import WebsocketCommunicator
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 
 from cms.experiments.consumers import ExperimentStatusConsumer
+from cms.experiments.models import Experiment, ExperimentRun
 from cms.experiments.schemas import ExperimentStatus, RunStatus
 
-# Test password constant for all test users
-TEST_PASSWORD = "test"  # nosec B105
+User = get_user_model()
 
 
-def _build_communicator(experiment_id: int, user=None):
-    """Build a WebsocketCommunicator with the given user in scope."""
-    communicator = WebsocketCommunicator(
-        ExperimentStatusConsumer.as_asgi(),
-        f"/ws/experiment-status/{experiment_id}/",
-    )
+def _build_communicator(experiment_id, user=None):
+    communicator = WebsocketCommunicator(ExperimentStatusConsumer.as_asgi(), f"/ws/experiment-status/{experiment_id}/")
     communicator.scope["url_route"] = {"kwargs": {"experiment_id": str(experiment_id)}}
     communicator.scope["user"] = user
     return communicator
 
 
-def _make_staff_user(pk=1):
-    """Create a mock staff user."""
-    user = MagicMock()
-    user.pk = pk
-    user.is_staff = True
-    user.is_authenticated = True
-    user.is_anonymous = False
-    # Make isinstance(user, AnonymousUser) return False
-    user.__class__ = type("User", (), {})
-    return user
+@database_sync_to_async
+def _make_user(username, *, is_staff=True):
+    return User.objects.create_user(username=username, email=f"{username}@e.com", is_staff=is_staff)
 
 
-def _make_non_staff_user(pk=2):
-    """Create a mock non-staff user."""
-    user = MagicMock()
-    user.pk = pk
-    user.is_staff = False
-    user.is_authenticated = True
-    user.is_anonymous = False
-    user.__class__ = type("User", (), {})
-    return user
+@database_sync_to_async
+def _make_experiment(owner, *, status=ExperimentStatus.DRAFT.value, runs=()):
+    exp = Experiment.objects.create(user=owner, name="WS Exp", scenario_id="basic", status=status)
+    for run_number, run_status in runs:
+        ExperimentRun.objects.create(experiment=exp, run_number=run_number, status=run_status)
+    return exp
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 class TestConsumerAuthentication:
-    """5.3: Test consumer authentication (reject unauthenticated, reject non-owner)."""
-
     async def test_rejects_anonymous_user(self):
         communicator = _build_communicator(999, user=AnonymousUser())
         connected, code = await communicator.connect()
@@ -69,105 +60,76 @@ class TestConsumerAuthentication:
         assert code == 4001
 
     async def test_rejects_non_staff_user(self):
-        user = _make_non_staff_user()
+        user = await _make_user("ws-nonstaff", is_staff=False)
         communicator = _build_communicator(999, user=user)
         connected, code = await communicator.connect()
         assert connected is False
         assert code == 4003
 
     async def test_rejects_non_owner(self):
-        _make_staff_user(pk=1)
-        other = _make_staff_user(pk=2)
+        owner = await _make_user("ws-owner")
+        other = await _make_user("ws-other")
+        exp = await _make_experiment(owner)
 
-        # Patch the consumer's _get_experiment to return None (not owner)
-        with patch.object(ExperimentStatusConsumer, "_get_experiment", new_callable=AsyncMock, return_value=None):
-            communicator = _build_communicator(100, user=other)
-            connected, code = await communicator.connect()
-            assert connected is False
-            assert code == 4004
+        communicator = _build_communicator(exp.pk, user=other)
+        connected, code = await communicator.connect()
+        assert connected is False
+        assert code == 4004
 
     async def test_accepts_owner(self):
-        user = _make_staff_user(pk=1)
-        mock_experiment = MagicMock()
-        mock_experiment.status = ExperimentStatus.DRAFT.value
+        owner = await _make_user("ws-accept")
+        exp = await _make_experiment(owner)
 
-        with (
-            patch.object(
-                ExperimentStatusConsumer, "_get_experiment", new_callable=AsyncMock, return_value=mock_experiment
-            ),
-            patch.object(ExperimentStatusConsumer, "_get_runs", new_callable=AsyncMock, return_value=[]),
-        ):
-            communicator = _build_communicator(100, user=user)
-            connected, _ = await communicator.connect()
-            assert connected is True
-            await communicator.disconnect()
+        communicator = _build_communicator(exp.pk, user=owner)
+        connected, _ = await communicator.connect()
+        assert connected is True
+        await communicator.disconnect()
 
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 class TestConsumerHydration:
-    """5.4: Test hydration on connect (initial state sent correctly)."""
-
     async def test_hydrate_message_on_connect(self):
-        user = _make_staff_user(pk=1)
-        mock_experiment = MagicMock()
-        mock_experiment.status = ExperimentStatus.RUNNING.value
+        owner = await _make_user("ws-hydrate")
+        exp = await _make_experiment(
+            owner,
+            status=ExperimentStatus.RUNNING.value,
+            runs=[(1, RunStatus.PROVISIONING.value), (2, RunStatus.PENDING.value)],
+        )
 
-        mock_runs = [
-            {"run_id": 1, "run_number": 1, "status": RunStatus.PROVISIONING.value, "error_message": ""},
-            {"run_id": 2, "run_number": 2, "status": RunStatus.PENDING.value, "error_message": ""},
+        communicator = _build_communicator(exp.pk, user=owner)
+        connected, _ = await communicator.connect()
+        assert connected is True
+
+        response = await communicator.receive_json_from(timeout=3)
+        assert response["type"] == "hydrate"
+        assert response["experiment_id"] == exp.pk
+        assert response["experiment_status"] == ExperimentStatus.RUNNING.value
+        assert [(r["run_number"], r["status"]) for r in response["runs"]] == [
+            (1, RunStatus.PROVISIONING.value),
+            (2, RunStatus.PENDING.value),
         ]
-
-        with (
-            patch.object(
-                ExperimentStatusConsumer, "_get_experiment", new_callable=AsyncMock, return_value=mock_experiment
-            ),
-            patch.object(ExperimentStatusConsumer, "_get_runs", new_callable=AsyncMock, return_value=mock_runs),
-        ):
-            communicator = _build_communicator(100, user=user)
-            connected, _ = await communicator.connect()
-            assert connected is True
-
-            response = await communicator.receive_json_from(timeout=3)
-            assert response["type"] == "hydrate"
-            assert response["experiment_id"] == 100
-            assert response["experiment_status"] == ExperimentStatus.RUNNING.value
-            assert len(response["runs"]) == 2
-            assert response["runs"][0]["run_number"] == 1
-            assert response["runs"][0]["status"] == RunStatus.PROVISIONING.value
-            assert response["runs"][1]["run_number"] == 2
-            assert response["runs"][1]["status"] == RunStatus.PENDING.value
-
-            await communicator.disconnect()
+        await communicator.disconnect()
 
     async def test_hydrate_empty_runs(self):
-        user = _make_staff_user(pk=1)
-        mock_experiment = MagicMock()
-        mock_experiment.status = ExperimentStatus.DRAFT.value
+        owner = await _make_user("ws-hydrate-empty")
+        exp = await _make_experiment(owner, status=ExperimentStatus.DRAFT.value)
 
-        with (
-            patch.object(
-                ExperimentStatusConsumer, "_get_experiment", new_callable=AsyncMock, return_value=mock_experiment
-            ),
-            patch.object(ExperimentStatusConsumer, "_get_runs", new_callable=AsyncMock, return_value=[]),
-        ):
-            communicator = _build_communicator(100, user=user)
-            connected, _ = await communicator.connect()
-            assert connected is True
+        communicator = _build_communicator(exp.pk, user=owner)
+        connected, _ = await communicator.connect()
+        assert connected is True
 
-            response = await communicator.receive_json_from(timeout=3)
-            assert response["type"] == "hydrate"
-            assert response["runs"] == []
-
-            await communicator.disconnect()
+        response = await communicator.receive_json_from(timeout=3)
+        assert response["type"] == "hydrate"
+        assert response["runs"] == []
+        await communicator.disconnect()
 
 
 @pytest.mark.asyncio
 class TestConsumerBroadcast:
-    """5.5: Test broadcast reception (run status updates delivered to connected clients)."""
+    """The broadcast handlers format the channel event onto the socket transport."""
 
     async def test_receives_run_status_broadcast(self):
-        """Verify experiment_run_status handler sends correct JSON to client."""
         consumer = ExperimentStatusConsumer()
         consumer.send = AsyncMock()
 
@@ -181,32 +143,21 @@ class TestConsumerBroadcast:
             }
         )
 
-        import json
-
         consumer.send.assert_called_once()
-        response = json.loads(consumer.send.call_args[1]["text_data"])
+        response = json.loads(consumer.send.call_args.kwargs["text_data"])
         assert response["type"] == "run_status"
         assert response["run_id"] == 42
         assert response["run_number"] == 1
         assert response["status"] == "executing_victims"
 
     async def test_receives_experiment_status_broadcast(self):
-        """Verify experiment_status handler sends correct JSON to client."""
         consumer = ExperimentStatusConsumer()
         consumer.send = AsyncMock()
 
-        await consumer.experiment_status(
-            {
-                "type": "experiment.status",
-                "experiment_id": 100,
-                "status": "completed",
-            }
-        )
-
-        import json
+        await consumer.experiment_status({"type": "experiment.status", "experiment_id": 100, "status": "completed"})
 
         consumer.send.assert_called_once()
-        response = json.loads(consumer.send.call_args[1]["text_data"])
+        response = json.loads(consumer.send.call_args.kwargs["text_data"])
         assert response["type"] == "experiment_status"
         assert response["experiment_id"] == 100
         assert response["status"] == "completed"

--- a/shifter/shifter_platform/tests/cms/experiments/test_handlers.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_handlers.py
@@ -2,6 +2,7 @@
 
 import json
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 
@@ -102,83 +103,95 @@ class TestProcessEvent:
         mock_orch_cls.assert_not_called()
 
 
+@pytest.mark.django_db
 class TestNotifications:
-    @patch("cms.experiments.handlers.Experiment.objects.only")
-    def test_experiment_recipient_missing_experiment_returns_none(self, mock_only):
-        from cms.experiments.handlers import _experiment_recipient_id
+    """Notification + broadcast helpers, driven against real rows.
+
+    These persist a ``WebSocketNotification`` for the experiment owner (the
+    channel-layer fan-out is best-effort and falls back to persistence). Only the
+    channel-layer transport is mocked at the ``channels`` boundary to drive the
+    fallback path.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _registered(self):
+        from cms.experiments.notifications import register_experiment_notifications
+        from shared.notifications import clear_notification_registry
+
+        clear_notification_registry()
+        register_experiment_notifications()
+
+    def _owner_and_experiment(self):
+        from django.contrib.auth import get_user_model
+
         from cms.experiments.models import Experiment
 
-        mock_only.return_value.get.side_effect = Experiment.DoesNotExist
+        suffix = uuid4().hex[:8]
+        user = get_user_model().objects.create_user(username=f"h-{suffix}@e.com", email=f"h-{suffix}@e.com")
+        experiment = Experiment.objects.create(user=user, name="Handler Exp", scenario_id="basic")
+        return user, experiment
 
-        assert _experiment_recipient_id(999) is None
+    def test_experiment_recipient_returns_owner(self):
+        from cms.experiments.handlers import _experiment_recipient_id
 
-    @patch("cms.experiments.handlers._experiment_recipient_id", return_value=None)
-    def test_run_status_notification_skips_missing_recipient(self, mock_recipient):
+        user, experiment = self._owner_and_experiment()
+        assert _experiment_recipient_id(experiment.pk) == user.id
+
+    def test_experiment_recipient_missing_experiment_returns_none(self):
+        from cms.experiments.handlers import _experiment_recipient_id
+
+        assert _experiment_recipient_id(999999) is None
+
+    def test_run_status_notification_skips_missing_recipient(self):
         from cms.experiments.handlers import _publish_run_status_notification
+        from shared.models import WebSocketNotification
 
         _publish_run_status_notification(
-            experiment_id=999,
-            run_id=5,
-            run_number=1,
-            status=RunStatus.FAILED.value,
-            error_message="missing owner",
+            experiment_id=999999, run_id=5, run_number=1, status=RunStatus.FAILED.value, error_message="no owner"
         )
+        assert not WebSocketNotification.objects.exists()
 
-        mock_recipient.assert_called_once_with(999)
-
-    @patch("cms.experiments.handlers._experiment_recipient_id", return_value=None)
-    def test_experiment_status_notification_skips_missing_recipient(self, mock_recipient):
+    def test_experiment_status_notification_skips_missing_recipient(self):
         from cms.experiments.handlers import _publish_experiment_status_notification
+        from shared.models import WebSocketNotification
 
-        _publish_experiment_status_notification(999, "failed")
+        _publish_experiment_status_notification(999999, "failed")
+        assert not WebSocketNotification.objects.exists()
 
-        mock_recipient.assert_called_once_with(999)
-
-    def test_broadcast_run_status_queues_notification_when_channel_layer_fails(self):
+    def test_broadcast_run_status_persists_notification_when_channel_layer_fails(self):
         from cms.experiments.handlers import _broadcast_run_status
+        from shared.models import WebSocketNotification
 
-        with (
-            patch("channels.layers.get_channel_layer", side_effect=RuntimeError("unavailable")),
-            patch("cms.experiments.handlers._publish_run_status_notification") as mock_publish,
-        ):
-            _broadcast_run_status(10, 5, 1, RunStatus.FAILED.value, "SSM timeout")
+        user, experiment = self._owner_and_experiment()
+        with patch("channels.layers.get_channel_layer", side_effect=RuntimeError("unavailable")):
+            _broadcast_run_status(experiment.pk, 5, 1, RunStatus.FAILED.value, "SSM timeout")
 
-        mock_publish.assert_called_once_with(10, 5, 1, RunStatus.FAILED.value, "SSM timeout")
+        assert WebSocketNotification.objects.filter(recipient_id=user.id).exists()
 
-    def test_broadcast_experiment_status_queues_notification_when_channel_layer_fails(self):
+    def test_broadcast_experiment_status_persists_notification_when_channel_layer_fails(self):
         from cms.experiments.handlers import _broadcast_experiment_status
+        from shared.models import WebSocketNotification
 
-        with (
-            patch("channels.layers.get_channel_layer", side_effect=RuntimeError("unavailable")),
-            patch("cms.experiments.handlers._publish_experiment_status_notification") as mock_publish,
-        ):
-            _broadcast_experiment_status(10, "failed")
+        user, experiment = self._owner_and_experiment()
+        with patch("channels.layers.get_channel_layer", side_effect=RuntimeError("unavailable")):
+            _broadcast_experiment_status(experiment.pk, "failed")
 
-        mock_publish.assert_called_once_with(10, "failed")
+        assert WebSocketNotification.objects.filter(recipient_id=user.id).exists()
 
-    def test_broadcast_run_status_for_missing_run_returns(self):
+    def test_broadcast_run_status_for_missing_run_is_noop(self):
         from cms.experiments.handlers import _broadcast_run_status_for
-        from cms.experiments.models import ExperimentRun
+        from shared.models import WebSocketNotification
 
-        with (
-            patch("cms.experiments.handlers.ExperimentRun.objects.get", side_effect=ExperimentRun.DoesNotExist),
-            patch("cms.experiments.handlers._broadcast_run_status") as mock_broadcast,
-        ):
-            _broadcast_run_status_for(10, 999)
+        _, experiment = self._owner_and_experiment()
+        _broadcast_run_status_for(experiment.pk, 999999)  # no such run
+        assert not WebSocketNotification.objects.exists()
 
-        mock_broadcast.assert_not_called()
-
-    def test_broadcast_experiment_status_if_terminal_missing_experiment_returns(self):
+    def test_broadcast_experiment_status_if_terminal_missing_experiment_is_noop(self):
         from cms.experiments.handlers import _broadcast_experiment_status_if_terminal
-        from cms.experiments.models import Experiment
+        from shared.models import WebSocketNotification
 
-        with (
-            patch("cms.experiments.handlers.Experiment.objects.get", side_effect=Experiment.DoesNotExist),
-            patch("cms.experiments.handlers._broadcast_experiment_status") as mock_broadcast,
-        ):
-            _broadcast_experiment_status_if_terminal(999)
-
-        mock_broadcast.assert_not_called()
+        _broadcast_experiment_status_if_terminal(999999)
+        assert not WebSocketNotification.objects.exists()
 
 
 class TestEventHandlers:


### PR DESCRIPTION
Continue Group 4 of #957 (PR C — experiments handlers + consumers).

## Scope note
`cms/experiments/test_handlers.py` is mostly a dispatcher to the **decomposition-owned** `ExperimentOrchestrator` (#885/#886/#889–891 own `test_orchestrator*`). Per a scoping decision, this PR does a **partial** rewrite: the genuinely behavior-testable parts are converted; the orchestrator-dispatch tests keep their mock and remain in a (reduced) baseline. Driving the real orchestrator is that decomposition's surface, not #957's.

## Changes

- **`test_consumers`** (fully rewritten) — drives the real `ExperimentStatusConsumer` through the Channels `WebsocketCommunicator` against real `Experiment`/`ExperimentRun` rows and real users, instead of patching `_get_experiment`/`_get_runs`. Covers anonymous / no-user / non-staff / non-owner rejection and hydrate-on-connect; the broadcast-handler tests assert the formatted event on the consumer's `send` transport (the channels boundary).
- **`test_handlers`** (partial) — the notification + channel-layer broadcast helpers are driven against real rows, asserting the persisted `WebSocketNotification` fallback with the channel layer failed at the `channels` boundary. The event-dispatch tests asserting routing into `ExperimentOrchestrator` keep their orchestrator mock; the `test_handlers` baseline is tightened to those remaining counts.

Shrink `boundary_mock_baseline.json` by 16 internal-patch allowances (`test_consumers` removed entirely; `test_handlers` reduced); update `docs/adr/README.md`.

## Verification

- Both suites green (38); `tests/cms/experiments` green under `-n auto` (xdist).
- `adr_guard.py` full run green; full `pytest (shifter_platform)` suite green via pre-commit hook.

Refs #957.