### PR TITLE
Add shared Ground Control MCP config for Cursor

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "ground-control": {
+      "command": "node",
+      "args": ["${env:GROUND_CONTROL_DIR}/mcp/ground-control/index.js"],
+      "env": {
+        "GC_BASE_URL": "http://red-dragon:8000",
+        "GH_REPO": "Brad-Edwards/shifter"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,7 @@ cython_debug/
 .cursorindexingignore
 .cursor/*
 !.cursor/environment.json
+!.cursor/mcp.json
 !.cursor/rules/
 
 # Node.js


### PR DESCRIPTION
## Summary

- Track `.cursor/mcp.json` with a team-shared `ground-control` MCP server block so Cursor agents pick up Ground Control tools in this repo.
- Un-ignore `.cursor/mcp.json` in `.gitignore` (alongside the existing exceptions for `environment.json` and `rules/`).

Cursor reads `.cursor/mcp.json`, not repo-root `.mcp.json`. The server entry uses `${env:GROUND_CONTROL_DIR}` and reads `GROUND_CONTROL_API_TOKEN` from the repo-root `.env` at startup.

Personal or machine-local MCP servers (shifter-db, playwright, etc.) should stay in `~/.cursor/mcp.json`; Cursor merges project and user configs.

## Test plan

- [ ] Open repo in Cursor; confirm `ground-control` appears under Settings → Tools & MCP
- [ ] With `GROUND_CONTROL_DIR` set and repo-root `.env` containing `GROUND_CONTROL_API_TOKEN`, invoke a GC tool (e.g. `gc_get_repo_ground_control_context`)


Made with [Cursor](https://cursor.com)