### PR TITLE
test: rewrite logout/docs/range-lifecycle/launch-range suites; fix budget flake at root cause

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -414,6 +414,25 @@ entries. Completed so far:
   `tests/integration/asgi/test_terminal_ws.py`. Generic/impossible-state and
   incidental-logging tests are dropped per the policy intent.
 
+- config / documentation / integration / views misc (`config/test_logout`,
+  `documentation/test_views`, `integration/engine/test_range_lifecycle`,
+  `views/test_launch_range_scenarios`): `test_logout` drives the real
+  `logout_view` through the test Client with a real session (the real Django
+  `logout` flushes it) instead of patching `config.views.logout`.
+  `documentation/test_views` drives the real `doc_index` render and asserts the
+  captured `response.context` (nav_tree / active_nav) instead of patching
+  `documentation.views.render`. `test_range_lifecycle` drives the real
+  `get_rdp_connection_info` → `get_rdp_password` over the boto3 Secrets Manager
+  boundary instead of patching `engine.services.get_rdp_password`.
+  `test_launch_range_scenarios` drives the real `mission_control:launch_range`
+  endpoint → real `cms_list_scenarios` / `cms_get_agent` / `cms_create_range`
+  against a real custom hydratable `Scenario` + a real Windows `AgentConfig`
+  (engine provisioning is a no-op, so the range stays `provisioning`), with the
+  real-boundary CMSError paths (a second launch hits "already have an active
+  range"; an unknown agent classifies to a safe message) and `caplog` for the
+  success/failure log assertions, instead of patching `cms_create_range` /
+  `cms_list_scenarios` / `cms_get_agent` / `logger`.
+
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`
 (#885, #886, #889-#891), and `cms/scenario_editor/**` (#887, #888).

--- a/scripts/adr_guard/boundary_mock_baseline.json
+++ b/scripts/adr_guard/boundary_mock_baseline.json
@@ -1106,11 +1106,6 @@
       "target": "cms.experiments.orchestrator.start_experiment_task"
     },
     {
-      "count": 2,
-      "path": "shifter/shifter_platform/tests/config/test_logout.py",
-      "target": "config.views.logout"
-    },
-    {
       "count": 1,
       "path": "shifter/shifter_platform/tests/ctf/conftest.py",
       "target": "cms.services.create_range"
@@ -1851,16 +1846,6 @@
       "target": "ctf.services.submission.verify_flag"
     },
     {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/documentation/test_views.py",
-      "target": "documentation.views.render"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/integration/engine/test_range_lifecycle.py",
-      "target": "engine.services.get_rdp_password"
-    },
-    {
       "count": 1,
       "path": "shifter/shifter_platform/tests/scenario_editor/test_view_error_flows.py",
       "target": "cms.scenario_editor.services.clone_scenario"
@@ -1879,26 +1864,6 @@
       "count": 5,
       "path": "shifter/shifter_platform/tests/scenario_editor/test_view_error_flows.py",
       "target": "cms.scenario_editor.services.validate_yaml"
-    },
-    {
-      "count": 11,
-      "path": "shifter/shifter_platform/tests/views/test_launch_range_scenarios.py",
-      "target": "mission_control.views.cms_create_range"
-    },
-    {
-      "count": 1,
-      "path": "shifter/shifter_platform/tests/views/test_launch_range_scenarios.py",
-      "target": "mission_control.views.cms_get_agent"
-    },
-    {
-      "count": 4,
-      "path": "shifter/shifter_platform/tests/views/test_launch_range_scenarios.py",
-      "target": "mission_control.views.cms_list_scenarios"
-    },
-    {
-      "count": 3,
-      "path": "shifter/shifter_platform/tests/views/test_launch_range_scenarios.py",
-      "target": "mission_control.views.logger"
     },
     {
       "count": 2,

--- a/shifter/shifter_platform/tests/config/test_logout.py
+++ b/shifter/shifter_platform/tests/config/test_logout.py
@@ -1,84 +1,64 @@
-"""Tests for the unified logout view (config/views.py:logout_view).
+"""Behavior tests for the unified logout view (config/views.py:logout_view).
 
-Verifies that:
-- OIDC users are logged out and redirected to Cognito's logout endpoint
-- Non-OIDC users (magic-link, dev-login) are logged out with a simple session clear
-- Unauthenticated requests redirect to the landing page
-- Only POST is accepted
+Drives the real view through the test Client with a real session: the real
+Django ``logout`` flushes the session and the view redirects appropriately,
+instead of patching ``config.views.logout`` and asserting it was called.
 """
 
-from unittest.mock import MagicMock, patch
-
 import pytest
-from django.contrib.auth import BACKEND_SESSION_KEY
-from django.test import RequestFactory
+from django.contrib.auth import get_user_model
+from django.test import Client
 
-from config.views import logout_view
+pytestmark = pytest.mark.django_db
 
+User = get_user_model()
 
-@pytest.fixture
-def rf():
-    """Django RequestFactory."""
-    return RequestFactory()
+LOGOUT_URL = "/logout/"
 
 
 @pytest.fixture
-def mock_user():
-    """Create a mock authenticated user."""
-    user = MagicMock()
-    user.is_authenticated = True
-    user.email = "test@example.com"
-    return user
+def user(db):
+    return User.objects.create_user(username="logout@example.com", email="logout@example.com")
 
 
 class TestLogoutView:
-    """Test the unified logout view."""
+    def test_non_oidc_user_gets_session_logout(self, user):
+        """A ModelBackend (non-OIDC) user is logged out and sent to the landing page."""
+        client = Client()
+        client.force_login(user, backend="django.contrib.auth.backends.ModelBackend")
+        assert "_auth_user_id" in client.session  # logged in
 
-    def test_non_oidc_user_gets_session_logout(self, rf, mock_user):
-        """Non-OIDC user (ModelBackend) should get a simple session logout."""
-        request = rf.post("/logout/")
-        request.user = mock_user
-        request.session = {"_auth_user_backend": "django.contrib.auth.backends.ModelBackend"}
+        response = client.post(LOGOUT_URL)
 
-        with patch("config.views.logout") as mock_logout:
-            response = logout_view(request)
+        assert response.status_code == 302
+        assert response.url == "/"
+        # Real logout flushed the session.
+        assert "_auth_user_id" not in client.session
 
-        mock_logout.assert_called_once_with(request)
+    def test_oidc_user_redirects_to_landing_without_op_logout(self, user):
+        """An OIDC-backend user is logged out; with no Cognito logout method
+        configured in test settings, the view falls back to the landing page."""
+        client = Client()
+        client.force_login(user, backend="config.oidc.ShifterOIDCBackend")
+
+        response = client.post(LOGOUT_URL)
+
+        assert response.status_code == 302
+        assert response.url == "/"
+        assert "_auth_user_id" not in client.session
+
+    def test_unauthenticated_redirects_to_landing(self):
+        """An unauthenticated POST redirects to the landing page."""
+        response = Client().post(LOGOUT_URL)
+
         assert response.status_code == 302
         assert response.url == "/"
 
-    def test_oidc_user_redirects_to_cognito_logout(self, rf, mock_user):
-        """OIDC user should be logged out and redirected to Cognito logout URL."""
-        request = rf.post("/logout/")
-        request.user = mock_user
-        request.session = {
-            BACKEND_SESSION_KEY: "config.oidc.ShifterOIDCBackend",
-        }
+    def test_get_not_allowed(self, user):
+        """GET is rejected (logout is POST-only)."""
+        client = Client()
+        client.force_login(user)
 
-        # No OIDC_OP_LOGOUT_URL_METHOD configured, so falls back to LOGOUT_REDIRECT_URL
-        with patch("config.views.logout") as mock_logout:
-            response = logout_view(request)
+        response = client.get(LOGOUT_URL)
 
-        mock_logout.assert_called_once_with(request)
-        assert response.status_code == 302
-        # In dev/test (no OIDC_AUTH_DOMAIN env var), provider_logout_url returns "/"
-        assert response.url == "/"
-
-    def test_unauthenticated_redirects_to_landing(self, rf):
-        """Unauthenticated POST should redirect to landing page."""
-        request = rf.post("/logout/")
-        anon = MagicMock()
-        anon.is_authenticated = False
-        request.user = anon
-
-        response = logout_view(request)
-        assert response.status_code == 302
-        assert response.url == "/"
-
-    def test_get_not_allowed(self, rf, mock_user):
-        """GET requests should be rejected (405 Method Not Allowed)."""
-        request = rf.get("/logout/")
-        request.user = mock_user
-
-        response = logout_view(request)
         assert response.status_code == 405

--- a/shifter/shifter_platform/tests/documentation/test_views.py
+++ b/shifter/shifter_platform/tests/documentation/test_views.py
@@ -4,13 +4,15 @@ Tests the view logic, not specific documentation content.
 Content-specific tests are brittle and break when docs are reorganized.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
-from django.http import Http404, HttpResponse
+from django.http import Http404
 from django.test import RequestFactory
 
 from documentation.views import doc_index, doc_page
+
+DOCS_INDEX_URL = "/docs/"
 
 
 @pytest.fixture
@@ -62,12 +64,10 @@ class TestAccessControl:
         assert response.status_code == 302
         assert "login" in response.url.lower() or "oidc" in response.url.lower()
 
-    @patch("documentation.views.render")
-    def test_authenticated_user_can_access(self, mock_render, rf, mock_user):
-        """Authenticated users get 200 OK."""
-        mock_render.return_value = HttpResponse(status=200)
-        request = _make_request(rf, mock_user)
-        response = doc_index(request)
+    def test_authenticated_user_can_access(self, authenticated_client):
+        """Authenticated users get 200 OK from the real rendered docs index."""
+        client, _user = authenticated_client()
+        response = client.get(DOCS_INDEX_URL)
 
         assert response.status_code == 200
 
@@ -138,39 +138,26 @@ class TestSecurity:
 class TestBasicFunctionality:
     """Tests for core view behavior."""
 
-    @patch("documentation.views.render")
-    def test_index_returns_nav_tree(self, mock_render, rf, mock_user):
-        """Index page includes nav_tree in context."""
-        mock_render.return_value = HttpResponse(status=200)
-        request = _make_request(rf, mock_user)
-        doc_index(request)
+    def test_index_returns_nav_tree(self, authenticated_client):
+        """Index page includes nav_tree in the real render context."""
+        client, _user = authenticated_client()
+        response = client.get(DOCS_INDEX_URL)
 
-        mock_render.assert_called_once()
-        context = mock_render.call_args[0][2]
-        assert "nav_tree" in context
-        assert isinstance(context["nav_tree"], list)
+        assert response.status_code == 200
+        assert isinstance(response.context["nav_tree"], list)
 
-    @patch("documentation.views.render")
-    def test_index_sets_active_nav(self, mock_render, rf, mock_user):
+    def test_index_sets_active_nav(self, authenticated_client):
         """Docs pages set active_nav to 'docs'."""
-        mock_render.return_value = HttpResponse(status=200)
-        request = _make_request(rf, mock_user)
-        doc_index(request)
+        client, _user = authenticated_client()
+        response = client.get(DOCS_INDEX_URL)
 
-        mock_render.assert_called_once()
-        context = mock_render.call_args[0][2]
-        assert context["active_nav"] == "docs"
+        assert response.context["active_nav"] == "docs"
 
-    @patch("documentation.views.render")
-    def test_nav_tree_excludes_deprecated(self, mock_render, rf, mock_user):
-        """Nav tree does not include _deprecated folder."""
-        mock_render.return_value = HttpResponse(status=200)
-        request = _make_request(rf, mock_user)
-        doc_index(request)
-
-        mock_render.assert_called_once()
-        context = mock_render.call_args[0][2]
-        nav_tree = context["nav_tree"]
+    def test_nav_tree_excludes_deprecated(self, authenticated_client):
+        """Nav tree does not include the _deprecated folder."""
+        client, _user = authenticated_client()
+        response = client.get(DOCS_INDEX_URL)
+        nav_tree = response.context["nav_tree"]
 
         def find_deprecated(items):
             for item in items:

--- a/shifter/shifter_platform/tests/integration/engine/test_range_lifecycle.py
+++ b/shifter/shifter_platform/tests/integration/engine/test_range_lifecycle.py
@@ -5,7 +5,8 @@ AWS services (ECS, Secrets Manager) are mocked as they require infrastructure.
 """
 
 import uuid
-from unittest.mock import patch
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -485,13 +486,24 @@ class TestGetActiveForUserIntegration:
 # =============================================================================
 
 
+@contextmanager
+def _boto3_rdp_secret(value):
+    """Bind the boto3 Secrets Manager client so the real get_rdp_password (and
+    the sftp ssh-key fetch) resolve ``value`` over the cloud boundary instead of
+    patching the first-party ``engine.services.get_rdp_password``."""
+    client = MagicMock()
+    client.get_secret_value.return_value = {"SecretString": value}
+    with patch("boto3.client", return_value=client):
+        yield
+
+
 @pytest.mark.django_db
 class TestGetRdpConnectionInfoIntegration:
     """Integration tests for get_rdp_connection_info with real DB."""
 
     def test_returns_connection_info_for_windows_instance(self, range_ready):
         """get_rdp_connection_info returns correct info for Windows."""
-        with patch("engine.services.get_rdp_password", return_value="PerInstanceWinPw!"):
+        with _boto3_rdp_secret("PerInstanceWinPw!"):
             result = get_rdp_connection_info(
                 user=range_ready.user,
                 instance_uuid="victim-uuid-456",
@@ -505,7 +517,7 @@ class TestGetRdpConnectionInfoIntegration:
 
     def test_returns_connection_info_for_kali_instance(self, range_ready):
         """get_rdp_connection_info returns correct info for Kali."""
-        with patch("engine.services.get_rdp_password", return_value="PerInstanceKaliPw!"):
+        with _boto3_rdp_secret("PerInstanceKaliPw!"):
             result = get_rdp_connection_info(
                 user=range_ready.user,
                 instance_uuid="attacker-uuid-123",
@@ -561,7 +573,7 @@ class TestGetRdpConnectionInfoIntegration:
             ],
         )
 
-        with patch("engine.services.get_rdp_password", return_value="PerInstanceUbuntuPw!"):
+        with _boto3_rdp_secret("PerInstanceUbuntuPw!"):
             result = get_rdp_connection_info(user=user, instance_uuid="ubuntu-uuid")
 
         assert result["os_type"] == "ubuntu"

--- a/shifter/shifter_platform/tests/integration/mission_control/test_page_renders.py
+++ b/shifter/shifter_platform/tests/integration/mission_control/test_page_renders.py
@@ -118,24 +118,44 @@ def ctf_participant(db, user):
 
 
 def _render_query_count(client: Client, url: str):
-    """Return (response, steady-state query_count) for a GET.
-
-    A warm-up request is issued first and discarded, so the measured count is
-    the steady-state per-render query cost — which is what these budgets are
-    meant to pin. Several per-process lazy caches (permission/content-type
-    prefetch, the auth-backend setup) issue a one-time query on first access in
-    a fresh process. Under pytest-xdist the budget module may share a worker
-    with a sibling test module that leaves such a cache cold; without the
-    warm-up that one-time query lands on whichever render is measured first and
-    intermittently inflates every exact-count budget on the worker (all five
-    fail together). Warming first makes the measurement independent of worker
-    scheduling while still catching any real per-render regression, which is
-    paid by both the warm-up and the measured render.
-    """
-    client.get(url)  # warm per-process lazy caches; intentionally not measured
+    """Return (response, query_count) for a GET, capturing only the render."""
     with CaptureQueriesContext(connection) as ctx:
         response = client.get(url)
     return response, len(ctx.captured_queries)
+
+
+@pytest.fixture(autouse=True)
+def _real_context_processors():
+    """Pin the real context processors for these exact-count budgets.
+
+    Django caches the resolved context-processor callables on each template
+    ``Engine`` (a ``cached_property``). Several ctf view suites patch the
+    context processors by module path (``mission_control.context_processors
+    .active_range``, ``shared.context_processors.user_permissions``,
+    ``ctf.context_processors.ctf_navigation``) to isolate their view tests; if
+    one of those patched renders is the first to warm a cold ``Engine`` on a
+    pytest-xdist worker, the *mocked* processors get cached process-wide and
+    survive the ``with patch`` block — so later renders silently skip those
+    processors' queries and every exact-count budget on the worker fails (the
+    measured count drops, e.g. 4 -> 2). Dropping the cached resolution before
+    and after each budget test forces re-resolution against the live (real,
+    unpatched) module attributes, so the budgets are deterministic regardless of
+    worker scheduling; clearing on teardown also leaves the next test a cold
+    cache so a ctf suite that follows can still apply its own patch. The
+    underlying ctf-suite fragility (relying on a cold Engine cache) is tracked
+    for the ctf decomposition.
+    """
+    from django.template import engines
+
+    def _reset() -> None:
+        for backend in engines.all():
+            engine = getattr(backend, "engine", None)
+            if engine is not None:
+                engine.__dict__.pop("template_context_processors", None)
+
+    _reset()
+    yield
+    _reset()
 
 
 @pytest.mark.django_db

--- a/shifter/shifter_platform/tests/views/test_launch_range_scenarios.py
+++ b/shifter/shifter_platform/tests/views/test_launch_range_scenarios.py
@@ -1,578 +1,224 @@
-"""Tests for launch_range view wiring to cms_create_range.
+"""Behavior tests for the launch_range view.
 
-All tests mock the ORM -- no @pytest.mark.django_db markers.
-Views are called via RequestFactory with mock users; CMS service
-functions are patched at the view-module boundary.
-
-Verifies that launch_range:
-- Validates inputs (agent_id required, JSON format)
-- Uses CMS for scenario validation
-- Calls cms_create_range and returns RangeContext dict
-- Handles CMSError appropriately
-- Logs successful launches
+Drives the real ``mission_control:launch_range`` endpoint → real
+``cms_list_scenarios`` / ``cms_get_agent`` / ``cms_create_range`` against real
+``Scenario`` / ``AgentConfig`` rows (a custom hydratable scenario + a real
+Windows agent), instead of patching the cms service functions / ``render`` /
+``logger``. Engine provisioning is a no-op (ECS unconfigured), so a launched
+range stays ``provisioning`` and no cloud mock is needed.
 """
 
 import json
-from unittest.mock import MagicMock, patch
-from uuid import uuid4
+import logging
 
 import pytest
-from django.test import RequestFactory
+from django.contrib.auth import get_user_model
+from django.urls import reverse
 
-from mission_control import views
-from shared.enums import ResourceStatus
-from shared.exceptions import CMSError
-from shared.schemas import InstanceContext, RangeContext
+pytestmark = pytest.mark.django_db
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+User = get_user_model()
+
+SCENARIO_ID = "launch-behavior-test"
+LAUNCH_URL = reverse("mission_control:launch_range")
+
+# A scenario whose instances carry explicit os_types (kali attacker + windows
+# victim with an XDR agent), so it hydrates cleanly with a single Windows agent.
+HYDRATABLE_DEFINITION = {
+    "instances": [
+        {"name": "Attacker", "role": "attacker", "os_type": "kali", "xdr_agent": False},
+        {"name": "Target", "role": "victim", "os_type": "windows", "xdr_agent": True},
+    ],
+    "subnets": [{"name": "core", "instances": ["Attacker", "Target"]}],
+    "ngfw": False,
+}
 
 
 def _json(response):
-    """Extract JSON from a JsonResponse."""
     return json.loads(response.content)
 
 
-# ---------------------------------------------------------------------------
-# Shared fixtures
-# ---------------------------------------------------------------------------
+@pytest.fixture
+def windows_os(db):
+    from cms.models import OperatingSystem
+
+    os_obj, _ = OperatingSystem.objects.get_or_create(
+        slug="windows", defaults={"name": "Windows", "extensions": [".msi"]}
+    )
+    return os_obj
 
 
 @pytest.fixture
-def rf():
-    """Django RequestFactory (no DB needed)."""
-    return RequestFactory()
+def scenario(db):
+    from cms.models import Scenario
 
-
-@pytest.fixture
-def mock_user():
-    """Authenticated mock user."""
-    user = MagicMock()
-    user.id = 1
-    user.pk = 1
-    user.username = "test@example.com"
-    user.email = "test@example.com"
-    user.is_authenticated = True
-    user.is_active = True
-    return user
-
-
-@pytest.fixture
-def mock_windows_agent():
-    """Mock Windows AgentConfig object."""
-    agent = MagicMock()
-    agent.id = 10
-    agent.name = "Windows Agent"
-    agent.os = MagicMock()
-    agent.os.slug = "windows"
-    agent.os.name = "Windows"
-    agent.original_filename = "cortex_agent.msi"
-    agent.s3_key = "agents/123/agent.msi"
-    agent.file_size_bytes = 5000000
-    agent.sha256_hash = "abc123def456"
-    return agent
-
-
-@pytest.fixture
-def mock_cms_list_scenarios():
-    """Mock CMS list_scenarios to return basic and ad_attack_lab."""
-    scenarios = [
-        {"id": "basic", "name": "Basic"},
-        {"id": "ad_attack_lab", "name": "AD Attack Lab"},
-    ]
-    with patch.object(views, "cms_list_scenarios", return_value=scenarios):
-        yield scenarios
-
-
-@pytest.fixture
-def mock_cms_get_agent(mock_windows_agent):
-    """Mock CMS get_agent to return the mock Windows agent."""
-    with patch.object(views, "cms_get_agent", return_value=mock_windows_agent) as mock_get:
-        yield mock_get
-
-
-@pytest.fixture
-def mock_range_context():
-    """Create a mock RangeContext for testing."""
-    return RangeContext(
-        request_id=uuid4(),
-        range_id=42,
-        scenario_id="basic",
-        user_id=1,
-        status=ResourceStatus.PROVISIONING,
-        instances=[
-            InstanceContext(role="attacker", os_type="kali"),
-            InstanceContext(role="victim", os_type="windows"),
-        ],
-        agent_name="Windows Agent",
+    staff = User.objects.create_user(
+        username="launch-author@example.com", email="launch-author@example.com", is_staff=True
+    )
+    return Scenario.objects.create(
+        scenario_id=SCENARIO_ID,
+        name="Launch Behavior",
+        description="Hydratable scenario for launch_range behavior tests.",
+        definition=HYDRATABLE_DEFINITION,
+        created_by=staff,
+        updated_by=staff,
     )
 
 
-# -----------------------------------------------------------------------------
-# Input validation tests
-# -----------------------------------------------------------------------------
+@pytest.fixture
+def agent(db, windows_os, launch_client):
+    from cms.models import AgentConfig
+
+    _client, user = launch_client
+    return AgentConfig.objects.create(
+        name="Launch Agent",
+        s3_key="agents/test/agent.msi",
+        original_filename="agent.msi",
+        file_size_bytes=5_000_000,
+        sha256_hash="abc123",
+        user=user,
+        os=windows_os,
+    )
+
+
+@pytest.fixture
+def launch_client(authenticated_client):
+    return authenticated_client(email="launcher@example.com")
+
+
+def _post(client, payload):
+    return client.post(LAUNCH_URL, data=json.dumps(payload), content_type="application/json")
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
 
 
 class TestLaunchRangeInputValidation:
-    """Tests for input validation in launch_range view."""
-
-    def test_returns_400_for_invalid_json(self, rf, mock_user):
-        """View returns 400 when request body is not valid JSON."""
-        request = rf.post(
-            "/api/range/launch/",
-            data="not valid json{",
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        response = views.launch_range(request)
+    def test_returns_400_for_invalid_json(self, launch_client):
+        client, _user = launch_client
+        response = client.post(LAUNCH_URL, data="not valid json{", content_type="application/json")
         assert response.status_code == 400
         assert _json(response)["error"] == "Invalid JSON"
 
-    def test_returns_400_for_empty_body(self, rf, mock_user):
-        """View returns 400 when request body is empty."""
-        request = rf.post(
-            "/api/range/launch/",
-            data="",
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        response = views.launch_range(request)
+    def test_returns_400_for_empty_body(self, launch_client):
+        client, _user = launch_client
+        response = client.post(LAUNCH_URL, data="", content_type="application/json")
         assert response.status_code == 400
         assert _json(response)["error"] == "Invalid JSON"
 
-    def test_returns_400_when_agent_id_missing(self, rf, mock_user, mock_cms_list_scenarios):
-        """View returns 400 when agent_id is not provided."""
-        request = rf.post(
-            "/api/range/launch/",
-            data=json.dumps({"scenario": "basic"}),
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        response = views.launch_range(request)
+    def test_returns_400_when_no_agent_provided(self, launch_client, scenario):
+        client, _user = launch_client
+        response = _post(client, {"scenario": SCENARIO_ID})
         assert response.status_code == 400
         assert "agent_id" in _json(response)["error"]
 
-    def test_returns_400_when_agent_id_is_null(self, rf, mock_user, mock_cms_list_scenarios):
-        """View returns 400 when agent_id is explicitly null."""
-        request = rf.post(
-            "/api/range/launch/",
-            data=json.dumps({"agent_id": None, "scenario": "basic"}),
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        response = views.launch_range(request)
-        assert response.status_code == 400
-        assert "agent_id" in _json(response)["error"]
-
-    def test_returns_400_when_agent_id_is_zero(self, rf, mock_user, mock_cms_list_scenarios):
-        """View returns 400 when agent_id is zero (falsy)."""
-        request = rf.post(
-            "/api/range/launch/",
-            data=json.dumps({"agent_id": 0, "scenario": "basic"}),
-            content_type="application/json",
-        )
-        request.user = mock_user
-
-        response = views.launch_range(request)
+    @pytest.mark.parametrize("bad_agent_id", [None, 0])
+    def test_returns_400_for_falsy_agent_id(self, launch_client, scenario, bad_agent_id):
+        client, _user = launch_client
+        response = _post(client, {"agent_id": bad_agent_id, "scenario": SCENARIO_ID})
         assert response.status_code == 400
         assert "agent_id" in _json(response)["error"]
 
 
-# -----------------------------------------------------------------------------
-# Scenario validation tests
-# -----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Scenario validation
+# ---------------------------------------------------------------------------
 
 
 class TestLaunchRangeScenarioValidation:
-    """Tests for scenario validation in launch_range view."""
+    def test_accepts_a_valid_scenario(self, launch_client, agent, scenario):
+        client, _user = launch_client
+        response = _post(client, {"agent_id": agent.id, "scenario": SCENARIO_ID})
+        assert response.status_code == 200
 
-    def test_accepts_basic_scenario(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """View accepts 'basic' scenario."""
-        with patch.object(views, "cms_create_range", return_value=mock_range_context):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id, "scenario": "basic"}),
-                content_type="application/json",
-            )
-            request.user = mock_user
+    def test_rejects_unknown_scenario(self, launch_client, agent, scenario):
+        client, _user = launch_client
+        response = _post(client, {"agent_id": agent.id, "scenario": "no-such-scenario"})
+        assert response.status_code == 400
+        assert "Invalid" in _json(response)["error"]
 
-            response = views.launch_range(request)
-            assert response.status_code == 200
+    def test_omitting_scenario_defaults_to_basic(self, launch_client, agent, scenario):
+        """When no scenario is given the view defaults to 'basic' (a real builtin).
 
-    def test_accepts_ad_attack_lab_scenario(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """View accepts 'ad_attack_lab' scenario."""
-        with patch.object(views, "cms_create_range", return_value=mock_range_context):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps(
-                    {
-                        "agent_id": mock_windows_agent.id,
-                        "scenario": "ad_attack_lab",
-                    }
-                ),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            assert response.status_code == 200
-
-    def test_rejects_unknown_scenario(self, rf, mock_user, mock_windows_agent, mock_cms_get_agent):
-        """View rejects unknown scenario with 400 error."""
-        with patch.object(
-            views,
-            "cms_list_scenarios",
-            return_value=[{"id": "basic", "name": "Basic"}],
-        ):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps(
-                    {
-                        "agent_id": mock_windows_agent.id,
-                        "scenario": "unknown_scenario",
-                    }
-                ),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            assert response.status_code == 400
-            assert "Invalid" in _json(response)["error"]
-
-    def test_scenario_validation_uses_cms(self, rf, mock_user, mock_windows_agent, mock_cms_get_agent):
-        """Scenario validation uses CMS list_scenarios, not hardcoded list."""
-        mock_scenarios = [{"id": "basic", "name": "Basic"}]
-
-        with patch.object(views, "cms_list_scenarios", return_value=mock_scenarios):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps(
-                    {
-                        "agent_id": mock_windows_agent.id,
-                        "scenario": "ad_attack_lab",
-                    }
-                ),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            # ad_attack_lab should be rejected since CMS doesn't list it
-            response = views.launch_range(request)
-            assert response.status_code == 400
-
-    def test_defaults_to_basic_scenario(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """View defaults to 'basic' scenario when not specified."""
-        with patch.object(views, "cms_create_range", return_value=mock_range_context) as mock_create:
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            assert response.status_code == 200
-            # Verify basic was passed to cms_create_range
-            mock_create.assert_called_once()
-            call_args = mock_create.call_args
-            assert call_args[0][1] == "basic"  # scenario is 2nd positional arg
+        'basic' is a valid scenario, so it passes scenario validation rather than
+        being rejected as 'Invalid scenario' — it then fails hydration with this
+        Windows-only agent, which proves the default was accepted (not rejected).
+        """
+        client, _user = launch_client
+        response = _post(client, {"agent_id": agent.id})
+        assert response.status_code == 400
+        assert _json(response)["error"] != "Invalid scenario"
 
 
-# -----------------------------------------------------------------------------
-# Success behavior tests
-# -----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Success behavior
+# ---------------------------------------------------------------------------
 
 
 class TestLaunchRangeSuccess:
-    """Tests for successful launch_range behavior."""
+    def test_returns_success_with_range_dict(self, launch_client, agent, scenario):
+        client, user = launch_client
+        response = _post(client, {"agent_id": agent.id, "scenario": SCENARIO_ID})
 
-    def test_returns_success_with_range_context_dict(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """Successful launch returns success=True and range as dict."""
-        with patch.object(views, "cms_create_range", return_value=mock_range_context):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id, "scenario": "basic"}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            assert response.status_code == 200
-            data = _json(response)
-            assert data["success"] is True
-            assert "range" in data
-            assert isinstance(data["range"], dict)
-
-    def test_range_dict_contains_expected_fields(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """Range dict contains RangeContext fields."""
-        with patch.object(views, "cms_create_range", return_value=mock_range_context):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id, "scenario": "basic"}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            data = _json(response)
-            range_data = data["range"]
-
-            # Verify RangeContext fields are present
-            assert range_data["range_id"] == 42
-            assert range_data["scenario_id"] == "basic"
-            assert range_data["user_id"] == 1
-            assert range_data["status"] == "provisioning"
-            assert range_data["agent_name"] == "Windows Agent"
-            assert isinstance(range_data["instances"], list)
-            assert len(range_data["instances"]) == 2
-
-    def test_range_dict_contains_computed_fields(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """Range dict includes computed fields from RangeContext."""
-        with patch.object(views, "cms_create_range", return_value=mock_range_context):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            data = _json(response)
-            range_data = data["range"]
-
-            # Computed fields should be present
-            assert range_data["is_ready"] is False  # PROVISIONING != READY
-            assert range_data["is_terminal"] is False  # Not DESTROYED/FAILED
-            assert range_data["is_active"] is True  # Not terminal
-
-    def test_calls_cms_create_range_with_correct_args(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """launch_range passes correct arguments to cms_create_range."""
-        with patch.object(views, "cms_create_range", return_value=mock_range_context) as mock_create:
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps(
-                    {
-                        "agent_id": mock_windows_agent.id,
-                        "scenario": "ad_attack_lab",
-                    }
-                ),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            views.launch_range(request)
-
-            mock_create.assert_called_once()
-            call_args = mock_create.call_args
-
-            # Verify positional args: (user, scenario, agents_by_os)
-            assert call_args[0][0].email == mock_user.email  # User object
-            assert call_args[0][1] == "ad_attack_lab"  # scenario
-            assert call_args[0][2] == {"windows": mock_windows_agent.id}  # agents_by_os
+        assert response.status_code == 200
+        data = _json(response)
+        assert data["success"] is True
+        range_data = data["range"]
+        assert isinstance(range_data, dict)
+        assert range_data["scenario_id"] == SCENARIO_ID
+        assert range_data["user_id"] == user.id
+        assert range_data["status"] == "provisioning"
+        assert isinstance(range_data["instances"], list)
+        # Computed RangeContext fields (provisioning, not yet ready/terminal).
+        assert range_data["is_ready"] is False
+        assert range_data["is_terminal"] is False
+        assert range_data["is_active"] is True
 
 
-# -----------------------------------------------------------------------------
-# Error handling tests
-# -----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
 
 
 class TestLaunchRangeErrorHandling:
-    """Tests for error handling in launch_range view."""
+    def test_active_range_conflict_maps_to_authored_literal(self, launch_client, agent, scenario):
+        """A second launch while a range is active is rejected with the authored
+        'already have an active range' guidance (never echoing str(e))."""
+        client, _user = launch_client
+        first = _post(client, {"agent_id": agent.id, "scenario": SCENARIO_ID})
+        assert first.status_code == 200
 
-    def test_returns_400_on_cms_error(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-    ):
-        """View returns 400 when cms_create_range raises CMSError.
+        second = _post(client, {"agent_id": agent.id, "scenario": SCENARIO_ID})
+        assert second.status_code == 400
+        assert _json(second)["error"] == "You already have an active range"
 
-        The response body is now selected from a fixed set of authored literals
-        in ``shared.errors.classify_user_message`` so the original exception
-        text never reaches the client (CodeQL ``py/stack-trace-exposure``).
-        """
-        with patch.object(
-            views,
-            "cms_create_range",
-            side_effect=CMSError("Agent not found"),
-        ):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id, "scenario": "basic"}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            assert response.status_code == 400
-            # "not found" classifies as a not-found message.
-            assert _json(response)["error"] == "Resource not found"
-
-    def test_active_range_conflict_maps_to_authored_literal(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-    ):
-        """The "already have an active range" guidance is preserved via an
-        authored literal in the view — never by echoing ``str(e)`` directly.
-        """
-        with patch.object(
-            views,
-            "cms_create_range",
-            side_effect=CMSError("User already has an active range"),
-        ):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id, "scenario": "basic"}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            response = views.launch_range(request)
-            assert _json(response)["error"] == "You already have an active range"
+    def test_unknown_agent_maps_to_safe_message(self, launch_client, scenario):
+        """A non-existent agent id surfaces a classified, non-leaking message."""
+        client, _user = launch_client
+        response = _post(client, {"agent_id": 999999, "scenario": SCENARIO_ID})
+        assert response.status_code == 400
+        # Classified literal, not the raw exception text.
+        assert _json(response)["error"] in {"Resource not found", "Agent not available"}
 
 
-# -----------------------------------------------------------------------------
-# Logging tests
-# -----------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
 
 
 class TestLaunchRangeLogging:
-    """Tests for logging in launch_range view."""
+    def test_logs_info_on_successful_launch(self, launch_client, agent, scenario, caplog):
+        client, _user = launch_client
+        with caplog.at_level(logging.INFO, logger="mission_control.views"):
+            response = _post(client, {"agent_id": agent.id, "scenario": SCENARIO_ID})
+        assert response.status_code == 200
+        assert "Range launched" in caplog.text
 
-    def test_logs_info_on_successful_launch(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-        mock_range_context,
-    ):
-        """View logs INFO on successful launch."""
-        with (
-            patch.object(views, "cms_create_range", return_value=mock_range_context),
-            patch.object(views, "logger") as mock_logger,
-        ):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id, "scenario": "basic"}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            views.launch_range(request)
-            mock_logger.info.assert_called_once()
-
-    def test_no_log_on_validation_failure(self, rf, mock_user):
-        """View does not log INFO when validation fails."""
-        with patch.object(views, "logger") as mock_logger:
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"scenario": "basic"}),  # Missing agent_id
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            with patch.object(
-                views,
-                "cms_list_scenarios",
-                return_value=[{"id": "basic", "name": "Basic"}],
-            ):
-                views.launch_range(request)
-
-            mock_logger.info.assert_not_called()
-
-    def test_no_log_on_cms_error(
-        self,
-        rf,
-        mock_user,
-        mock_windows_agent,
-        mock_cms_list_scenarios,
-        mock_cms_get_agent,
-    ):
-        """View does not log INFO when CMSError occurs."""
-        with (
-            patch.object(
-                views,
-                "cms_create_range",
-                side_effect=CMSError("Test error"),
-            ),
-            patch.object(views, "logger") as mock_logger,
-        ):
-            request = rf.post(
-                "/api/range/launch/",
-                data=json.dumps({"agent_id": mock_windows_agent.id, "scenario": "basic"}),
-                content_type="application/json",
-            )
-            request.user = mock_user
-
-            views.launch_range(request)
-            mock_logger.info.assert_not_called()
+    def test_no_info_log_on_validation_failure(self, launch_client, scenario, caplog):
+        client, _user = launch_client
+        with caplog.at_level(logging.INFO, logger="mission_control.views"):
+            response = _post(client, {"scenario": SCENARIO_ID})  # no agent
+        assert response.status_code == 400
+        assert "Range launched" not in caplog.text


### PR DESCRIPTION
## What

Group 5 PR5 of #957: rewrite four remaining mock-coupled suites to behavior tests (ADR-019), and **correctly** fix the `TestPageRenderQueryBudgets` flake.

### Behavior rewrites (28 allowances; baseline 387 → 380)
- **config/test_logout**: drive the real `logout_view` via the test Client with a real session (real `logout` flushes it) instead of patching `config.views.logout`.
- **documentation/test_views**: drive the real `doc_index` render and assert the captured `response.context` (nav_tree / active_nav) instead of patching `documentation.views.render`.
- **integration/engine/test_range_lifecycle**: drive the real `get_rdp_connection_info` → `get_rdp_password` over the boto3 Secrets Manager boundary instead of patching `engine.services.get_rdp_password`.
- **views/test_launch_range_scenarios**: drive the real `launch_range` endpoint → real `cms_list_scenarios`/`cms_get_agent`/`cms_create_range` against a real custom hydratable `Scenario` + real Windows `AgentConfig`, with real CMSError paths and `caplog`, instead of patching the cms services / `logger`.

### Budget-flake fix (corrects PR3)
The PR3 warm-up was the wrong fix — it assumed cold-cache *extra* queries, but the real symptom is *fewer* queries. Root cause: ctf view suites patch context processors **by module path**, and Django caches resolved context-processor callables on the template `Engine` (`cached_property`). When a ctf patched render is the first to warm a cold Engine on an xdist worker, the **mocked** processors are cached process-wide and survive the `with patch` block, so later renders skip those processors' queries (4 → 2) and every exact-count budget on the worker fails. Replaced the warm-up with an autouse fixture that drops the Engine's cached context-processor resolution before/after each budget test — pinning the real processors deterministically. Reproduced the leak and verified the fix directly.

> The underlying ctf-suite fragility (relying on a cold Engine cache) is flagged for the ctf decomposition — not fixed here (out of #957 scope).

## Testing
- All rewritten suites pass (`-n0` and `-n auto`).
- Budget flake reproduced deterministically and confirmed fixed.
- `adr_guard` passes; full pre-commit suite passes.