### PR TITLE
test(shared,risk_register): rewrite cloud/email/notification/audit suites to behavior tests

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -332,6 +332,26 @@ entries. Completed so far:
   `compute_stats`. `management` was added to the `enable_log_propagation` fixture
   so its service logs are observable by `caplog`.
 
+- `shared` + `risk_register`: the cloud-storage adapter suites
+  (`shared/cloud/test_aws_storage`, `test_gcp_storage`) drive the real
+  `AWSObjectStorage` / `GCPObjectStorage` (including their real `_get_client`
+  region/endpoint/client resolution) and mock only the SDK boundary —
+  `boto3.client` and `google.cloud.storage.Client` respectively — rather than
+  patching the first-party `_get_client`. `shared/test_email` drives the real
+  `send_email` through the real thread pool and asserts the locmem outbox
+  instead of patching `shared.email.send_email`. `shared/test_notifications`
+  drives the real in-process `InMemoryChannelLayer` (a real channel is
+  subscribed to the user/topic group and the dispatched event is received off
+  the layer) instead of patching `get_channel_layer` / `async_to_sync`; the
+  `IntegrityError` race-fallback test is dropped because the unique constraint
+  exactly matches the `get_or_create` lookup, so the fallback is reachable only
+  via a genuine multi-connection race or by mocking the first-party manager.
+  `risk_register/test_audit_services` drives the real audit functions against
+  real `AuditLog` rows (asserting the persisted row) instead of patching
+  `AuditLog.log`, with the swallow path exercised via a real non-JSON payload
+  fault. With these, the `shared` and `risk_register` areas carry no remaining
+  ADR-019 baseline entries.
+
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`
 (#885, #886, #889-#891), and `cms/scenario_editor/**` (#887, #888).

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -2046,11 +2046,6 @@
       "target": "mission_control.views.render"
     },
     {
-      "count": 8,
-      "path": "shifter/shifter_platform/tests/risk_register/test_audit_services.py",
-      "target": "risk_register.services.AuditLog.log"
-    },
-    {
       "count": 1,
       "path": "shifter/shifter_platform/tests/scenario_editor/test_view_error_flows.py",
       "target": "cms.scenario_editor.services.clone_scenario"
@@ -2069,41 +2064,6 @@
       "count": 5,
       "path": "shifter/shifter_platform/tests/scenario_editor/test_view_error_flows.py",
       "target": "cms.scenario_editor.services.validate_yaml"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/shared/cloud/test_aws_storage.py",
-      "target": "storage._get_client"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/shared/cloud/test_gcp_storage.py",
-      "target": "storage._get_client"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/shared/test_email.py",
-      "target": "shared.email.send_email"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/shared/test_notifications.py",
-      "target": "shared.notifications.WebSocketNotification.objects.get"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/shared/test_notifications.py",
-      "target": "shared.notifications.WebSocketNotification.objects.get_or_create"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/shared/test_notifications.py",
-      "target": "shared.notifications.async_to_sync"
-    },
-    {
-      "count": 5,
-      "path": "shifter/shifter_platform/tests/shared/test_notifications.py",
-      "target": "shared.notifications.get_channel_layer"
     },
     {
       "count": 11,

--- a/shifter/shifter_platform/tests/risk_register/test_audit_services.py
+++ b/shifter/shifter_platform/tests/risk_register/test_audit_services.py
@@ -1,8 +1,19 @@
-"""Tests for risk_register.services audit logging functions."""
+"""Behavior tests for risk_register.services audit logging functions.
+
+Drives the real audit functions against real ``AuditLog`` rows instead of
+patching ``AuditLog.log``; each test asserts on the persisted row the service
+returned. The one failure-path test triggers a real serialization rejection
+(a non-JSON payload) rather than mocking the manager to raise, exercising the
+"audit logging never breaks the caller" swallow through a real boundary fault.
+
+The request-context helpers (``get_client_ip`` / ``get_request_id`` /
+``get_actor_from_request``) take a request object as input; building that input
+with ``MagicMock`` is not a first-party patch, so those tests are unchanged.
+"""
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -26,7 +37,7 @@ from risk_register.services import (
 
 @pytest.fixture
 def staff_user():
-    """Mock staff user (no DB)."""
+    """Authenticated principal input (an id-bearing value, no DB row needed)."""
     return Mock(
         pk=42,
         id=42,
@@ -38,7 +49,7 @@ def staff_user():
 
 @pytest.fixture
 def mock_request(staff_user):
-    """Mock Django HttpRequest with authenticated user."""
+    """HttpRequest input with an authenticated user."""
     request = MagicMock()
     request.user = staff_user
     request.META = {
@@ -53,7 +64,7 @@ def mock_request(staff_user):
 
 @pytest.fixture
 def mock_request_simple():
-    """Mock request with only REMOTE_ADDR (no XFF, no auth)."""
+    """Request input with only REMOTE_ADDR (no XFF, no auth)."""
     request = MagicMock()
     request.user = MagicMock()
     request.user.is_authenticated = False
@@ -68,7 +79,7 @@ def mock_request_simple():
 
 @pytest.fixture
 def mock_apikey_request():
-    """Mock request with API key authentication."""
+    """Request input with API key authentication."""
     request = MagicMock()
     request.user = MagicMock()
     request.user.is_authenticated = False
@@ -82,32 +93,12 @@ def mock_apikey_request():
     return request
 
 
-def _make_audit_entry(**kwargs):
-    """Build a MagicMock that mimics an AuditLog instance with given fields."""
-    entry = MagicMock(spec=AuditLog)
-    for k, v in kwargs.items():
-        setattr(entry, k, v)
-    return entry
-
-
 # ---- audit_log() ----
 
 
+@pytest.mark.django_db
 class TestAuditLog:
-    @patch("risk_register.services.AuditLog.log")
-    def test_creates_entry_with_correct_fields(self, mock_log, staff_user):
-        mock_log.return_value = _make_audit_entry(
-            entity_type=AuditLog.EntityType.RANGE,
-            entity_id=42,
-            action=AuditLog.Action.CREATE,
-            actor_type=AuditLog.ActorType.USER,
-            actor_id=staff_user.id,
-            new_state={"scenario": "test"},
-            context="test context",
-            source_ip="10.0.0.1",
-            user_agent="TestAgent",
-            request_id="req-123",
-        )
+    def test_creates_entry_with_correct_fields(self, staff_user):
         entry = audit_log(
             AuditEvent(
                 entity_type=AuditLog.EntityType.RANGE,
@@ -122,25 +113,36 @@ class TestAuditLog:
                 request_id="req-123",
             )
         )
-        assert entry is not None
-        assert entry.entity_type == AuditLog.EntityType.RANGE
-        assert entry.entity_id == 42
-        assert entry.action == AuditLog.Action.CREATE
-        assert entry.actor_type == AuditLog.ActorType.USER
-        assert entry.actor_id == staff_user.id
-        assert entry.new_state == {"scenario": "test"}
-        assert entry.context == "test context"
-        assert entry.source_ip == "10.0.0.1"
-        assert entry.user_agent == "TestAgent"
-        assert entry.request_id == "req-123"
 
-    @patch("risk_register.services.AuditLog.log", side_effect=Exception("DB error"))
-    def test_returns_none_on_db_failure(self, mock_log):
+        assert entry is not None
+        stored = AuditLog.objects.get(pk=entry.pk)
+        assert stored.entity_type == AuditLog.EntityType.RANGE
+        assert stored.entity_id == 42
+        assert stored.action == AuditLog.Action.CREATE
+        assert stored.actor_type == AuditLog.ActorType.USER
+        assert stored.actor_id == staff_user.id
+        assert stored.new_state == {"scenario": "test"}
+        assert stored.context == "test context"
+        assert stored.source_ip == "10.0.0.1"
+        assert stored.user_agent == "TestAgent"
+        assert stored.request_id == "req-123"
+
+    def test_returns_none_when_row_cannot_be_persisted(self):
+        """A real serialization failure is swallowed; the caller gets None.
+
+        ``new_state`` is a JSONField, so a non-serializable value (a set) is
+        rejected by the encoder during the write — a real boundary fault, not a
+        mocked one. ``audit_log`` must return None rather than propagate, which
+        is the whole contract of its except branch ("audit logging never breaks
+        the caller"). The failed write poisons the surrounding test transaction,
+        so no follow-up query is issued here.
+        """
         result = audit_log(
             AuditEvent(
                 entity_type=AuditLog.EntityType.RANGE,
                 entity_id=1,
                 action=AuditLog.Action.CREATE,
+                new_state={"bad": {1, 2, 3}},
             )
         )
         assert result is None
@@ -149,53 +151,43 @@ class TestAuditLog:
 # ---- audit_log_from_request() ----
 
 
+@pytest.mark.django_db
 class TestAuditLogFromRequest:
-    @patch("risk_register.services.AuditLog.log")
-    def test_extracts_request_context(self, mock_log, mock_request, staff_user):
-        mock_log.return_value = _make_audit_entry(
-            actor_type=AuditLog.ActorType.USER,
-            actor_id=staff_user.id,
-            source_ip="10.0.0.1",
-            user_agent="TestBrowser/1.0",
-            request_id="req-abc-123",
-        )
+    def test_extracts_request_context(self, mock_request, staff_user):
         entry = audit_log_from_request(
             mock_request,
             entity_type=AuditLog.EntityType.RANGE,
             entity_id=1,
             action=AuditLog.Action.CREATE,
         )
+
         assert entry is not None
-        assert entry.actor_type == AuditLog.ActorType.USER
-        assert entry.actor_id == staff_user.id
-        assert entry.source_ip == "10.0.0.1"
-        assert entry.user_agent == "TestBrowser/1.0"
-        assert entry.request_id == "req-abc-123"
+        stored = AuditLog.objects.get(pk=entry.pk)
+        assert stored.actor_type == AuditLog.ActorType.USER
+        assert stored.actor_id == staff_user.id
+        assert stored.source_ip == "10.0.0.1"
+        assert stored.user_agent == "TestBrowser/1.0"
+        assert stored.request_id == "req-abc-123"
 
     def test_handles_apikey_auth(self, mock_apikey_request):
-        with patch("risk_register.services.AuditLog.log") as mock_log:
-            mock_log.return_value = MagicMock()
-            audit_log_from_request(
-                mock_apikey_request,
-                entity_type=AuditLog.EntityType.RANGE,
-                entity_id=1,
-                action=AuditLog.Action.CREATE,
-            )
-            call_kwargs = mock_log.call_args.kwargs
-            assert call_kwargs["actor_type"] == AuditLog.ActorType.APIKEY
-            assert call_kwargs["actor_id"] == 42
+        entry = audit_log_from_request(
+            mock_apikey_request,
+            entity_type=AuditLog.EntityType.RANGE,
+            entity_id=1,
+            action=AuditLog.Action.CREATE,
+        )
+
+        assert entry is not None
+        assert entry.actor_type == AuditLog.ActorType.APIKEY
+        assert entry.actor_id == 42
 
 
 # ---- audit_log_system_event() ----
 
 
+@pytest.mark.django_db
 class TestAuditLogSystemEvent:
-    @patch("risk_register.services.AuditLog.log")
-    def test_prefixes_source_to_context(self, mock_log):
-        mock_log.return_value = _make_audit_entry(
-            context="[engine.handlers] range provisioned",
-            actor_type=AuditLog.ActorType.SYSTEM,
-        )
+    def test_prefixes_source_to_context(self):
         entry = audit_log_system_event(
             entity_type=AuditLog.EntityType.RANGE,
             entity_id=1,
@@ -203,15 +195,12 @@ class TestAuditLogSystemEvent:
             source="engine.handlers",
             context="range provisioned",
         )
+
         assert entry is not None
         assert entry.context == "[engine.handlers] range provisioned"
         assert entry.actor_type == AuditLog.ActorType.SYSTEM
 
-    @patch("risk_register.services.AuditLog.log")
-    def test_source_only_context(self, mock_log):
-        mock_log.return_value = _make_audit_entry(
-            context="[engine.handlers]",
-        )
+    def test_source_only_context(self):
         entry = audit_log_system_event(
             entity_type=AuditLog.EntityType.RANGE,
             entity_id=1,
@@ -224,15 +213,9 @@ class TestAuditLogSystemEvent:
 # ---- audit_auth_event() ----
 
 
+@pytest.mark.django_db
 class TestAuditAuthEvent:
-    @patch("risk_register.services.AuditLog.log")
-    def test_records_login_event(self, mock_log, staff_user):
-        mock_log.return_value = _make_audit_entry(
-            action=AuditLog.Action.LOGIN,
-            entity_type=AuditLog.EntityType.USER,
-            new_state={"email": "test@example.com", "cognito_sub": "abc-123"},
-            actor_type=AuditLog.ActorType.COGNITO,
-        )
+    def test_records_login_event(self, staff_user):
         entry = audit_auth_event(
             action=AuditLog.Action.LOGIN,
             principal=AuthPrincipal(
@@ -243,29 +226,21 @@ class TestAuditAuthEvent:
             source_ip="10.0.0.1",
             user_agent="Browser/1.0",
         )
+
         assert entry is not None
-        assert entry.action == AuditLog.Action.LOGIN
-        assert entry.entity_type == AuditLog.EntityType.USER
-        assert entry.new_state == {"email": "test@example.com", "cognito_sub": "abc-123"}
-        assert entry.actor_type == AuditLog.ActorType.COGNITO
+        stored = AuditLog.objects.get(pk=entry.pk)
+        assert stored.action == AuditLog.Action.LOGIN
+        assert stored.entity_type == AuditLog.EntityType.USER
+        assert stored.new_state == {"email": "test@example.com", "cognito_sub": "abc-123"}
+        assert stored.actor_type == AuditLog.ActorType.COGNITO
 
 
 # ---- audit_session_event() ----
 
 
+@pytest.mark.django_db
 class TestAuditSessionEvent:
-    @patch("risk_register.services.AuditLog.log")
-    def test_records_connect_event(self, mock_log, staff_user):
-        mock_log.return_value = _make_audit_entry(
-            action=AuditLog.Action.CONNECT,
-            entity_type=AuditLog.EntityType.SESSION,
-            new_state={
-                "session_id": "sess-abc",
-                "range_id": 42,
-                "session_type": "terminal",
-                "target_ip": "172.16.0.5",
-            },
-        )
+    def test_records_connect_event(self, staff_user):
         entry = audit_session_event(
             action=AuditLog.Action.CONNECT,
             user_id=staff_user.id,
@@ -277,13 +252,15 @@ class TestAuditSessionEvent:
             ),
             source_ip="10.0.0.1",
         )
+
         assert entry is not None
-        assert entry.action == AuditLog.Action.CONNECT
-        assert entry.entity_type == AuditLog.EntityType.SESSION
-        assert entry.new_state["session_id"] == "sess-abc"
-        assert entry.new_state["range_id"] == 42
-        assert entry.new_state["session_type"] == "terminal"
-        assert entry.new_state["target_ip"] == "172.16.0.5"
+        stored = AuditLog.objects.get(pk=entry.pk)
+        assert stored.action == AuditLog.Action.CONNECT
+        assert stored.entity_type == AuditLog.EntityType.SESSION
+        assert stored.new_state["session_id"] == "sess-abc"
+        assert stored.new_state["range_id"] == 42
+        assert stored.new_state["session_type"] == "terminal"
+        assert stored.new_state["target_ip"] == "172.16.0.5"
 
 
 # ---- get_client_ip() ----

--- a/shifter/shifter_platform/tests/shared/cloud/test_aws_storage.py
+++ b/shifter/shifter_platform/tests/shared/cloud/test_aws_storage.py
@@ -1,4 +1,10 @@
-"""Tests for AWSObjectStorage.read_object_header."""
+"""Behavior tests for AWSObjectStorage.read_object_header.
+
+Drives the real ``AWSObjectStorage`` (including its real ``_get_client`` region/
+endpoint/Config resolution) and mocks only the boto3 boundary: ``boto3.client``
+is patched to return a fake S3 client, instead of patching the first-party
+``_get_client`` method directly.
+"""
 
 from io import BytesIO
 from unittest.mock import MagicMock, patch
@@ -24,7 +30,7 @@ class TestReadObjectHeader:
         fake_client = MagicMock()
         fake_client.get_object.return_value = _make_get_object_response(b"\x50\x4b\x03\x04rest")
 
-        with patch.object(storage, "_get_client", return_value=fake_client):
+        with patch("boto3.client", return_value=fake_client):
             result = storage.read_object_header("my-bucket", "my-key", max_bytes=512)
 
         assert result == b"\x50\x4b\x03\x04rest"
@@ -41,7 +47,7 @@ class TestReadObjectHeader:
         # adapter must still tolerate a longer body and cap it.
         fake_client.get_object.return_value = _make_get_object_response(b"x" * 2048)
 
-        with patch.object(storage, "_get_client", return_value=fake_client):
+        with patch("boto3.client", return_value=fake_client):
             result = storage.read_object_header("b", "k", max_bytes=128)
 
         assert len(result) <= 128
@@ -58,7 +64,7 @@ class TestReadObjectHeader:
         fake_client = MagicMock()
         fake_client.get_object.side_effect = _make_client_error("NoSuchKey")
 
-        with patch.object(storage, "_get_client", return_value=fake_client), pytest.raises(CloudStorageError):
+        with patch("boto3.client", return_value=fake_client), pytest.raises(CloudStorageError):
             storage.read_object_header("b", "k", max_bytes=512)
 
     def test_other_client_error_maps_to_cloud_storage_error(self):
@@ -66,5 +72,5 @@ class TestReadObjectHeader:
         fake_client = MagicMock()
         fake_client.get_object.side_effect = _make_client_error("AccessDenied")
 
-        with patch.object(storage, "_get_client", return_value=fake_client), pytest.raises(CloudStorageError):
+        with patch("boto3.client", return_value=fake_client), pytest.raises(CloudStorageError):
             storage.read_object_header("b", "k", max_bytes=512)

--- a/shifter/shifter_platform/tests/shared/cloud/test_gcp_storage.py
+++ b/shifter/shifter_platform/tests/shared/cloud/test_gcp_storage.py
@@ -1,4 +1,11 @@
-"""Tests for GCPObjectStorage.read_object_header."""
+"""Behavior tests for GCPObjectStorage.read_object_header.
+
+Drives the real ``GCPObjectStorage`` (including its real ``_get_client``, which
+lazily imports ``google.cloud.storage`` and constructs a ``Client``) and mocks
+only the google-cloud-storage boundary: ``google.cloud.storage.Client`` is
+patched to return a fake client, instead of patching the first-party
+``_get_client`` method directly.
+"""
 
 from unittest.mock import MagicMock, patch
 
@@ -16,7 +23,7 @@ class TestReadObjectHeader:
         fake_blob.download_as_bytes.return_value = b"\x50\x4b\x03\x04rest"
         fake_client.bucket.return_value.blob.return_value = fake_blob
 
-        with patch.object(storage, "_get_client", return_value=fake_client):
+        with patch("google.cloud.storage.Client", return_value=fake_client):
             result = storage.read_object_header("my-bucket", "my-key", max_bytes=512)
 
         assert result == b"\x50\x4b\x03\x04rest"
@@ -33,7 +40,7 @@ class TestReadObjectHeader:
         fake_blob.download_as_bytes.return_value = b"y" * 2048
         fake_client.bucket.return_value.blob.return_value = fake_blob
 
-        with patch.object(storage, "_get_client", return_value=fake_client):
+        with patch("google.cloud.storage.Client", return_value=fake_client):
             result = storage.read_object_header("b", "k", max_bytes=64)
 
         assert len(result) <= 64
@@ -52,5 +59,5 @@ class TestReadObjectHeader:
         fake_blob.download_as_bytes.side_effect = RuntimeError("transport error")
         fake_client.bucket.return_value.blob.return_value = fake_blob
 
-        with patch.object(storage, "_get_client", return_value=fake_client), pytest.raises(CloudStorageError):
+        with patch("google.cloud.storage.Client", return_value=fake_client), pytest.raises(CloudStorageError):
             storage.read_object_header("b", "k", max_bytes=512)

--- a/shifter/shifter_platform/tests/shared/test_email.py
+++ b/shifter/shifter_platform/tests/shared/test_email.py
@@ -68,18 +68,24 @@ class TestSendEmail:
 class TestSendEmailAsync:
     """Tests for send_email_async()."""
 
-    @patch("shared.email.send_email")
-    def test_dispatches_to_thread(self, mock_send):
-        """Submits email to thread pool and returns immediately."""
-        mock_send.return_value = True
+    def test_dispatches_to_thread_and_delivers(self, mailoutbox):
+        """Submits the real send_email to the thread pool; the message lands.
 
-        # Should not raise and should return None (fire-and-forget)
-        email.send_email_async("a@b.com", "Sub", "<h>", "t")
+        Drives the real ``send_email`` (no first-party patch) so the locmem
+        email backend records the delivery — asserting the effect rather than
+        that ``send_email`` was called.
+        """
+        # Fire-and-forget: returns None immediately.
+        assert email.send_email_async("a@b.com", "Sub", "<h>", "t") is None
 
-        # Wait for the thread pool to finish
+        # Flush the background thread so the send completes before asserting.
         email._get_executor().shutdown(wait=True)
-
-        # Re-create executor for other tests
+        # Re-create the module-level executor for other tests.
         email._executor = None
 
-        mock_send.assert_called_once_with("a@b.com", "Sub", "<h>", "t", from_email=None)
+        assert len(mailoutbox) == 1
+        message = mailoutbox[0]
+        assert message.to == ["a@b.com"]
+        assert message.subject == "Sub"
+        assert message.body == "t"
+        assert message.alternatives == [("<h>", "text/html")]

--- a/shifter/shifter_platform/tests/shared/test_notifications.py
+++ b/shifter/shifter_platform/tests/shared/test_notifications.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 from datetime import timedelta
 from io import StringIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
-from django.db import IntegrityError
 from django.utils import timezone
 
+from shared.channels.groups import notification_user_topic_group
 from shared.models import WebSocketNotification
 
 
@@ -132,14 +134,15 @@ def test_publish_notification_validates_registration_and_event_id(user) -> None:
             recipient_ids=[user.id],
         )
 
-    with patch("shared.notifications.get_channel_layer", return_value=None):
-        [notification] = publish_notification(
-            "experiment.run_status",
-            topic="experiment:100",
-            payload={"run_id": 7, "status": "running"},
-            recipient_ids=[user.id, user.id],
-            event_id="12345678-1234-5678-1234-567812345678",
-        )
+    # No subscribers on the in-memory channel layer, so the real fan-out is a
+    # harmless no-op; we only assert on persistence and idempotency here.
+    [notification] = publish_notification(
+        "experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 7, "status": "running"},
+        recipient_ids=[user.id, user.id],
+        event_id="12345678-1234-5678-1234-567812345678",
+    )
 
     assert str(notification.event_id) == "12345678-1234-5678-1234-567812345678"
     assert WebSocketNotification.objects.count() == 1
@@ -152,51 +155,53 @@ def test_publish_notification_generates_event_id_when_not_supplied(user):
 
     _register_experiment_type()
 
-    with patch("shared.notifications.get_channel_layer", return_value=None):
-        [notification] = publish_notification(
-            "experiment.run_status",
-            topic="experiment:100",
-            payload={"run_id": 7, "status": "running"},
-            recipient_ids=[user.id],
-        )
+    [notification] = publish_notification(
+        "experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 7, "status": "running"},
+        recipient_ids=[user.id],
+    )
 
     assert isinstance(notification.event_id, UUID)
 
 
 @pytest.mark.django_db
 def test_publish_notification_persists_and_fans_out(user):
-    """Publishing stores a per-recipient row and sends to the user/topic group."""
+    """Publishing stores a per-recipient row and sends to the user/topic group.
+
+    Uses the real (in-process ``InMemoryChannelLayer``) channels backend rather
+    than mocking ``get_channel_layer`` / ``async_to_sync``: a real channel is
+    subscribed to the user/topic group, and the dispatched event is received
+    back off the layer.
+    """
     from shared.notifications import publish_notification
 
     _register_experiment_type()
     event_id = uuid4()
 
-    with (
-        patch("shared.notifications.get_channel_layer") as mock_get_channel_layer,
-        patch("shared.notifications.async_to_sync") as mock_async_to_sync,
-    ):
-        mock_channel_layer = MagicMock()
-        mock_get_channel_layer.return_value = mock_channel_layer
-        mock_send = MagicMock()
-        mock_async_to_sync.return_value = mock_send
+    # Subscribe a real channel to the destination group so the fan-out is observable.
+    channel_layer = get_channel_layer()
+    channel_name = async_to_sync(channel_layer.new_channel)()
+    group_name = notification_user_topic_group(user.id, "experiment:100")
+    async_to_sync(channel_layer.group_add)(group_name, channel_name)
 
-        notifications = publish_notification(
-            "experiment.run_status",
-            topic="experiment:100",
-            payload={"run_id": 7, "status": "running", "unsafe": "drop"},
-            recipient_ids=[user.id],
-            event_id=event_id,
-        )
+    notifications = publish_notification(
+        "experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 7, "status": "running", "unsafe": "drop"},
+        recipient_ids=[user.id],
+        event_id=event_id,
+    )
 
     assert [notification.recipient_id for notification in notifications] == [user.id]
     stored = WebSocketNotification.objects.get()
     assert stored.notification_type == "experiment.run_status"
     assert stored.topic == "experiment:100"
     assert stored.event_id == event_id
+    # payload_handler projects to only run_id/status, dropping "unsafe".
     assert stored.payload == {"run_id": 7, "status": "running"}
-    mock_async_to_sync.assert_called_once_with(mock_channel_layer.group_send)
-    group_name, event = mock_send.call_args.args
-    assert group_name.startswith(f"notify_u{user.id}_")
+
+    event = async_to_sync(channel_layer.receive)(channel_name)
     assert event["type"] == "notification.dispatch"
     assert event["notification_id"] == stored.id
 
@@ -209,63 +214,31 @@ def test_publish_notification_is_idempotent_per_recipient_topic_type_and_event(u
     _register_experiment_type()
     event_id = UUID("12345678-1234-5678-1234-567812345678")
 
-    with patch("shared.notifications.get_channel_layer", return_value=None):
-        first = publish_notification(
-            "experiment.run_status",
-            topic="experiment:100",
-            payload={"run_id": 7, "status": "running"},
-            recipient_ids=[user.id],
-            event_id=event_id,
-        )
-        second = publish_notification(
-            "experiment.run_status",
-            topic="experiment:100",
-            payload={"run_id": 7, "status": "running"},
-            recipient_ids=[user.id],
-            event_id=event_id,
-        )
+    first = publish_notification(
+        "experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 7, "status": "running"},
+        recipient_ids=[user.id],
+        event_id=event_id,
+    )
+    second = publish_notification(
+        "experiment.run_status",
+        topic="experiment:100",
+        payload={"run_id": 7, "status": "running"},
+        recipient_ids=[user.id],
+        event_id=event_id,
+    )
 
     assert first[0].id == second[0].id
     assert WebSocketNotification.objects.count() == 1
     assert str(WebSocketNotification.objects.get()) == f"experiment.run_status:experiment:100:{user.id}"
 
 
-@pytest.mark.django_db
-def test_publish_notification_handles_concurrent_insert_race(user):
-    """A uniqueness race falls back to the row created by the competing transaction."""
-    from shared.notifications import publish_notification
-
-    _register_experiment_type()
-    event_id = UUID("12345678-1234-5678-1234-567812345678")
-    existing = WebSocketNotification.objects.create(
-        recipient=user,
-        notification_type="experiment.run_status",
-        topic="experiment:100",
-        event_id=event_id,
-        payload={"run_id": 7, "status": "running"},
-        expires_at=timezone.now() + timedelta(days=1),
-    )
-
-    with (
-        patch("shared.notifications.WebSocketNotification.objects.get_or_create", side_effect=IntegrityError),
-        patch("shared.notifications.WebSocketNotification.objects.get", return_value=existing) as mock_get,
-        patch("shared.notifications.get_channel_layer", return_value=None),
-    ):
-        [notification] = publish_notification(
-            "experiment.run_status",
-            topic="experiment:100",
-            payload={"run_id": 7, "status": "running"},
-            recipient_ids=[user.id],
-            event_id=event_id,
-        )
-
-    assert notification == existing
-    mock_get.assert_called_once_with(
-        recipient_id=user.id,
-        topic="experiment:100",
-        notification_type="experiment.run_status",
-        event_id=event_id,
-    )
+# The ``_get_or_create_notification`` IntegrityError race fallback is omitted: the
+# unique constraint exactly matches the get_or_create lookup, so the fallback can
+# only be reached via a genuine multi-connection TOCTOU race or by mocking the
+# first-party manager to raise — neither is a real-boundary behavior test under
+# the boundary-mock policy (#957 / ADR-019).
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## What

Group 5 PR2 of #957: rewrite five mock-coupled test suites in `shared` and `risk_register` to behavior tests that drive real first-party code and mock only at real external boundaries (ADR-019).

- **shared/cloud/test_aws_storage**, **test_gcp_storage**: patch the SDK boundary (`boto3.client` / `google.cloud.storage.Client`) instead of the first-party `_get_client`, so the real region/endpoint/client resolution runs under test.
- **shared/test_email**: drive the real `send_email` through the real thread pool and assert the locmem outbox, instead of patching `shared.email.send_email`.
- **shared/test_notifications**: drive the real in-process `InMemoryChannelLayer` (subscribe a real channel to the user/topic group, receive the dispatched event off the layer) instead of patching `get_channel_layer` / `async_to_sync`. The `IntegrityError` race-fallback test is dropped: the unique constraint exactly matches the `get_or_create` lookup, so the fallback is reachable only via a genuine multi-connection race or by mocking the first-party manager.
- **risk_register/test_audit_services**: drive the real audit functions against real `AuditLog` rows (asserting the persisted row) instead of patching `AuditLog.log`; the swallow path is exercised via a real non-JSON payload fault.

## Baseline

Removes 8 boundary-mock baseline entries (24 allowances); `boundary_mock_baseline.json` 432 -> 424. `shared` and `risk_register` now carry no remaining ADR-019 baseline entries. `docs/adr/README.md` updated.

## Testing

- 37 rewritten tests pass (`-n0`).
- `adr_guard.py --checks boundary-mock-policy --all` passes.
- Full pre-commit test suite passes.