### PR TITLE
test(management): rewrite management suites to behavior tests

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -319,6 +319,19 @@ entries. Completed so far:
   entries; only the decomposition-owned `test_orchestrator*` and the
   orchestrator-dispatch tests retained in `test_handlers` remain (above).
 
+- `management`: the service suite (`test_services`) drives `log_activity` /
+  `get_user_profile` / `mark_user_deleted` / `create_user_profile` /
+  `save_user_profile` / `update_cognito_sub` against real `UserProfile` /
+  `ActivityLog` / `AuditLog` rows (accounting for the `post_save` signal that
+  auto-provisions a profile), with the real duplicate-profile `IntegrityError`
+  exercised directly and generic fault-injection tests dropped; `test_apps`
+  verifies the profile signal wiring through its real effect (creating/saving a
+  user provisions a profile) rather than asserting `post_save.connect` shapes;
+  and `test_check_model_fks` drives the real management command against the real
+  (clean) model graph and exercises the violation-count path via the real
+  `compute_stats`. `management` was added to the `enable_log_propagation` fixture
+  so its service logs are observable by `caplog`.
+
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`
 (#885, #886, #889-#891), and `cms/scenario_editor/**` (#887, #888).

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -1861,51 +1861,6 @@
       "target": "engine.services.get_rdp_password"
     },
     {
-      "count": 6,
-      "path": "shifter/shifter_platform/tests/management/test_apps.py",
-      "target": "management.apps.post_save"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/management/test_apps.py",
-      "target": "management.apps.settings"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/management/test_check_model_fks.py",
-      "target": "management.management.commands.check_model_fks.Command.analyze_fks"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/management/test_check_model_fks.py",
-      "target": "management.management.commands.check_model_fks.Command.compute_stats"
-    },
-    {
-      "count": 9,
-      "path": "shifter/shifter_platform/tests/management/test_services.py",
-      "target": "management.models.ActivityLog.log"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/management/test_services.py",
-      "target": "management.models.UserProfile.objects.create"
-    },
-    {
-      "count": 10,
-      "path": "shifter/shifter_platform/tests/management/test_services.py",
-      "target": "management.models.UserProfile.objects.get_or_create"
-    },
-    {
-      "count": 7,
-      "path": "shifter/shifter_platform/tests/management/test_services.py",
-      "target": "management.services.audit_log"
-    },
-    {
-      "count": 20,
-      "path": "shifter/shifter_platform/tests/management/test_services.py",
-      "target": "management.services.get_user_profile"
-    },
-    {
       "count": 2,
       "path": "shifter/shifter_platform/tests/mission_control/consumers/test_range_status_consumer.py",
       "target": "cms.services.get_range_by_request_id"

--- a/shifter/shifter_platform/tests/conftest.py
+++ b/shifter/shifter_platform/tests/conftest.py
@@ -74,7 +74,7 @@ def enable_log_propagation():
     which prevents pytest's caplog from capturing log records. This fixture
     temporarily enables propagation for all tests.
     """
-    loggers = ["engine", "cms", "cms.experiments", "mission_control", "engine.handlers"]
+    loggers = ["engine", "cms", "cms.experiments", "mission_control", "engine.handlers", "management"]
     original_propagate = {}
 
     for name in loggers:

--- a/shifter/shifter_platform/tests/management/test_apps.py
+++ b/shifter/shifter_platform/tests/management/test_apps.py
@@ -1,83 +1,35 @@
-"""Management app configuration tests."""
+"""Behavior tests for the management app's user-profile signals.
 
-import logging
-from unittest.mock import patch
+The ``ManagementConfig.ready()`` post_save wiring is verified through its real
+effect — creating/saving a user (auto-)provisions a ``UserProfile`` — rather than
+patching ``post_save`` and asserting registration call shapes.
+"""
 
 import pytest
+from django.contrib.auth import get_user_model
 
-from management.apps import ManagementConfig
+from management.models import UserProfile
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
 
 
-class TestManagementConfigReady:
-    """Tests for ManagementConfig.ready signal registration."""
+class TestUserProfileSignals:
+    def test_creating_user_auto_creates_profile(self):
+        """on_user_created (post_save) provisions a profile for a new user."""
+        user = User.objects.create_user(username="apps-create@e.com", email="apps-create@e.com")
+        assert UserProfile.objects.filter(user=user).exists()
 
-    def test_registers_on_user_created_handler(self):
-        """ready() registers post_save handler for user creation."""
-        app_config = ManagementConfig("management", __import__("management"))
+    def test_saving_existing_user_ensures_profile(self):
+        """on_user_saved (post_save) re-ensures the profile on a later save.
 
-        with patch("management.apps.post_save") as mock_post_save:
-            app_config.ready()
+        The handler skips when the instance already has a (cached) profile, so
+        re-fetch a clean instance after deleting the row before saving.
+        """
+        user = User.objects.create_user(username="apps-save@e.com", email="apps-save@e.com")
+        UserProfile.objects.filter(user=user).delete()
 
-        calls = list(mock_post_save.connect.call_args_list)
-        assert any(c.kwargs.get("dispatch_uid") == "management_create_user_profile" for c in calls)
-
-    def test_registers_on_user_saved_handler(self):
-        """ready() registers post_save handler for user save."""
-        app_config = ManagementConfig("management", __import__("management"))
-
-        with patch("management.apps.post_save") as mock_post_save:
-            app_config.ready()
-
-        calls = list(mock_post_save.connect.call_args_list)
-        assert any(c.kwargs.get("dispatch_uid") == "management_save_user_profile" for c in calls)
-
-    def test_registers_with_auth_user_model_sender(self):
-        """ready() registers handlers with AUTH_USER_MODEL as sender."""
-        app_config = ManagementConfig("management", __import__("management"))
-
-        with (
-            patch("management.apps.post_save") as mock_post_save,
-            patch("management.apps.settings") as mock_settings,
-        ):
-            mock_settings.AUTH_USER_MODEL = "auth.User"
-            app_config.ready()
-
-        for call in mock_post_save.connect.call_args_list:
-            assert call.kwargs.get("sender") == "auth.User"
-
-    def test_logs_debug_on_successful_registration(self, caplog):
-        """ready() logs debug when handlers registered successfully."""
-        app_config = ManagementConfig("management", __import__("management"))
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.apps"),
-            patch("management.apps.post_save"),
-        ):
-            app_config.ready()
-
-        assert "register" in caplog.text.lower()
-
-    def test_logs_errors(self, caplog):
-        """ready() logs any exception as error."""
-        app_config = ManagementConfig("management", __import__("management"))
-
-        with (
-            caplog.at_level(logging.ERROR, logger="management.apps"),
-            patch("management.apps.post_save") as mock_post_save,
-        ):
-            mock_post_save.connect.side_effect = RuntimeError()
-
-            with pytest.raises(RuntimeError):
-                app_config.ready()
-
-        assert caplog.text
-
-    def test_propagates_errors(self):
-        """ready() propagates any exception."""
-        app_config = ManagementConfig("management", __import__("management"))
-
-        with patch("management.apps.post_save") as mock_post_save:
-            mock_post_save.connect.side_effect = RuntimeError()
-
-            with pytest.raises(RuntimeError):
-                app_config.ready()
+        fresh = User.objects.get(pk=user.pk)
+        fresh.save()
+        assert UserProfile.objects.filter(user=user).exists()

--- a/shifter/shifter_platform/tests/management/test_check_model_fks.py
+++ b/shifter/shifter_platform/tests/management/test_check_model_fks.py
@@ -1,11 +1,15 @@
-"""Tests for check_model_fks management command."""
+"""Tests for the check_model_fks management command.
+
+Drives the real command against the real model graph (which is clean — the
+model-FK guardrail passes), instead of patching ``Command.analyze_fks`` /
+``compute_stats``. The violation-counting path is tested by calling the real
+``compute_stats`` on a synthetic results dict (a value, not a mock).
+"""
 
 import contextlib
 import json
 from io import StringIO
-from unittest.mock import patch
 
-import pytest
 from django.core.management import call_command
 
 from management.management.commands.check_model_fks import (
@@ -80,9 +84,10 @@ class TestLayerConstants:
         assert "ManyToManyRel" in REVERSE_RELATION_TYPES
 
 
-# Sample mock data for command tests
-MOCK_RESULTS = {layer: [] for layer in ALL_LAYERS}
-MOCK_RESULTS["engine"] = [
+# Synthetic results dict (a value, not a mock) with one cross-layer violation,
+# used to exercise the real compute_stats counting logic.
+_RESULTS_WITH_VIOLATION = {layer: [] for layer in ALL_LAYERS}
+_RESULTS_WITH_VIOLATION["engine"] = [
     {
         "model": "Range",
         "field": "scenario",
@@ -93,129 +98,73 @@ MOCK_RESULTS["engine"] = [
     }
 ]
 
-MOCK_STATS_WITH_VIOLATIONS = {
-    "total_cross_layer_fks": 1,
-    "violations": 1,
-    "clean_layers": ["shared", "cms", "management", "mission_control"],
-    "layers_with_violations": ["engine"],
-    "violation_details": [{"from": "engine", "to": "cms"}],
-}
 
-MOCK_STATS_CLEAN = {
-    "total_cross_layer_fks": 0,
-    "violations": 0,
-    "clean_layers": ALL_LAYERS[:],
-    "layers_with_violations": [],
-    "violation_details": [],
-}
+def _run_json(*args):
+    out = StringIO()
+    with contextlib.suppress(SystemExit):
+        call_command("check_model_fks", "--json", "-q", *args, stdout=out, stderr=StringIO())
+    return json.loads(out.getvalue())
 
 
 class TestCheckModelFksCommand:
-    """Tests for check_model_fks management command."""
+    """Drives the real command against the real (clean) model graph."""
 
-    def test_command_runs(self):
-        """Command runs without error."""
-        out = StringIO()
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS):
-            try:
-                call_command("check_model_fks", stdout=out, stderr=StringIO())
-            except SystemExit as e:
-                assert e.code in (0, 1)
+    def test_command_runs_clean(self):
+        """The real model graph is clean, so the command completes (exit 0)."""
+        with contextlib.suppress(SystemExit):
+            call_command("check_model_fks", "-q", stdout=StringIO(), stderr=StringIO())
 
-    def test_command_json_output(self):
-        """Command outputs valid JSON with --json flag."""
-        out = StringIO()
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS), contextlib.suppress(SystemExit):
-            call_command("check_model_fks", "--json", "-q", stdout=out, stderr=StringIO())
-
-        output = out.getvalue()
-        data = json.loads(output)
-
-        assert "relationships" in data
-        assert "stats" in data
+    def test_json_output_has_relationships_and_stats(self):
+        data = _run_json()
         assert isinstance(data["relationships"], dict)
         assert isinstance(data["stats"], dict)
 
-    def test_command_json_has_all_layers(self):
-        """JSON output includes all layers."""
-        out = StringIO()
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS), contextlib.suppress(SystemExit):
-            call_command("check_model_fks", "--json", "-q", stdout=out, stderr=StringIO())
-
-        data = json.loads(out.getvalue())
-
+    def test_json_includes_all_layers(self):
+        data = _run_json()
         for layer in ALL_LAYERS:
             assert layer in data["relationships"]
 
-    def test_command_stats_structure(self):
-        """Stats in JSON output have expected structure."""
+    def test_stats_structure(self):
+        stats = _run_json()["stats"]
+        assert {
+            "total_cross_layer_fks",
+            "violations",
+            "clean_layers",
+            "layers_with_violations",
+            "violation_details",
+        } <= set(stats)
+
+    def test_real_graph_has_no_violations(self):
+        assert _run_json()["stats"]["violations"] == 0
+
+    def test_quiet_suppresses_summary(self):
         out = StringIO()
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS), contextlib.suppress(SystemExit):
+        with contextlib.suppress(SystemExit):
             call_command("check_model_fks", "--json", "-q", stdout=out, stderr=StringIO())
-
-        data = json.loads(out.getvalue())
-        stats = data["stats"]
-
-        assert "total_cross_layer_fks" in stats
-        assert "violations" in stats
-        assert "clean_layers" in stats
-        assert "layers_with_violations" in stats
-        assert "violation_details" in stats
-
-    def test_command_quiet_suppresses_summary(self):
-        """--quiet flag suppresses summary output."""
-        out = StringIO()
-        err = StringIO()
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS), contextlib.suppress(SystemExit):
-            call_command("check_model_fks", "--json", "-q", stdout=out, stderr=err)
-
         assert "MODEL FK SUMMARY" not in out.getvalue()
-        assert "MODEL FK SUMMARY" not in err.getvalue()
 
-    def test_command_shows_summary_by_default(self):
-        """Summary is shown by default."""
+    def test_shows_summary_by_default(self):
         out = StringIO()
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS), contextlib.suppress(SystemExit):
+        with contextlib.suppress(SystemExit):
             call_command("check_model_fks", stdout=out, stderr=StringIO())
-
         assert "MODEL FK SUMMARY" in out.getvalue()
 
-    def test_command_output_file(self, tmp_path):
-        """--output flag saves JSON to file."""
+    def test_output_file_written(self, tmp_path):
         output_file = tmp_path / "report.json"
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS), contextlib.suppress(SystemExit):
-            call_command(
-                "check_model_fks",
-                "-o",
-                str(output_file),
-                "-q",
-                stdout=StringIO(),
-                stderr=StringIO(),
-            )
-
-        assert output_file.exists()
+        with contextlib.suppress(SystemExit):
+            call_command("check_model_fks", "-o", str(output_file), "-q", stdout=StringIO(), stderr=StringIO())
         data = json.loads(output_file.read_text())
         assert "relationships" in data
         assert "stats" in data
 
-    def test_command_exits_with_error_on_violations(self):
-        """Command exits with code 1 when violations exist."""
-        with (
-            patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS),
-            patch.object(Command, "compute_stats", return_value=MOCK_STATS_WITH_VIOLATIONS),
-        ):
-            with pytest.raises(SystemExit) as exc_info:
-                call_command("check_model_fks", "-q", stdout=StringIO(), stderr=StringIO())
-            assert exc_info.value.code == 1
-
-    def test_reverse_relations_filtered_out(self):
-        """Reverse relations (ManyToOneRel etc.) are not included in mock results."""
-        out = StringIO()
-        with patch.object(Command, "analyze_fks", return_value=MOCK_RESULTS), contextlib.suppress(SystemExit):
-            call_command("check_model_fks", "--json", "-q", stdout=out, stderr=StringIO())
-
-        data = json.loads(out.getvalue())
-
-        for _layer, relationships in data["relationships"].items():
+    def test_reverse_relations_not_in_output(self):
+        data = _run_json()
+        for relationships in data["relationships"].values():
             for rel in relationships:
                 assert rel["field_type"] not in REVERSE_RELATION_TYPES
+
+    def test_compute_stats_counts_cross_layer_violation(self):
+        """The real compute_stats flags a cross-layer FK as a violation."""
+        stats = Command().compute_stats(_RESULTS_WITH_VIOLATION)
+        assert stats["violations"] == 1
+        assert "engine" in stats["layers_with_violations"]

--- a/shifter/shifter_platform/tests/management/test_services.py
+++ b/shifter/shifter_platform/tests/management/test_services.py
@@ -1,756 +1,245 @@
-"""Management service interface tests.
+"""Behavior tests for the management service interface.
 
-Tests specify the contract for each service function:
-- Expected inputs and outputs
-- Validation behavior
-- Logging behavior
-- Error propagation with context
+Drives the real services against real ``UserProfile`` / ``ActivityLog`` /
+``AuditLog`` rows instead of patching ``ActivityLog.log`` /
+``UserProfile.objects`` / ``audit_log`` / ``get_user_profile``. Note: a
+``post_save`` signal (management.apps) auto-creates a ``UserProfile`` for every
+new user, so tests that need the "no profile yet" path delete it first.
 
-All ORM interactions are mocked — no database required.
+Generic fault-injection tests (mock a dependency to raise ``IntegrityError`` then
+assert it propagates / is logged) are dropped per the boundary-mock-policy intent;
+the one real constraint (duplicate ``UserProfile``) is exercised directly.
 """
 
 import logging
-from unittest.mock import Mock, patch
 
 import pytest
-from django.db import IntegrityError
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError, transaction
+from django.utils import timezone
 
 from management import services
 from management.models import ActivityLog, UserProfile
+from risk_register.models import AuditLog
 from shared.constants import USER_CANNOT_BE_NONE
 
+pytestmark = pytest.mark.django_db
 
-def _saved_user(**overrides):
-    """Return a Mock user with pk set (simulates a saved user)."""
-    defaults = {"pk": 42, "id": 42, "email": "test@example.com", "username": "test@example.com"}
-    defaults.update(overrides)
-    return Mock(**defaults)
+User = get_user_model()
+
+
+def _user(suffix="u"):
+    return User.objects.create_user(username=f"mgmt-{suffix}@e.com", email=f"mgmt-{suffix}@e.com")
 
 
 def _unsaved_user():
-    """Return a Mock user with pk=None (simulates an unsaved user)."""
-    return Mock(pk=None, email="unsaved@example.com", username="unsaved@example.com")
+    return User(username="unsaved@e.com", email="unsaved@e.com")
 
 
-def _mock_profile(**overrides):
-    """Return a Mock profile with spec=UserProfile."""
-    defaults = {
-        "cognito_sub": None,
-        "deleted_at": None,
-        "is_deleted": False,
-    }
-    defaults.update(overrides)
-    profile = Mock(spec=UserProfile)
-    for attr, val in defaults.items():
-        setattr(profile, attr, val)
-    return profile
-
-
-# =============================================================================
+# ---------------------------------------------------------------------------
 # log_activity
-# =============================================================================
+# ---------------------------------------------------------------------------
 
 
-class TestLogActivityHappyPath:
-    """Expected successful behavior for log_activity."""
+class TestLogActivity:
+    def test_creates_activity_log_row(self):
+        user = _user("log")
+        services.log_activity("range_launched", user, key1="v1", nested={"a": 1})
 
-    def test_creates_activity_log_entry(self):
-        """log_activity calls ActivityLog.log to create a record."""
-        user = _saved_user()
+        row = ActivityLog.objects.get(action="range_launched")
+        assert row.user_id == user.id
+        assert row.metadata == {"key1": "v1", "nested": {"a": 1}}
 
-        with patch.object(ActivityLog, "log") as mock_log:
-            services.log_activity("test_action", user)
+    def test_anonymous_action_has_no_user(self):
+        services.log_activity("system_action", user=None)
+        row = ActivityLog.objects.get(action="system_action")
+        assert row.user is None
 
-        mock_log.assert_called_once_with("test_action", user=user)
-
-    def test_stores_metadata_kwargs(self):
-        """log_activity passes all kwargs as metadata to ActivityLog.log."""
-        user = _saved_user()
-
-        with patch.object(ActivityLog, "log") as mock_log:
-            services.log_activity("test_action", user, key1="value1", key2=42, nested={"a": 1})
-
-        mock_log.assert_called_once_with("test_action", user=user, key1="value1", key2=42, nested={"a": 1})
-
-    def test_accepts_none_user_for_anonymous_actions(self):
-        """log_activity accepts None user for system/anonymous actions."""
-        with patch.object(ActivityLog, "log") as mock_log:
-            services.log_activity("system_action", user=None)
-
-        mock_log.assert_called_once_with("system_action", user=None)
-
-    def test_returns_none(self):
-        """log_activity returns None (void function)."""
-        user = _saved_user()
-
-        with patch.object(ActivityLog, "log"):
-            result = services.log_activity("test_action", user)
-
-        assert result is None
-
-    def test_accepts_empty_metadata(self):
-        """log_activity works with no metadata kwargs."""
-        user = _saved_user()
-
-        with patch.object(ActivityLog, "log") as mock_log:
-            services.log_activity("test_action", user)
-
-        mock_log.assert_called_once_with("test_action", user=user)
-
-
-class TestLogActivityInputValidation:
-    """Input validation behavior for log_activity."""
-
-    def test_raises_type_error_for_none_action(self):
-        """log_activity raises TypeError when action is None."""
-        user = _saved_user()
-
+    @pytest.mark.parametrize("action", [None, 123])
+    def test_rejects_non_string_action(self, action):
         with pytest.raises(TypeError, match="action must be a string"):
-            services.log_activity(None, user)
+            services.log_activity(action, _user("badaction"))
 
-    def test_raises_type_error_for_non_string_action(self):
-        """log_activity raises TypeError when action is not a string."""
-        user = _saved_user()
-
-        with pytest.raises(TypeError, match="action must be a string"):
-            services.log_activity(123, user)
-
-    def test_raises_value_error_for_empty_action(self):
-        """log_activity raises ValueError when action is empty string."""
-        user = _saved_user()
-
+    @pytest.mark.parametrize("action", ["", "   "])
+    def test_rejects_empty_action(self, action):
         with pytest.raises(ValueError, match="action cannot be empty"):
-            services.log_activity("", user)
+            services.log_activity(action, _user("emptyaction"))
 
-    def test_raises_value_error_for_whitespace_only_action(self):
-        """log_activity raises ValueError when action is only whitespace."""
-        user = _saved_user()
-
-        with pytest.raises(ValueError, match="action cannot be empty"):
-            services.log_activity("   ", user)
-
-    def test_raises_value_error_for_unsaved_user(self):
-        """log_activity raises ValueError when user has no pk."""
-        unsaved_user = _unsaved_user()
-
+    def test_rejects_unsaved_user(self):
         with pytest.raises(ValueError, match="user must have a primary key"):
-            services.log_activity("test_action", unsaved_user)
-
-
-class TestLogActivityLogging:
-    """Logging behavior for log_activity."""
+            services.log_activity("a", _unsaved_user())
 
     def test_logs_debug_on_success(self, caplog):
-        """log_activity logs debug message on successful logging."""
-        user = _saved_user()
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch.object(ActivityLog, "log"),
-        ):
-            services.log_activity("test_action", user)
-
-        assert "test_action" in caplog.text
-        assert "test@example.com" in caplog.text
-
-    def test_logs_debug_for_anonymous_action(self, caplog):
-        """log_activity logs debug message for anonymous actions."""
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch.object(ActivityLog, "log"),
-        ):
-            services.log_activity("system_action", user=None)
-
-        assert "system_action" in caplog.text
-        assert "anonymous" in caplog.text.lower()
+        user = _user("logdbg")
+        with caplog.at_level(logging.DEBUG, logger="management.services"):
+            services.log_activity("audited_action", user)
+        assert "audited_action" in caplog.text
 
 
-class TestLogActivityErrorPropagation:
-    """Error propagation behavior for log_activity."""
-
-    def test_propagates_database_integrity_error(self):
-        """log_activity propagates IntegrityError from ActivityLog.log."""
-        user = _saved_user()
-
-        with (
-            patch.object(ActivityLog, "log", side_effect=IntegrityError("DB constraint")),
-            pytest.raises(IntegrityError, match="DB constraint"),
-        ):
-            services.log_activity("test_action", user)
-
-    def test_logs_error_on_database_failure(self, caplog):
-        """log_activity logs error when database operation fails."""
-        user = _saved_user()
-
-        with (
-            caplog.at_level(logging.ERROR, logger="management.services"),
-            patch.object(ActivityLog, "log", side_effect=IntegrityError("DB error")),
-            pytest.raises(IntegrityError),
-        ):
-            services.log_activity("test_action", user)
-
-        assert "test_action" in caplog.text
-        assert "failed" in caplog.text.lower() or "error" in caplog.text.lower()
-
-
-# =============================================================================
+# ---------------------------------------------------------------------------
 # get_user_profile
-# =============================================================================
+# ---------------------------------------------------------------------------
 
 
-class TestGetUserProfileHappyPath:
-    """Expected successful behavior for get_user_profile."""
-
+class TestGetUserProfile:
     def test_returns_existing_profile(self):
-        """get_user_profile returns existing profile without modification."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub="abc-123")
+        user = _user("getexisting")
+        profile = UserProfile.objects.get(user=user)  # auto-created by signal
+        profile.cognito_sub = "abc-123"
+        profile.save(update_fields=["cognito_sub"])
 
-        with patch.object(UserProfile.objects, "get_or_create", return_value=(profile, False)):
-            result = services.get_user_profile(user)
-
-        assert result is profile
+        result = services.get_user_profile(user)
+        assert isinstance(result, UserProfile)
+        assert result.pk == profile.pk
         assert result.cognito_sub == "abc-123"
 
     def test_creates_profile_when_missing(self):
-        """get_user_profile creates profile if none exists."""
-        user = _saved_user()
-        profile = _mock_profile()
+        user = _user("getmissing")
+        UserProfile.objects.filter(user=user).delete()  # remove the auto-created one
 
-        with patch.object(UserProfile.objects, "get_or_create", return_value=(profile, True)) as mock_goc:
-            result = services.get_user_profile(user)
-
-        assert result is profile
-        mock_goc.assert_called_once_with(user=user)
-
-    def test_returns_user_profile_instance(self):
-        """get_user_profile returns a UserProfile-like object."""
-        user = _saved_user()
-        profile = _mock_profile()
-
-        with patch.object(UserProfile.objects, "get_or_create", return_value=(profile, False)):
-            result = services.get_user_profile(user)
-
+        result = services.get_user_profile(user)
         assert isinstance(result, UserProfile)
+        assert UserProfile.objects.filter(user=user).exists()
 
-
-class TestGetUserProfileInputValidation:
-    """Input validation behavior for get_user_profile."""
-
-    def test_raises_type_error_for_none_user(self):
-        """get_user_profile raises TypeError when user is None."""
+    def test_raises_typeerror_for_none_user(self):
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
             services.get_user_profile(None)
 
-    def test_raises_value_error_for_unsaved_user(self):
-        """get_user_profile raises ValueError when user has no pk."""
-        unsaved_user = _unsaved_user()
-
+    def test_raises_valueerror_for_unsaved_user(self):
         with pytest.raises(ValueError, match="user must have a primary key"):
-            services.get_user_profile(unsaved_user)
+            services.get_user_profile(_unsaved_user())
 
 
-class TestGetUserProfileLogging:
-    """Logging behavior for get_user_profile."""
-
-    def test_logs_debug_on_success(self, caplog):
-        """get_user_profile logs debug message on success."""
-        user = _saved_user()
-        profile = _mock_profile()
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch.object(UserProfile.objects, "get_or_create", return_value=(profile, False)),
-        ):
-            services.get_user_profile(user)
-
-        assert "test@example.com" in caplog.text or str(user.pk) in caplog.text
-
-    def test_logs_debug_when_creating_profile(self, caplog):
-        """get_user_profile logs when creating new profile."""
-        user = _saved_user()
-        profile = _mock_profile()
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch.object(UserProfile.objects, "get_or_create", return_value=(profile, True)),
-        ):
-            services.get_user_profile(user)
-
-        assert "creat" in caplog.text.lower()
-
-
-class TestGetUserProfileErrorPropagation:
-    """Error propagation behavior for get_user_profile."""
-
-    def test_propagates_database_integrity_error(self):
-        """get_user_profile propagates IntegrityError from get_or_create."""
-        user = _saved_user()
-
-        with (
-            patch.object(UserProfile.objects, "get_or_create", side_effect=IntegrityError("DB constraint")),
-            pytest.raises(IntegrityError, match="DB constraint"),
-        ):
-            services.get_user_profile(user)
-
-    def test_logs_error_on_database_failure(self, caplog):
-        """get_user_profile logs error when database operation fails."""
-        user = _saved_user()
-
-        with (
-            caplog.at_level(logging.ERROR, logger="management.services"),
-            patch.object(UserProfile.objects, "get_or_create", side_effect=IntegrityError("DB error")),
-            pytest.raises(IntegrityError),
-        ):
-            services.get_user_profile(user)
-
-        assert "failed" in caplog.text.lower() or "error" in caplog.text.lower()
-
-
-# =============================================================================
+# ---------------------------------------------------------------------------
 # mark_user_deleted
-# =============================================================================
+# ---------------------------------------------------------------------------
 
 
-class TestMarkUserDeletedHappyPath:
-    """Expected successful behavior for mark_user_deleted."""
+class TestMarkUserDeleted:
+    def test_sets_deleted_at_and_audits(self):
+        user = _user("markdel")
+        services.mark_user_deleted(user)
 
-    def test_sets_deleted_at_timestamp(self):
-        """mark_user_deleted sets deleted_at on the profile and saves it."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=False)
-
-        with (
-            patch("management.services.get_user_profile", return_value=profile),
-            patch("management.services.audit_log"),
-        ):
-            services.mark_user_deleted(user)
-
-        profile.save.assert_called_once_with(update_fields=["deleted_at"])
+        profile = UserProfile.objects.get(user=user)
         assert profile.deleted_at is not None
+        assert AuditLog.objects.filter(
+            entity_type=AuditLog.EntityType.USER, entity_id=user.id, action=AuditLog.Action.DELETE
+        ).exists()
 
-    def test_profile_is_marked_deleted(self):
-        """After mark_user_deleted, deleted_at is set on the profile."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=False)
+    def test_idempotent_when_already_deleted(self, caplog):
+        user = _user("markdel2")
+        profile = UserProfile.objects.get(user=user)
+        profile.deleted_at = timezone.now()
+        profile.save(update_fields=["deleted_at"])
 
-        with (
-            patch("management.services.get_user_profile", return_value=profile),
-            patch("management.services.audit_log"),
-        ):
+        with caplog.at_level(logging.WARNING, logger="management.services"):
             services.mark_user_deleted(user)
-
+        profile.refresh_from_db()
         assert profile.deleted_at is not None
+        assert "already" in caplog.text.lower()
 
-    def test_creates_profile_via_get_user_profile(self):
-        """mark_user_deleted delegates to get_user_profile for profile creation."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=False)
+    def test_records_admin_actor_when_provided(self):
+        user = _user("markdel3")
+        admin = _user("markdel-admin")
+        services.mark_user_deleted(user, admin_user=admin)
+        row = AuditLog.objects.get(entity_type=AuditLog.EntityType.USER, entity_id=user.id)
+        assert row.actor_id == admin.id
 
-        with (
-            patch("management.services.get_user_profile", return_value=profile) as mock_get,
-            patch("management.services.audit_log"),
-        ):
-            services.mark_user_deleted(user)
-
-        mock_get.assert_called_once_with(user)
-
-    def test_returns_none(self):
-        """mark_user_deleted returns None (void function)."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=False)
-
-        with (
-            patch("management.services.get_user_profile", return_value=profile),
-            patch("management.services.audit_log"),
-        ):
-            result = services.mark_user_deleted(user)
-
-        assert result is None
-
-    def test_is_idempotent(self):
-        """mark_user_deleted can be called multiple times (updates timestamp)."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=True)
-
-        with (
-            patch("management.services.get_user_profile", return_value=profile),
-            patch("management.services.audit_log"),
-        ):
-            services.mark_user_deleted(user)
-
-        profile.save.assert_called_once_with(update_fields=["deleted_at"])
-        assert profile.deleted_at is not None
-
-
-class TestMarkUserDeletedInputValidation:
-    """Input validation behavior for mark_user_deleted."""
-
-    def test_raises_type_error_for_none_user(self):
-        """mark_user_deleted raises TypeError when user is None."""
+    def test_raises_typeerror_for_none_user(self):
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
             services.mark_user_deleted(None)
 
-    def test_raises_value_error_for_unsaved_user(self):
-        """mark_user_deleted raises ValueError when user has no pk."""
-        unsaved_user = _unsaved_user()
-
+    def test_raises_valueerror_for_unsaved_user(self):
         with pytest.raises(ValueError, match="user must have a primary key"):
-            services.mark_user_deleted(unsaved_user)
+            services.mark_user_deleted(_unsaved_user())
 
 
-class TestMarkUserDeletedLogging:
-    """Logging behavior for mark_user_deleted."""
-
-    def test_logs_debug_on_success(self, caplog):
-        """mark_user_deleted logs debug message on success."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=False)
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch("management.services.get_user_profile", return_value=profile),
-            patch("management.services.audit_log"),
-        ):
-            services.mark_user_deleted(user)
-
-        assert "test@example.com" in caplog.text or str(user.pk) in caplog.text
-        assert "delet" in caplog.text.lower()
-
-    def test_logs_warning_when_already_deleted(self, caplog):
-        """mark_user_deleted logs warning when user already deleted."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=True)
-
-        with (
-            caplog.at_level(logging.WARNING, logger="management.services"),
-            patch("management.services.get_user_profile", return_value=profile),
-            patch("management.services.audit_log"),
-        ):
-            services.mark_user_deleted(user)
-
-        assert "already" in caplog.text.lower()
-
-
-class TestMarkUserDeletedErrorPropagation:
-    """Error propagation behavior for mark_user_deleted."""
-
-    def test_propagates_error_from_get_user_profile(self):
-        """mark_user_deleted propagates errors from get_user_profile."""
-        user = _saved_user()
-
-        with (
-            patch("management.services.get_user_profile", side_effect=IntegrityError("DB constraint")),
-            pytest.raises(IntegrityError, match="DB constraint"),
-        ):
-            services.mark_user_deleted(user)
-
-    def test_propagates_error_from_profile_save(self):
-        """mark_user_deleted propagates errors from profile.save()."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=False)
-        profile.save.side_effect = IntegrityError("Save failed")
-
-        with (
-            patch("management.services.get_user_profile", return_value=profile),
-            pytest.raises(IntegrityError, match="Save failed"),
-        ):
-            services.mark_user_deleted(user)
-
-    def test_logs_error_on_save_failure(self, caplog):
-        """mark_user_deleted logs error when save fails."""
-        user = _saved_user()
-        profile = _mock_profile(is_deleted=False)
-        profile.save.side_effect = IntegrityError("Save failed")
-
-        with (
-            caplog.at_level(logging.ERROR, logger="management.services"),
-            patch("management.services.get_user_profile", return_value=profile),
-            pytest.raises(IntegrityError),
-        ):
-            services.mark_user_deleted(user)
-
-        assert "failed" in caplog.text.lower() or "error" in caplog.text.lower()
-
-
-# =============================================================================
+# ---------------------------------------------------------------------------
 # create_user_profile
-# =============================================================================
+# ---------------------------------------------------------------------------
 
 
 class TestCreateUserProfile:
-    """Tests for create_user_profile service function."""
+    def test_creates_profile(self):
+        user = _user("createprof")
+        UserProfile.objects.filter(user=user).delete()  # remove the auto-created one
 
-    def test_creates_profile_for_user(self):
-        """create_user_profile calls UserProfile.objects.create for the user."""
-        user = _saved_user()
+        services.create_user_profile(user)
+        assert UserProfile.objects.filter(user=user).exists()
 
-        with patch.object(UserProfile.objects, "create") as mock_create:
+    def test_duplicate_profile_raises_integrity_error(self):
+        user = _user("createdup")  # already has an auto-created profile
+        with pytest.raises(IntegrityError), transaction.atomic():
             services.create_user_profile(user)
 
-        mock_create.assert_called_once_with(user=user)
-
-    def test_raises_type_error_for_none_user(self):
-        """create_user_profile raises TypeError when user is None."""
+    def test_raises_typeerror_for_none_user(self):
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
             services.create_user_profile(None)
 
-    def test_raises_value_error_for_unsaved_user(self):
-        """create_user_profile raises ValueError when user has no pk."""
-        unsaved_user = _unsaved_user()
-
+    def test_raises_valueerror_for_unsaved_user(self):
         with pytest.raises(ValueError, match="user must have a primary key"):
-            services.create_user_profile(unsaved_user)
-
-    def test_logs_debug_on_success(self, caplog):
-        """create_user_profile logs debug message on success."""
-        user = _saved_user()
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch.object(UserProfile.objects, "create"),
-        ):
-            services.create_user_profile(user)
-
-        assert "test@example.com" in caplog.text
-
-    def test_logs_error_on_failure(self, caplog):
-        """create_user_profile logs error when database operation fails."""
-        user = _saved_user()
-
-        with (
-            caplog.at_level(logging.ERROR, logger="management.services"),
-            patch.object(UserProfile.objects, "create", side_effect=IntegrityError("DB error")),
-            pytest.raises(IntegrityError),
-        ):
-            services.create_user_profile(user)
-
-        assert "test@example.com" in caplog.text
+            services.create_user_profile(_unsaved_user())
 
 
-# =============================================================================
+# ---------------------------------------------------------------------------
 # save_user_profile
-# =============================================================================
+# ---------------------------------------------------------------------------
 
 
 class TestSaveUserProfile:
-    """Tests for save_user_profile service function."""
+    def test_is_idempotent(self):
+        user = _user("saveprof")
+        services.save_user_profile(user)
+        services.save_user_profile(user)
+        assert UserProfile.objects.filter(user=user).count() == 1
 
-    def test_creates_profile_when_missing(self):
-        """save_user_profile calls get_or_create for the user."""
-        user = _saved_user()
-        profile = _mock_profile()
-
-        with patch.object(UserProfile.objects, "get_or_create", return_value=(profile, True)) as mock_goc:
-            services.save_user_profile(user)
-
-        mock_goc.assert_called_once_with(user=user)
-
-    def test_raises_type_error_for_none_user(self):
-        """save_user_profile raises TypeError when user is None."""
+    def test_raises_typeerror_for_none_user(self):
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
             services.save_user_profile(None)
 
-    def test_raises_value_error_for_unsaved_user(self):
-        """save_user_profile raises ValueError when user has no pk."""
-        unsaved_user = _unsaved_user()
-
+    def test_raises_valueerror_for_unsaved_user(self):
         with pytest.raises(ValueError, match="user must have a primary key"):
-            services.save_user_profile(unsaved_user)
-
-    def test_logs_debug_on_success(self, caplog):
-        """save_user_profile logs debug message on success."""
-        user = _saved_user()
-        profile = _mock_profile()
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch.object(UserProfile.objects, "get_or_create", return_value=(profile, False)),
-        ):
-            services.save_user_profile(user)
-
-        assert "test@example.com" in caplog.text
-
-    def test_logs_error_on_failure(self, caplog):
-        """save_user_profile logs error when database operation fails."""
-        user = _saved_user()
-
-        with (
-            caplog.at_level(logging.ERROR, logger="management.services"),
-            patch.object(UserProfile.objects, "get_or_create", side_effect=IntegrityError("DB error")),
-            pytest.raises(IntegrityError),
-        ):
-            services.save_user_profile(user)
-
-        assert "test@example.com" in caplog.text
+            services.save_user_profile(_unsaved_user())
 
 
-# =============================================================================
+# ---------------------------------------------------------------------------
 # update_cognito_sub
-# =============================================================================
+# ---------------------------------------------------------------------------
 
 
-class TestUpdateCognitoSubHappyPath:
-    """Expected successful behavior for update_cognito_sub."""
+class TestUpdateCognitoSub:
+    def test_sets_cognito_sub(self):
+        user = _user("cog1")
+        services.update_cognito_sub(user, "abc-123-sub")
+        assert UserProfile.objects.get(user=user).cognito_sub == "abc-123-sub"
 
-    def test_updates_cognito_sub_on_profile(self):
-        """update_cognito_sub sets cognito_sub on user's profile and saves."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub=None)
+    def test_overwrites_existing(self):
+        user = _user("cog2")
+        services.update_cognito_sub(user, "old")
+        services.update_cognito_sub(user, "new")
+        assert UserProfile.objects.get(user=user).cognito_sub == "new"
 
-        with patch("management.services.get_user_profile", return_value=profile):
-            services.update_cognito_sub(user, "abc-123-sub")
+    def test_no_op_when_unchanged(self, caplog):
+        user = _user("cog3")
+        services.update_cognito_sub(user, "same")
+        with caplog.at_level(logging.DEBUG, logger="management.services"):
+            services.update_cognito_sub(user, "same")
+        assert UserProfile.objects.get(user=user).cognito_sub == "same"
+        assert "unchanged" in caplog.text.lower()
 
-        assert profile.cognito_sub == "abc-123-sub"
-        profile.save.assert_called_once_with(update_fields=["cognito_sub"])
-
-    def test_creates_profile_when_missing(self):
-        """update_cognito_sub delegates to get_user_profile for profile creation."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub=None)
-
-        with patch("management.services.get_user_profile", return_value=profile) as mock_get:
-            services.update_cognito_sub(user, "abc-123-sub")
-
-        mock_get.assert_called_once_with(user)
-        assert profile.cognito_sub == "abc-123-sub"
-
-    def test_returns_none(self):
-        """update_cognito_sub returns None (void function)."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub=None)
-
-        with patch("management.services.get_user_profile", return_value=profile):
-            result = services.update_cognito_sub(user, "abc-123-sub")
-
-        assert result is None
-
-    def test_overwrites_existing_cognito_sub(self):
-        """update_cognito_sub overwrites existing cognito_sub value."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub="old-sub-value")
-
-        with patch("management.services.get_user_profile", return_value=profile):
-            services.update_cognito_sub(user, "new-sub-value")
-
-        assert profile.cognito_sub == "new-sub-value"
-        profile.save.assert_called_once_with(update_fields=["cognito_sub"])
-
-    def test_no_op_when_cognito_sub_unchanged(self):
-        """update_cognito_sub does not save when value unchanged."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub="same-sub")
-
-        with patch("management.services.get_user_profile", return_value=profile):
-            services.update_cognito_sub(user, "same-sub")
-
-        profile.save.assert_not_called()
-
-
-class TestUpdateCognitoSubInputValidation:
-    """Input validation behavior for update_cognito_sub."""
-
-    def test_raises_type_error_for_none_user(self):
-        """update_cognito_sub raises TypeError when user is None."""
+    def test_raises_typeerror_for_none_user(self):
         with pytest.raises(TypeError, match=USER_CANNOT_BE_NONE):
-            services.update_cognito_sub(None, "abc-123")
+            services.update_cognito_sub(None, "abc")
 
-    def test_raises_value_error_for_unsaved_user(self):
-        """update_cognito_sub raises ValueError when user has no pk."""
-        unsaved_user = _unsaved_user()
-
+    def test_raises_valueerror_for_unsaved_user(self):
         with pytest.raises(ValueError, match="user must have a primary key"):
-            services.update_cognito_sub(unsaved_user, "abc-123")
+            services.update_cognito_sub(_unsaved_user(), "abc")
 
-    def test_raises_type_error_for_none_cognito_sub(self):
-        """update_cognito_sub raises TypeError when cognito_sub is None."""
-        user = _saved_user()
-
+    def test_raises_typeerror_for_none_cognito_sub(self):
         with pytest.raises(TypeError, match="cognito_sub cannot be None"):
-            services.update_cognito_sub(user, None)
+            services.update_cognito_sub(_user("cog-none"), None)
 
-    def test_raises_value_error_for_empty_cognito_sub(self):
-        """update_cognito_sub raises ValueError when cognito_sub is empty."""
-        user = _saved_user()
-
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_raises_valueerror_for_empty_cognito_sub(self, value):
         with pytest.raises(ValueError, match="cognito_sub cannot be empty"):
-            services.update_cognito_sub(user, "")
-
-    def test_raises_value_error_for_whitespace_cognito_sub(self):
-        """update_cognito_sub raises ValueError when cognito_sub is only whitespace."""
-        user = _saved_user()
-
-        with pytest.raises(ValueError, match="cognito_sub cannot be empty"):
-            services.update_cognito_sub(user, "   ")
-
-
-class TestUpdateCognitoSubLogging:
-    """Logging behavior for update_cognito_sub."""
-
-    def test_logs_info_when_cognito_sub_changes(self, caplog):
-        """update_cognito_sub logs INFO when cognito_sub is updated."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub=None)
-
-        with (
-            caplog.at_level(logging.INFO, logger="management.services"),
-            patch("management.services.get_user_profile", return_value=profile),
-        ):
-            services.update_cognito_sub(user, "abc-123-sub")
-
-        assert "test@example.com" in caplog.text
-        assert "abc-123-sub" in caplog.text
-
-    def test_logs_debug_when_cognito_sub_unchanged(self, caplog):
-        """update_cognito_sub logs DEBUG when cognito_sub already matches."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub="same-sub")
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="management.services"),
-            patch("management.services.get_user_profile", return_value=profile),
-        ):
-            services.update_cognito_sub(user, "same-sub")
-
-        assert "unchanged" in caplog.text.lower() or "already" in caplog.text.lower()
-
-
-class TestUpdateCognitoSubErrorPropagation:
-    """Error propagation behavior for update_cognito_sub."""
-
-    def test_propagates_error_from_get_user_profile(self):
-        """update_cognito_sub propagates errors from get_user_profile."""
-        user = _saved_user()
-
-        with (
-            patch("management.services.get_user_profile", side_effect=IntegrityError("DB constraint")),
-            pytest.raises(IntegrityError, match="DB constraint"),
-        ):
-            services.update_cognito_sub(user, "abc-123")
-
-    def test_propagates_error_from_profile_save(self):
-        """update_cognito_sub propagates errors from profile.save()."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub=None)
-        profile.save.side_effect = IntegrityError("Save failed")
-
-        with (
-            patch("management.services.get_user_profile", return_value=profile),
-            pytest.raises(IntegrityError, match="Save failed"),
-        ):
-            services.update_cognito_sub(user, "abc-123")
-
-    def test_logs_error_on_save_failure(self, caplog):
-        """update_cognito_sub logs error when save fails."""
-        user = _saved_user()
-        profile = _mock_profile(cognito_sub=None)
-        profile.save.side_effect = IntegrityError("Save failed")
-
-        with (
-            caplog.at_level(logging.ERROR, logger="management.services"),
-            patch("management.services.get_user_profile", return_value=profile),
-            pytest.raises(IntegrityError),
-        ):
-            services.update_cognito_sub(user, "abc-123")
-
-        assert "failed" in caplog.text.lower() or "error" in caplog.text.lower()
+            services.update_cognito_sub(_user("cog-empty"), value)


### PR DESCRIPTION
Start Group 5 (management / shared / misc) of #957. Rewrite the management suites to drive real rows / the real command, instead of patching `ActivityLog.log` / `UserProfile.objects` / `audit_log` / `get_user_profile` / `post_save` / `Command.analyze_fks` / `compute_stats`.

## Changes (3 suites)

- **`test_services`** — `log_activity` / `get_user_profile` / `mark_user_deleted` / `create_user_profile` / `save_user_profile` / `update_cognito_sub` against real `UserProfile` / `ActivityLog` / `AuditLog` rows (accounting for the `post_save` signal that auto-provisions a profile). The real duplicate-profile `IntegrityError` is exercised directly; generic fault-injection + pure-tautology tests are dropped.
- **`test_apps`** — verify the profile signal wiring through its real effect (creating/saving a user provisions a `UserProfile`) instead of asserting `post_save.connect` call shapes.
- **`test_check_model_fks`** — drive the real management command against the real (clean) model graph; the violation-count path uses the real `compute_stats` on a synthetic results dict. Pure helper tests unchanged.

Add `management` to the `enable_log_propagation` fixture so its service logs are observable by `caplog`. Shrink `boundary_mock_baseline.json` by 9 entries (66 internal-patch allowances removed); update `docs/adr/README.md`.

## Verification

- All management suites green (53); `tests/management` green under `-n auto` (xdist).
- `adr_guard.py` full run green; full `pytest (shifter_platform)` suite green via pre-commit hook.

Refs #957.