### PR TITLE
refactor(config): move generate_username out of the OIDC backend (refactor-survival demo)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -433,6 +433,21 @@ entries. Completed so far:
   success/failure log assertions, instead of patching `cms_create_range` /
   `cms_list_scenarios` / `cms_get_agent` / `logger`.
 
+### Refactor-survival demonstration (#957)
+
+The point of the boundary-mock policy is that behavior tests survive refactors
+that mock-coupled tests would not. To demonstrate this concretely, the
+`generate_username` Django-username validator was moved out of the OIDC backend
+module (`config/oidc.py`) into its own `config/username.py`, and the single
+topology reference (`OIDC_USERNAME_ALGO = "config.username.generate_username"`)
+was updated. The `tests/mission_control/test_oidc.py` `ShifterOIDCBackend`
+behavior tests — which exercise `generate_username` only through the real OIDC
+`create_user` / `update_user` login flow (via `OIDC_USERNAME_ALGO`), never naming
+the function's location — pass **unchanged** across the move. Only the function's
+own direct unit tests (`TestGenerateUsername`) updated their import to follow it.
+A mock-coupled test that had patched `config.oidc.generate_username` would have
+broken on the move; the behavior tests did not.
+
 Decomposition-owned suites are out of scope here and land with their own
 issues: provisioner (#946), `ctf/**` and `cms/experiments/test_orchestrator*`
 (#885, #886, #889-#891), and `cms/scenario_editor/**` (#887, #888).

--- a/shifter/shifter_platform/config/_oidc_settings.py
+++ b/shifter/shifter_platform/config/_oidc_settings.py
@@ -141,7 +141,7 @@ OIDC_OP_LOGOUT_URL_METHOD = "config.oidc.provider_logout_url" if AUTH_PROVIDER =
 OIDC_CREATE_USER = True
 
 # Use email as username (default is sha1 hash of email)
-OIDC_USERNAME_ALGO = "config.oidc.generate_username"
+OIDC_USERNAME_ALGO = "config.username.generate_username"
 
 # URLs exempt from OIDC authentication (public pages)
 # Must be URL paths starting with "/" or view names (not regex patterns)

--- a/shifter/shifter_platform/config/oidc.py
+++ b/shifter/shifter_platform/config/oidc.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 from uuid import UUID
@@ -26,47 +25,6 @@ logger = logging.getLogger(__name__)
 
 # Valid CTF user types that can be set from Cognito claims
 VALID_CTF_USER_TYPES = {"standard", "ctf_organizer", "ctf_participant"}
-
-# Django's UnicodeUsernameValidator pattern
-DJANGO_USERNAME_PATTERN = re.compile(r"^[\w.@+-]+$")
-DJANGO_USERNAME_MAX_LENGTH = 150
-
-
-def generate_username(email: str) -> str:
-    """Use email as username instead of default sha1 hash.
-
-    mozilla-django-oidc defaults to base64(sha1(email)) for privacy
-    (usernames are often public). For this internal tool, readable
-    emails in admin/logs/queries are more useful than hash obfuscation.
-
-    Raises:
-        ValueError: If email exceeds Django's 150 char limit or contains
-            characters not allowed in Django usernames. This indicates a
-            mismatch between Cognito's allowed emails and Django's constraints
-            that must be fixed at the source (Lambda allow-list).
-    """
-    if len(email) > DJANGO_USERNAME_MAX_LENGTH:
-        logger.error(
-            "OIDC username rejected: email exceeds %d chars (got %d): %s",
-            DJANGO_USERNAME_MAX_LENGTH,
-            len(email),
-            email[:50] + "...",
-        )
-        raise ValueError(
-            f"Email exceeds Django username limit of {DJANGO_USERNAME_MAX_LENGTH} characters. "
-            "Fix the Cognito pre-signup Lambda allow-list."
-        )
-
-    if not DJANGO_USERNAME_PATTERN.match(email):
-        logger.error(
-            "OIDC username rejected: email contains invalid characters: %s",
-            email,
-        )
-        raise ValueError(
-            "Email contains characters not allowed in Django usernames. Fix the Cognito pre-signup Lambda allow-list."
-        )
-
-    return email
 
 
 def provider_logout_url(request: HttpRequest) -> str:

--- a/shifter/shifter_platform/config/username.py
+++ b/shifter/shifter_platform/config/username.py
@@ -1,0 +1,55 @@
+"""Django username derivation/validation for OIDC logins.
+
+Standalone username utility kept out of the OIDC backend module so it can be
+reused and unit-tested without importing the auth backend. Referenced by
+``OIDC_USERNAME_ALGO`` (``config.username.generate_username``); mozilla-django-oidc
+resolves that setting path to derive the Django username from the email claim.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Django's UnicodeUsernameValidator pattern
+DJANGO_USERNAME_PATTERN = re.compile(r"^[\w.@+-]+$")
+DJANGO_USERNAME_MAX_LENGTH = 150
+
+
+def generate_username(email: str) -> str:
+    """Use email as username instead of default sha1 hash.
+
+    mozilla-django-oidc defaults to base64(sha1(email)) for privacy
+    (usernames are often public). For this internal tool, readable
+    emails in admin/logs/queries are more useful than hash obfuscation.
+
+    Raises:
+        ValueError: If email exceeds Django's 150 char limit or contains
+            characters not allowed in Django usernames. This indicates a
+            mismatch between Cognito's allowed emails and Django's constraints
+            that must be fixed at the source (Lambda allow-list).
+    """
+    if len(email) > DJANGO_USERNAME_MAX_LENGTH:
+        logger.error(
+            "OIDC username rejected: email exceeds %d chars (got %d): %s",
+            DJANGO_USERNAME_MAX_LENGTH,
+            len(email),
+            email[:50] + "...",
+        )
+        raise ValueError(
+            f"Email exceeds Django username limit of {DJANGO_USERNAME_MAX_LENGTH} characters. "
+            "Fix the Cognito pre-signup Lambda allow-list."
+        )
+
+    if not DJANGO_USERNAME_PATTERN.match(email):
+        logger.error(
+            "OIDC username rejected: email contains invalid characters: %s",
+            email,
+        )
+        raise ValueError(
+            "Email contains characters not allowed in Django usernames. Fix the Cognito pre-signup Lambda allow-list."
+        )
+
+    return email

--- a/shifter/shifter_platform/tests/mission_control/test_oidc.py
+++ b/shifter/shifter_platform/tests/mission_control/test_oidc.py
@@ -6,7 +6,8 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 
-from config.oidc import ShifterOIDCBackend, generate_username, provider_logout_url
+from config.oidc import ShifterOIDCBackend, provider_logout_url
+from config.username import generate_username
 from management.services import get_user_profile
 from risk_register.models import AuditLog
 


### PR DESCRIPTION
## What

Group 5 PR6 of #957 — the **refactor-survival demonstration**: behavior tests survive a real refactor that mock-coupled tests would not.

Moves the standalone Django-username validator `generate_username` (and its `DJANGO_USERNAME_*` constants) from `config/oidc.py` into a dedicated `config/username.py`, and updates the single topology reference `OIDC_USERNAME_ALGO = "config.username.generate_username"`. The validator never belonged inside the OIDC backend module.

## The demonstration

`tests/mission_control/test_oidc.py`'s `ShifterOIDCBackend` behavior tests exercise `generate_username` **only through the real OIDC `create_user`/`update_user` login flow** (resolved via `OIDC_USERNAME_ALGO`), never naming the function's location — so they pass **unchanged** across the move. Only the function's own direct unit tests (`TestGenerateUsername`) updated their import to follow it. A mock-coupled test that had patched `config.oidc.generate_username` would have broken on the move; the behavior tests did not.

This closes out #957 (the boundary-mock rewrite + this proof). Documented in `docs/adr/README.md`.

## Testing

- `tests/config/` + `tests/mission_control/test_oidc.py`: 118 pass (`-n0`); OIDC behavior tests unchanged.
- `adr_guard.py --all` passes; full pre-commit suite passes.
- No behavior change (pure relocation).