### PR TITLE
changed(cyberscript): swap-tolerant schema persistence with slug registry

### DIFF
--- a/changelog.d/951.changed.md
+++ b/changelog.d/951.changed.md
@@ -1,1 +1,3 @@
 Internal schema persistence now uses stable registry slugs for catalog types and versioned discriminators on persisted spec JSON blobs, enabling a future aces-sdl swap without rewriting module paths in the database.
+
+SonarCloud on path-filtered PRs now downloads coverage artifacts only for test jobs that actually ran, fixing PR Gate failures when unrelated suites (for example packer) were skipped.

--- a/changelog.d/951.changed.md
+++ b/changelog.d/951.changed.md
@@ -1,0 +1,1 @@
+Internal schema persistence now uses stable registry slugs for catalog types and versioned discriminators on persisted spec JSON blobs, enabling a future aces-sdl swap without rewriting module paths in the database.

--- a/shifter/cyberscript/persisted_envelope.py
+++ b/shifter/cyberscript/persisted_envelope.py
@@ -1,0 +1,44 @@
+"""Pure dict helpers for persisted spec envelopes (no Pydantic dependency).
+
+Lives at the cyberscript package root so the ECS provisioner can import it
+without loading the full Pydantic schema graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+SPEC_SCHEMA_KEY = "spec_schema"
+SPEC_VERSION_KEY = "spec_version"
+PAYLOAD_KEY = "payload"
+SPEC_VERSION = "1"
+
+
+def is_wrapped_persisted_spec(blob: dict[str, Any] | None) -> bool:
+    return bool(blob and SPEC_SCHEMA_KEY in blob and PAYLOAD_KEY in blob)
+
+
+def unwrap_persisted_spec(blob: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the inner payload dict, passing legacy undiscriminated blobs through."""
+    if not blob:
+        return {}
+    if is_wrapped_persisted_spec(blob):
+        payload = blob[PAYLOAD_KEY]
+        if isinstance(payload, dict):
+            return payload
+        msg = f"Expected dict payload for persisted spec, got {type(payload).__name__}"
+        raise TypeError(msg)
+    return blob
+
+
+def ensure_wrapped_persisted_spec(slug: str, blob: dict[str, Any] | None) -> dict[str, Any]:
+    """Return ``blob`` wrapped when it is legacy undiscriminated payload."""
+    if not blob:
+        return {}
+    if is_wrapped_persisted_spec(blob):
+        return blob
+    return {
+        SPEC_SCHEMA_KEY: slug,
+        SPEC_VERSION_KEY: SPEC_VERSION,
+        PAYLOAD_KEY: blob,
+    }

--- a/shifter/cyberscript/schemas/persistence.py
+++ b/shifter/cyberscript/schemas/persistence.py
@@ -1,0 +1,57 @@
+"""Wrap and unwrap persisted spec JSON with schema/version discriminators."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from cyberscript.persisted_envelope import (
+    PAYLOAD_KEY,
+    SPEC_SCHEMA_KEY,
+    SPEC_VERSION,
+    SPEC_VERSION_KEY,
+    ensure_wrapped_persisted_spec,
+    is_wrapped_persisted_spec,
+    unwrap_persisted_spec,
+)
+from .registry import get_model_for_slug
+
+
+def wrap_persisted_spec(slug: str, model: BaseModel, *, mode: str = "json") -> dict[str, Any]:
+    """Serialize a Pydantic model with schema/version metadata for DB storage."""
+    if not isinstance(model, BaseModel):
+        msg = f"wrap_persisted_spec expects a Pydantic model, got {type(model).__name__}"
+        raise TypeError(msg)
+    get_model_for_slug(slug)
+    return {
+        SPEC_SCHEMA_KEY: slug,
+        SPEC_VERSION_KEY: SPEC_VERSION,
+        PAYLOAD_KEY: model.model_dump(mode=mode),  # type: ignore[arg-type]
+    }
+
+
+def validate_persisted_spec(blob: dict[str, Any], slug: str) -> BaseModel:
+    """Validate a persisted blob (new or legacy format) against the expected schema."""
+    if blob.get(SPEC_SCHEMA_KEY) and blob[SPEC_SCHEMA_KEY] != slug:
+        msg = f"spec_schema mismatch: expected {slug}, got {blob[SPEC_SCHEMA_KEY]}"
+        raise ValueError(msg)
+    if blob.get(SPEC_VERSION_KEY) and blob[SPEC_VERSION_KEY] != SPEC_VERSION:
+        msg = f"Unsupported spec_version: {blob[SPEC_VERSION_KEY]}"
+        raise ValueError(msg)
+    model_cls = get_model_for_slug(slug)
+    payload = unwrap_persisted_spec(blob)
+    return model_cls.model_validate(payload)
+
+
+__all__ = [
+    "PAYLOAD_KEY",
+    "SPEC_SCHEMA_KEY",
+    "SPEC_VERSION",
+    "SPEC_VERSION_KEY",
+    "ensure_wrapped_persisted_spec",
+    "is_wrapped_persisted_spec",
+    "unwrap_persisted_spec",
+    "validate_persisted_spec",
+    "wrap_persisted_spec",
+]

--- a/shifter/cyberscript/schemas/registry.py
+++ b/shifter/cyberscript/schemas/registry.py
@@ -1,0 +1,63 @@
+"""Stable slug registry for cyberscript Pydantic schema classes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+LEGACY_DOTTED_PATH_TO_SLUG: dict[str, str] = {
+    "shared.schemas.SCMCredentialSpec": "credential.scm",
+    "shared.schemas.DeploymentProfileSpec": "credential.deployment_profile",
+    "shared.schemas.range.InstanceSpec": "instance.panw-ngfw",
+    "shared.schemas.app.NGFWAppSpec": "app.panw-ngfw",
+}
+
+
+class UnknownSpecSlugError(LookupError):
+    """Raised when a slug is not registered."""
+
+
+def _build_registry() -> dict[str, type[BaseModel]]:
+    from .app import NGFWAppSpec
+    from .credentials import DeploymentProfileSpec, SCMCredentialSpec
+    from .range import InstanceSpec, RangeSpec
+    from .subnet import SubnetSpec
+
+    return {
+        "credential.scm": SCMCredentialSpec,
+        "credential.deployment_profile": DeploymentProfileSpec,
+        "instance.panw-ngfw": InstanceSpec,
+        "app.panw-ngfw": NGFWAppSpec,
+        "range_spec": RangeSpec,
+        "instance_spec": InstanceSpec,
+        "subnet_spec": SubnetSpec,
+        "ngfw_app_spec": NGFWAppSpec,
+    }
+
+
+_REGISTRY: dict[str, type[BaseModel]] | None = None
+
+
+def _registry() -> dict[str, type[BaseModel]]:
+    global _REGISTRY  # noqa: PLW0603
+    if _REGISTRY is None:
+        _REGISTRY = _build_registry()
+    return _REGISTRY
+
+
+def get_model_for_slug(slug: str) -> type[BaseModel]:
+    """Return the Pydantic model class for a stable schema slug."""
+    try:
+        return _registry()[slug]
+    except KeyError as exc:
+        raise UnknownSpecSlugError(f"Unknown schema slug: {slug}") from exc
+
+
+def resolve_catalog_slug(dotted_path: str) -> str:
+    """Map a legacy catalog ``spec_class`` dotted path to its slug."""
+    try:
+        return LEGACY_DOTTED_PATH_TO_SLUG[dotted_path]
+    except KeyError as exc:
+        raise UnknownSpecSlugError(f"Unknown legacy spec_class path: {dotted_path}") from exc

--- a/shifter/engine/provisioner/config.py
+++ b/shifter/engine/provisioner/config.py
@@ -719,7 +719,9 @@ def get_range_from_db(range_id: int) -> dict[str, Any]:
             raise ValueError(f"Range {range_id} not found")
 
         user_id = row[1]
-        range_config = row[3] or {}
+        from cyberscript.persisted_envelope import unwrap_persisted_spec
+
+        range_config = unwrap_persisted_spec(row[3] or {})
 
         # Check if scenario requires NGFW (ngfw: true in range_config)
         ngfw_enabled = range_config.get("ngfw", False)

--- a/shifter/engine/provisioner/provisioner_db.py
+++ b/shifter/engine/provisioner/provisioner_db.py
@@ -268,10 +268,13 @@ def mark_range_instances_destroyed(range_id: int) -> tuple[int, int]:
 
 def _update_range_config(range_id: int, range_spec: dict[str, Any]) -> None:
     """Write updated range_config back to mission_control_range."""
+    from cyberscript.persisted_envelope import ensure_wrapped_persisted_spec
+
+    wrapped = ensure_wrapped_persisted_spec("range_spec", range_spec)
     with get_db_connection() as conn, conn.cursor() as cur:
         cur.execute(
             "UPDATE mission_control_range SET range_config = %s WHERE id = %s",
-            (json.dumps(range_spec), range_id),
+            (json.dumps(wrapped), range_id),
         )
         conn.commit()
     logger.info("Persisted updated range_config for range %d", range_id)
@@ -299,7 +302,10 @@ def get_range_data_by_request_id(request_id: str) -> dict[str, Any]:
         if not row:
             raise ValueError(f"Range request not found: {request_id}")
 
-        range_config = row[3] if row[3] else {}
+        range_config_raw = row[3] if row[3] else {}
+        from cyberscript.persisted_envelope import unwrap_persisted_spec
+
+        range_config = unwrap_persisted_spec(range_config_raw)
         user_id = row[2]
         ngfw_instance_id = None
 

--- a/shifter/engine/provisioner/provisioner_db_ngfw.py
+++ b/shifter/engine/provisioner/provisioner_db_ngfw.py
@@ -155,12 +155,14 @@ def get_ngfw_data_by_request_id(request_id: str) -> dict[str, Any]:
         row = cur.fetchone()
         if not row:
             raise ValueError(f"NGFW request not found: {request_id}")
+        from cyberscript.persisted_envelope import unwrap_persisted_spec
+
         return {
             "request_id": str(row[0]),
             "instance_id": str(row[1]),
             "app_id": str(row[2]) if row[2] else None,
-            "spec": row[3] if row[3] else {},
-            "app_spec": row[4] if row[4] else {},
+            "spec": unwrap_persisted_spec(row[3] if row[3] else {}),
+            "app_spec": unwrap_persisted_spec(row[4] if row[4] else {}),
             "state": row[5] if row[5] else {},
             "status": row[6],
         }

--- a/shifter/engine/provisioner/tests/test_module_coupling_coverage.py
+++ b/shifter/engine/provisioner/tests/test_module_coupling_coverage.py
@@ -381,7 +381,11 @@ def test_provisioner_db_status_helpers_use_owning_module_connection(monkeypatch:
     _update_range_config(42, {"subnets": [{"name": "attack", "cidr": "10.1.2.0/28"}]})
 
     saved_spec, saved_range_id = config_cursor.execute_calls[0][1]
-    assert json.loads(saved_spec) == {"subnets": [{"name": "attack", "cidr": "10.1.2.0/28"}]}
+    assert json.loads(saved_spec) == {
+        "spec_schema": "range_spec",
+        "spec_version": "1",
+        "payload": {"subnets": [{"name": "attack", "cidr": "10.1.2.0/28"}]},
+    }
     assert saved_range_id == 42
     config_conn.commit.assert_called_once_with()
 

--- a/shifter/shifter_platform/cms/migrations/0030_spec_slug_registry.py
+++ b/shifter/shifter_platform/cms/migrations/0030_spec_slug_registry.py
@@ -1,0 +1,119 @@
+# Migrate catalog spec_class dotted paths to stable spec_slug values.
+
+from django.db import migrations, models
+
+LEGACY_DOTTED_PATH_TO_SLUG = {
+    "shared.schemas.SCMCredentialSpec": "credential.scm",
+    "shared.schemas.DeploymentProfileSpec": "credential.deployment_profile",
+    "shared.schemas.range.InstanceSpec": "instance.panw-ngfw",
+    "shared.schemas.app.NGFWAppSpec": "app.panw-ngfw",
+}
+
+CATALOG_MODELS = ("CredentialType", "InstanceType", "AppType")
+
+SPEC_SCHEMA_KEY = "spec_schema"
+SPEC_VERSION_KEY = "spec_version"
+PAYLOAD_KEY = "payload"
+SPEC_VERSION = "1"
+RANGE_SPEC_SLUG = "range_spec"
+
+
+def _is_wrapped(blob):
+    return isinstance(blob, dict) and SPEC_SCHEMA_KEY in blob and PAYLOAD_KEY in blob
+
+
+def _wrap_range_instance_specs(apps, schema_editor):
+    range_instance = apps.get_model("cms", "RangeInstance")
+    for row in range_instance.objects.exclude(range_spec__isnull=True).iterator():
+        if _is_wrapped(row.range_spec):
+            continue
+        row.range_spec = {
+            SPEC_SCHEMA_KEY: RANGE_SPEC_SLUG,
+            SPEC_VERSION_KEY: SPEC_VERSION,
+            PAYLOAD_KEY: row.range_spec,
+        }
+        row.save(update_fields=["range_spec"])
+
+
+def _unwrap_range_instance_specs(apps, schema_editor):
+    range_instance = apps.get_model("cms", "RangeInstance")
+    for row in range_instance.objects.exclude(range_spec__isnull=True).iterator():
+        if not _is_wrapped(row.range_spec):
+            continue
+        row.range_spec = row.range_spec[PAYLOAD_KEY]
+        row.save(update_fields=["range_spec"])
+
+
+def _migrate_spec_class_to_slug(apps, schema_editor):
+    for model_name in CATALOG_MODELS:
+        model = apps.get_model("cms", model_name)
+        for row in model.objects.all().iterator():
+            slug = LEGACY_DOTTED_PATH_TO_SLUG.get(row.spec_class)
+            if slug is None:
+                msg = f"Unknown spec_class on {model_name} id={row.pk}: {row.spec_class!r}"
+                raise ValueError(msg)
+            row.spec_class = slug
+            row.save(update_fields=["spec_class"])
+
+
+def _migrate_slug_to_spec_class(apps, schema_editor):
+    slug_to_path = {v: k for k, v in LEGACY_DOTTED_PATH_TO_SLUG.items()}
+    for model_name in CATALOG_MODELS:
+        model = apps.get_model("cms", model_name)
+        for row in model.objects.all().iterator():
+            path = slug_to_path.get(row.spec_class)
+            if path is None:
+                msg = f"Unknown spec_slug on {model_name} id={row.pk}: {row.spec_class!r}"
+                raise ValueError(msg)
+            row.spec_class = path
+            row.save(update_fields=["spec_class"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0029_encrypt_sensitive_instance_data"),
+    ]
+
+    operations = [
+        migrations.RunPython(_migrate_spec_class_to_slug, _migrate_slug_to_spec_class),
+        migrations.RunPython(_wrap_range_instance_specs, _unwrap_range_instance_specs),
+        migrations.RenameField(
+            model_name="credentialtype",
+            old_name="spec_class",
+            new_name="spec_slug",
+        ),
+        migrations.RenameField(
+            model_name="instancetype",
+            old_name="spec_class",
+            new_name="spec_slug",
+        ),
+        migrations.RenameField(
+            model_name="apptype",
+            old_name="spec_class",
+            new_name="spec_slug",
+        ),
+        migrations.AlterField(
+            model_name="credentialtype",
+            name="spec_slug",
+            field=models.CharField(
+                help_text="Stable slug for Pydantic spec class (shared.schemas.registry)",
+                max_length=255,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="instancetype",
+            name="spec_slug",
+            field=models.CharField(
+                help_text="Stable slug for Pydantic spec class (shared.schemas.registry)",
+                max_length=255,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="apptype",
+            name="spec_slug",
+            field=models.CharField(
+                help_text="Stable slug for Pydantic spec class (shared.schemas.registry)",
+                max_length=255,
+            ),
+        ),
+    ]

--- a/shifter/shifter_platform/cms/models/catalogs.py
+++ b/shifter/shifter_platform/cms/models/catalogs.py
@@ -26,8 +26,8 @@ class CatalogBase(models.Model):
     Catalog entities are reference data that define available types,
     not user-owned instances. Examples: CredentialType, ScenarioType.
 
-    The ``spec_class`` field declares the dotted path to the Pydantic spec
-    class used to validate per-row payloads; it is owned by the abstract
+    The ``spec_slug`` field declares the stable registry slug for the Pydantic
+    spec class used to validate per-row payloads; it is owned by the abstract
     base because every concrete catalog needs it (and ``get_spec_class`` /
     ``validate_data`` here read it).
 
@@ -35,15 +35,15 @@ class CatalogBase(models.Model):
         name: Human-readable name for display.
         slug: URL-safe identifier for lookups.
         created_at: When this catalog entry was created.
-        spec_class: Dotted path to the Pydantic spec class for validation.
+        spec_slug: Stable slug resolved through ``shared.schemas.registry``.
     """
 
     name = models.CharField(max_length=100, help_text="Display name")
     slug = models.SlugField(max_length=50, unique=True, help_text="URL-safe identifier")
     created_at = models.DateTimeField(auto_now_add=True)
-    spec_class = models.CharField(
+    spec_slug = models.CharField(
         max_length=255,
-        help_text="Dotted path to Pydantic spec class",
+        help_text="Stable slug for Pydantic spec class (shared.schemas.registry)",
     )
 
     class Meta:
@@ -53,22 +53,22 @@ class CatalogBase(models.Model):
         return self.name
 
     def get_spec_class(self):
-        """Load and return the Pydantic spec class.
+        """Load and return the Pydantic spec class via the schema registry.
 
-        Requires subclass to define a `spec_class` CharField.
+        Requires subclass to define a ``spec_slug`` CharField.
 
         Returns:
             The Pydantic model class for validating data.
 
         Raises:
-            AttributeError: If subclass doesn't define spec_class.
-            ImportError: If the spec_class path is invalid.
+            AttributeError: If subclass doesn't define spec_slug.
+            LookupError: If spec_slug is unknown to the registry.
         """
-        from importlib import import_module
+        from shared.schemas.registry import get_model_for_slug
 
-        module_path, class_name = self.spec_class.rsplit(".", 1)
-        module = import_module(module_path)
-        return getattr(module, class_name)
+        if not getattr(self, "spec_slug", None):
+            raise AttributeError(f"{self.__class__.__name__} does not define spec_slug")
+        return get_model_for_slug(self.spec_slug)
 
     def validate_data(self, data: dict) -> dict:
         """Validate data against this type's spec.
@@ -165,9 +165,9 @@ class CredentialType(CatalogBase):
     """Catalog of credential types.
 
     Type Object pattern: types are data rows, not code enums. Each row
-    defines a credential type; ``spec_class`` (inherited from
+    defines a credential type; ``spec_slug`` (inherited from
     :class:`CatalogBase`) points at the Pydantic spec for per-credential
-    data validation, e.g. ``'shared.schemas.SCMCredentialSpec'``.
+    data validation via the schema registry.
     """
 
     class Meta:
@@ -178,9 +178,9 @@ class CredentialType(CatalogBase):
 class InstanceType(CatalogBase):
     """Catalog of instance types (container, vm, etc).
 
-    Type Object pattern: types are data rows, not code enums. ``spec_class``
+    Type Object pattern: types are data rows, not code enums. ``spec_slug``
     (inherited from :class:`CatalogBase`) points at the Pydantic spec for
-    per-instance data validation.
+    per-instance data validation via the schema registry.
     """
 
     class Meta:
@@ -191,9 +191,9 @@ class InstanceType(CatalogBase):
 class AppType(CatalogBase):
     """Catalog of app types (os, ngfw, agent, other).
 
-    Type Object pattern: types are data rows, not code enums. ``spec_class``
+    Type Object pattern: types are data rows, not code enums. ``spec_slug``
     (inherited from :class:`CatalogBase`) points at the Pydantic spec for
-    per-app data validation.
+    per-app data validation via the schema registry.
     """
 
     class Meta:

--- a/shifter/shifter_platform/cms/services/_common.py
+++ b/shifter/shifter_platform/cms/services/_common.py
@@ -181,9 +181,15 @@ def _flatten_range_spec_instances(range_spec: dict[str, Any] | None) -> list[dic
     - Current: instances nested under subnets (`range_spec["subnets"][*]["instances"]`)
     - Legacy: a flat `range_spec["instances"]` list (preserved for backward
       compatibility with existing prod rows)
+
+    New rows may carry ``spec_schema`` / ``spec_version`` / ``payload`` metadata;
+    those are unwrapped before shape detection.
     """
+    from shared.schemas.persistence import unwrap_persisted_spec
+
     if not range_spec:
         return []
+    range_spec = unwrap_persisted_spec(range_spec)
     subnet_specs = range_spec.get("subnets")
     if subnet_specs is not None:
         return [spec for subnet in subnet_specs for spec in subnet.get("instances", [])]

--- a/shifter/shifter_platform/cms/services/_range_create.py
+++ b/shifter/shifter_platform/cms/services/_range_create.py
@@ -11,6 +11,7 @@ from cms.models import AgentConfig, RangeInstance
 from risk_register.models import AuditLog
 from shared.constants import USER_CANNOT_BE_NONE, USER_MUST_BE_SAVED
 from shared.enums import ResourceStatus
+from shared.schemas.persistence import wrap_persisted_spec
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -185,7 +186,7 @@ def _persist_range_instance_record(
         scenario_id=scenario,
         user_id=user.id,
         agent=first_agent,
-        range_spec=range_spec.model_dump(mode="json"),
+        range_spec=wrap_persisted_spec("range_spec", range_spec),
     )
 
 

--- a/shifter/shifter_platform/engine/admin.py
+++ b/shifter/shifter_platform/engine/admin.py
@@ -3,6 +3,7 @@
 from django.contrib import admin
 
 from engine.models import Range, SubnetAllocation
+from shared.schemas.persistence import unwrap_persisted_spec
 
 
 @admin.register(Range)
@@ -15,7 +16,7 @@ class RangeAdmin(admin.ModelAdmin):
     @admin.display(description="Scenario")
     def scenario_id(self, obj):
         if obj.range_config:
-            return obj.range_config.get("scenario_id", "—")
+            return unwrap_persisted_spec(obj.range_config).get("scenario_id", "—")
         return "—"
 
 

--- a/shifter/shifter_platform/engine/interpreter.py
+++ b/shifter/shifter_platform/engine/interpreter.py
@@ -12,6 +12,8 @@ from uuid import uuid4
 
 from django.db import transaction
 
+from shared.schemas.persistence import wrap_persisted_spec
+
 if TYPE_CHECKING:
     from engine.models import App, Instance, Request, Subnet
     from shared.schemas import InstanceSpec, RangeSpec, RequestSpec, SubnetSpec
@@ -116,7 +118,7 @@ def _interpret_instance(instance_spec: InstanceSpec, request: Request, subnet: S
         subnet=subnet,
         role=instance_spec.role,
         os_type=instance_spec.os_type,
-        spec=instance_spec.model_dump(mode="json"),
+        spec=wrap_persisted_spec("instance_spec", instance_spec),
         status=ResourceStatus.PENDING.value,
     )
 
@@ -145,7 +147,7 @@ def _interpret_ngfw_app(ngfw_app_spec, instance: Instance, request: Request) -> 
         "request": request,
         "instance": instance,
         "app_type": App.AppType.NGFW,
-        "spec": ngfw_app_spec.model_dump(mode="json"),
+        "spec": wrap_persisted_spec("ngfw_app_spec", ngfw_app_spec),
         "status": ResourceStatus.PENDING.value,
     }
     if ngfw_app_spec.app_id:
@@ -185,7 +187,7 @@ def _interpret_subnet(subnet_spec: SubnetSpec, request: Request) -> Subnet:
         request=request,
         name=subnet_spec.name,
         connected_to=subnet_spec.connected_to,
-        spec=subnet_spec.model_dump(mode="json"),
+        spec=wrap_persisted_spec("subnet_spec", subnet_spec),
         status=ResourceStatus.PENDING.value,
     )
 

--- a/shifter/shifter_platform/engine/migrations/0021_wrap_persisted_spec_discriminators.py
+++ b/shifter/shifter_platform/engine/migrations/0021_wrap_persisted_spec_discriminators.py
@@ -1,0 +1,81 @@
+# Wrap persisted engine JSON blobs with spec_schema/spec_version discriminators.
+
+from django.db import migrations
+
+SPEC_SCHEMA_KEY = "spec_schema"
+SPEC_VERSION_KEY = "spec_version"
+PAYLOAD_KEY = "payload"
+SPEC_VERSION = "1"
+
+INSTANCE_SPEC_SLUG = "instance_spec"
+SUBNET_SPEC_SLUG = "subnet_spec"
+NGFW_APP_SPEC_SLUG = "ngfw_app_spec"
+RANGE_SPEC_SLUG = "range_spec"
+
+
+def _is_wrapped(blob):
+    return isinstance(blob, dict) and SPEC_SCHEMA_KEY in blob and PAYLOAD_KEY in blob
+
+
+def _wrap_blob(slug, blob):
+    if not blob or _is_wrapped(blob):
+        return blob
+    return {
+        SPEC_SCHEMA_KEY: slug,
+        SPEC_VERSION_KEY: SPEC_VERSION,
+        PAYLOAD_KEY: blob,
+    }
+
+
+def _unwrap_blob(blob):
+    if not blob or not _is_wrapped(blob):
+        return blob
+    return blob[PAYLOAD_KEY]
+
+
+def _wrap_persisted_specs(apps, schema_editor):
+    range_model = apps.get_model("engine", "Range")
+    for row in range_model.objects.exclude(range_config__isnull=True).iterator():
+        wrapped = _wrap_blob(RANGE_SPEC_SLUG, row.range_config)
+        if wrapped != row.range_config:
+            row.range_config = wrapped
+            row.save(update_fields=["range_config"])
+
+    for model_name, slug in (
+        ("Instance", INSTANCE_SPEC_SLUG),
+        ("App", NGFW_APP_SPEC_SLUG),
+        ("Subnet", SUBNET_SPEC_SLUG),
+    ):
+        model = apps.get_model("engine", model_name)
+        for row in model.objects.exclude(spec__isnull=True).iterator():
+            wrapped = _wrap_blob(slug, row.spec)
+            if wrapped != row.spec:
+                row.spec = wrapped
+                row.save(update_fields=["spec"])
+
+
+def _unwrap_persisted_specs(apps, schema_editor):
+    range_model = apps.get_model("engine", "Range")
+    for row in range_model.objects.exclude(range_config__isnull=True).iterator():
+        unwrapped = _unwrap_blob(row.range_config)
+        if unwrapped != row.range_config:
+            row.range_config = unwrapped
+            row.save(update_fields=["range_config"])
+
+    for model_name in ("Instance", "App", "Subnet"):
+        model = apps.get_model("engine", model_name)
+        for row in model.objects.exclude(spec__isnull=True).iterator():
+            unwrapped = _unwrap_blob(row.spec)
+            if unwrapped != row.spec:
+                row.spec = unwrapped
+                row.save(update_fields=["spec"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("engine", "0020_remove_subnetallocation_unique_active_cidr_per_vpc_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(_wrap_persisted_specs, _unwrap_persisted_specs),
+    ]

--- a/shifter/shifter_platform/engine/models.py
+++ b/shifter/shifter_platform/engine/models.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.db import models, transaction
 
 from shared.enums import RequestType
+from shared.schemas.persistence import unwrap_persisted_spec
 
 
 class Request(models.Model):
@@ -325,7 +326,8 @@ class Range(models.Model):
         db_table = "mission_control_range"
 
     def __str__(self):
-        scenario = self.range_config.get("scenario_id", "unknown") if self.range_config else "unknown"
+        config = unwrap_persisted_spec(self.range_config) if self.range_config else {}
+        scenario = config.get("scenario_id", "unknown")
         return f"Range {self.id} ({scenario}) - {self.status}"
 
     @property
@@ -564,7 +566,8 @@ class Subnet(Instantiation):
         """
         if not self.spec:
             return []
-        instances = self.spec.get("instances", [])
+        spec_payload = unwrap_persisted_spec(self.spec)
+        instances = spec_payload.get("instances", [])
         return [inst.get("uuid") for inst in instances if inst.get("uuid")]
 
 

--- a/shifter/shifter_platform/engine/services/_range.py
+++ b/shifter/shifter_platform/engine/services/_range.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from shared.enums import CANCELLABLE_STATUSES, ResourceStatus
 from shared.schemas import RangeContext, RangeSpec, RequestSpec
+from shared.schemas.persistence import wrap_persisted_spec
 
 from ._common import EngineError, _resolve_instance_host
 
@@ -100,7 +101,7 @@ def _persist_range_atomically(
                 cms_user_id=range_spec.user_id,
                 status=range_model.Status.PROVISIONING,
                 subnet_index=subnet_index,
-                range_config=range_spec.model_dump(),
+                range_config=wrap_persisted_spec("range_spec", range_spec),
             )
         else:
             range_obj = range_model.objects.create(
@@ -109,7 +110,7 @@ def _persist_range_atomically(
                 cms_user_id=range_spec.user_id,
                 status=range_model.Status.PROVISIONING,
                 subnet_index=subnet_index,
-                range_config=range_spec.model_dump(),
+                range_config=wrap_persisted_spec("range_spec", range_spec),
             )
 
         logger.info(

--- a/shifter/shifter_platform/shared/schemas/persistence.py
+++ b/shifter/shifter_platform/shared/schemas/persistence.py
@@ -1,0 +1,25 @@
+"""Wrap and unwrap persisted spec JSON with schema/version discriminators."""
+
+from cyberscript.schemas.persistence import (
+    PAYLOAD_KEY,
+    SPEC_SCHEMA_KEY,
+    SPEC_VERSION,
+    SPEC_VERSION_KEY,
+    ensure_wrapped_persisted_spec,
+    is_wrapped_persisted_spec,
+    unwrap_persisted_spec,
+    validate_persisted_spec,
+    wrap_persisted_spec,
+)
+
+__all__ = [
+    "PAYLOAD_KEY",
+    "SPEC_SCHEMA_KEY",
+    "SPEC_VERSION",
+    "SPEC_VERSION_KEY",
+    "ensure_wrapped_persisted_spec",
+    "is_wrapped_persisted_spec",
+    "unwrap_persisted_spec",
+    "validate_persisted_spec",
+    "wrap_persisted_spec",
+]

--- a/shifter/shifter_platform/shared/schemas/registry.py
+++ b/shifter/shifter_platform/shared/schemas/registry.py
@@ -1,0 +1,15 @@
+"""Stable slug registry for cyberscript Pydantic schema classes."""
+
+from cyberscript.schemas.registry import (
+    LEGACY_DOTTED_PATH_TO_SLUG,
+    UnknownSpecSlugError,
+    get_model_for_slug,
+    resolve_catalog_slug,
+)
+
+__all__ = [
+    "LEGACY_DOTTED_PATH_TO_SLUG",
+    "UnknownSpecSlugError",
+    "get_model_for_slug",
+    "resolve_catalog_slug",
+]

--- a/shifter/shifter_platform/tests/cms/conftest.py
+++ b/shifter/shifter_platform/tests/cms/conftest.py
@@ -131,7 +131,7 @@ def credential_type_obj():
     ct = CredentialType(
         name="Deployment Profile",
         slug="deployment_profile",
-        spec_class="shared.schemas.DeploymentProfileSpec",
+        spec_slug="credential.deployment_profile",
     )
     ct.pk = 1
     ct.id = 1
@@ -144,7 +144,7 @@ def scm_credential_type_obj():
     ct = CredentialType(
         name="SCM Credential",
         slug="scm",
-        spec_class="shared.schemas.SCMCredentialSpec",
+        spec_slug="credential.scm",
     )
     ct.pk = 2
     ct.id = 2

--- a/shifter/shifter_platform/tests/cms/test_credential_encryption.py
+++ b/shifter/shifter_platform/tests/cms/test_credential_encryption.py
@@ -224,7 +224,7 @@ class TestCredentialDataORMRoundTrip:
             slug="deployment_profile",
             defaults={
                 "name": "NGFW Deployment Profile",
-                "spec_class": "shared.schemas.DeploymentProfileSpec",
+                "spec_slug": "credential.deployment_profile",
             },
         )
         return ct
@@ -295,7 +295,7 @@ class TestInstanceDataORMRoundTrip:
             slug="panw-ngfw",
             defaults={
                 "name": "PANW NGFW",
-                "spec_class": "shared.schemas.range.InstanceSpec",
+                "spec_slug": "instance.panw-ngfw",
             },
         )
         return it

--- a/shifter/shifter_platform/tests/cms/test_credentials.py
+++ b/shifter/shifter_platform/tests/cms/test_credentials.py
@@ -21,7 +21,7 @@ def scm_credential_type():
             "id": 1,
             "name": "SCM Registration",
             "slug": "scm",
-            "spec_class": "shared.schemas.SCMCredentialSpec",
+            "spec_slug": "credential.scm",
         }
     )
     return ct
@@ -38,7 +38,7 @@ def deployment_profile_type():
             "id": 2,
             "name": "NGFW Deployment Profile",
             "slug": "deployment_profile",
-            "spec_class": "shared.schemas.DeploymentProfileSpec",
+            "spec_slug": "credential.deployment_profile",
         }
     )
     return ct
@@ -99,7 +99,7 @@ def _real_user(suffix):
 def _real_ct(slug, spec):
     from cms.models import CredentialType
 
-    return CredentialType.objects.get_or_create(slug=slug, defaults={"name": slug, "spec_class": spec})[0]
+    return CredentialType.objects.get_or_create(slug=slug, defaults={"name": slug, "spec_slug": spec})[0]
 
 
 # ---------------------------------------------------------------------------
@@ -115,14 +115,12 @@ class TestCredentialType:
         """CredentialType can be created with required fields."""
         from cms.models import CredentialType
 
-        cred_type = CredentialType.objects.create(
-            name="Test Type", slug="test-cred-type", spec_class="shared.schemas.SCMCredentialSpec"
-        )
+        cred_type = CredentialType.objects.create(name="Test Type", slug="test-cred-type", spec_slug="credential.scm")
 
         persisted = CredentialType.objects.get(pk=cred_type.pk)
         assert persisted.name == "Test Type"
         assert persisted.slug == "test-cred-type"
-        assert persisted.spec_class == "shared.schemas.SCMCredentialSpec"
+        assert persisted.spec_slug == "credential.scm"
 
     def test_get_spec_class_loads_scm_spec(self, scm_credential_type):
         """get_spec_class() should load SCMCredentialSpec."""

--- a/shifter/shifter_platform/tests/cms/test_handlers.py
+++ b/shifter/shifter_platform/tests/cms/test_handlers.py
@@ -298,12 +298,12 @@ def _make_instance_and_app(user, *, status=ResourceStatus.PROVISIONING.value):
     instance_type = InstanceType.objects.create(
         name="Handler Test Instance Type",
         slug=f"handler-it-{uuid4().hex[:8]}",
-        spec_class="shared.schemas.SCMCredentialSpec",
+        spec_slug="credential.scm",
     )
     app_type = AppType.objects.create(
         name="Handler Test App Type",
         slug=f"handler-at-{uuid4().hex[:8]}",
-        spec_class="shared.schemas.SCMCredentialSpec",
+        spec_slug="credential.scm",
     )
     instance = Instance.objects.create(request=req, name="ngfw-instance", instance_type=instance_type, status=status)
     app = App.objects.create(name="ngfw-app", app_type=app_type, instance=instance, status=status)

--- a/shifter/shifter_platform/tests/cms/test_handlers_ngfw.py
+++ b/shifter/shifter_platform/tests/cms/test_handlers_ngfw.py
@@ -37,7 +37,7 @@ def instance(request_obj):
     instance_type = InstanceType.objects.create(
         name="NGFW Test Instance Type",
         slug=f"ngfw-it-{uuid4().hex[:8]}",
-        spec_class="shared.schemas.SCMCredentialSpec",
+        spec_slug="credential.scm",
     )
     return Instance.objects.create(
         request=request_obj,
@@ -52,7 +52,7 @@ def app(instance):
     app_type = AppType.objects.create(
         name="NGFW Test App Type",
         slug=f"ngfw-at-{uuid4().hex[:8]}",
-        spec_class="shared.schemas.SCMCredentialSpec",
+        spec_slug="credential.scm",
     )
     return App.objects.create(
         name="ngfw-app",

--- a/shifter/shifter_platform/tests/cms/test_models.py
+++ b/shifter/shifter_platform/tests/cms/test_models.py
@@ -29,7 +29,7 @@ def _real_ct():
     """Get or create a real (saved) deployment-profile CredentialType."""
     ct, _ = CredentialType.objects.get_or_create(
         slug="deployment_profile",
-        defaults={"name": "Deployment Profile", "spec_class": "shared.schemas.DeploymentProfileSpec"},
+        defaults={"name": "Deployment Profile", "spec_slug": "credential.deployment_profile"},
     )
     return ct
 
@@ -187,7 +187,7 @@ class TestCredentialRelationships:
     def test_credential_protected_when_type_deleted(self):
         user = _user("protect")
         ct = CredentialType.objects.create(
-            name="Protected Type", slug="protected_test_type", spec_class="shared.schemas.DeploymentProfileSpec"
+            name="Protected Type", slug="protected_test_type", spec_slug="credential.deployment_profile"
         )
         _real_cred(user, "Using Type", ct=ct)
         with pytest.raises(ProtectedError), transaction.atomic():
@@ -198,9 +198,9 @@ class TestCredentialRelationships:
 class TestCredentialType:
     def test_slug_unique(self):
         CredentialType.objects.create(
-            name="Unique Test Type", slug="unique_test_slug_x", spec_class="shared.schemas.DeploymentProfileSpec"
+            name="Unique Test Type", slug="unique_test_slug_x", spec_slug="credential.deployment_profile"
         )
         with pytest.raises(IntegrityError), transaction.atomic():
             CredentialType.objects.create(
-                name="Another Test Type", slug="unique_test_slug_x", spec_class="shared.schemas.DeploymentProfileSpec"
+                name="Another Test Type", slug="unique_test_slug_x", spec_slug="credential.deployment_profile"
             )

--- a/shifter/shifter_platform/tests/cms/test_services_ngfws.py
+++ b/shifter/shifter_platform/tests/cms/test_services_ngfws.py
@@ -39,8 +39,8 @@ pytestmark = pytest.mark.django_db
 User = get_user_model()
 
 _CRED_SPEC = {
-    "deployment_profile": "shared.schemas.DeploymentProfileSpec",
-    "scm": "shared.schemas.SCMCredentialSpec",
+    "deployment_profile": "credential.deployment_profile",
+    "scm": "credential.scm",
 }
 _SCM_DATA = {
     "name": "scm",
@@ -63,11 +63,9 @@ def _ngfw_catalog(db):
     from cms.models import AppType, InstanceType
 
     InstanceType.objects.get_or_create(
-        slug="panw-ngfw", defaults={"name": "PAN-OS NGFW", "spec_class": "shared.schemas.range.InstanceSpec"}
+        slug="panw-ngfw", defaults={"name": "PAN-OS NGFW", "spec_slug": "instance.panw-ngfw"}
     )
-    AppType.objects.get_or_create(
-        slug="panw-ngfw", defaults={"name": "PANW NGFW", "spec_class": "shared.schemas.app.NGFWAppSpec"}
-    )
+    AppType.objects.get_or_create(slug="panw-ngfw", defaults={"name": "PANW NGFW", "spec_slug": "app.panw-ngfw"})
 
 
 @pytest.fixture
@@ -78,7 +76,7 @@ def user(db):
 def _credential(user, slug, data):
     from cms.models import Credential, CredentialType
 
-    ct, _ = CredentialType.objects.get_or_create(slug=slug, defaults={"name": slug, "spec_class": _CRED_SPEC[slug]})
+    ct, _ = CredentialType.objects.get_or_create(slug=slug, defaults={"name": slug, "spec_slug": _CRED_SPEC[slug]})
     return Credential.objects.create(user=user, credential_type=ct, name=f"{slug}-cred", data=data)
 
 

--- a/shifter/shifter_platform/tests/engine/services/test_create_range.py
+++ b/shifter/shifter_platform/tests/engine/services/test_create_range.py
@@ -58,6 +58,13 @@ class TestCreateRangePersistence:
         assert range_obj.user == user
         assert range_obj.cms_user_id == user.id
 
+    def test_persists_range_config_with_schema_discriminator(self, user):
+        create_range(make_request_spec(user_id=user.id))
+        range_obj = Range.objects.get()
+        assert range_obj.range_config["spec_schema"] == "range_spec"
+        assert range_obj.range_config["spec_version"] == "1"
+        assert range_obj.range_config["payload"]["scenario_id"] == "basic-attack"
+
     def test_allocates_a_subnet_index(self, user):
         create_range(make_request_spec(user_id=user.id))
         assert Range.objects.get().subnet_index is not None

--- a/shifter/shifter_platform/tests/integration/cms/test_services_credentials.py
+++ b/shifter/shifter_platform/tests/integration/cms/test_services_credentials.py
@@ -57,7 +57,7 @@ def scm_credential_type(db):
         slug="scm",
         defaults={
             "name": "SCM Credential",
-            "spec_class": "shared.schemas.SCMCredentialSpec",
+            "spec_slug": "credential.scm",
         },
     )
     return cred_type
@@ -70,7 +70,7 @@ def deployment_profile_type(db):
         slug="deployment_profile",
         defaults={
             "name": "Deployment Profile",
-            "spec_class": "shared.schemas.DeploymentProfileSpec",
+            "spec_slug": "credential.deployment_profile",
         },
     )
     return cred_type

--- a/shifter/shifter_platform/tests/integration/cms/test_soft_delete_manager.py
+++ b/shifter/shifter_platform/tests/integration/cms/test_soft_delete_manager.py
@@ -187,7 +187,7 @@ class TestSoftDeleteCascadesAndAuditPaths:
         instance_type = InstanceType.objects.create(
             name="Reverse-Test Type",
             slug="reverse-test-type",
-            spec_class="shared.schemas.SCMCredentialSpec",
+            spec_slug="credential.scm",
         )
 
         active_child = Instance.objects.create(

--- a/shifter/shifter_platform/tests/integration/mission_control/test_views_integration.py
+++ b/shifter/shifter_platform/tests/integration/mission_control/test_views_integration.py
@@ -57,7 +57,7 @@ def scm_credential_type(db):
         slug="scm",
         defaults={
             "name": "SCM Credential",
-            "spec_class": "shared.schemas.SCMCredentialSpec",
+            "spec_slug": "credential.scm",
         },
     )
     return cred_type
@@ -70,7 +70,7 @@ def deployment_profile_type(db):
         slug="deployment_profile",
         defaults={
             "name": "Deployment Profile",
-            "spec_class": "shared.schemas.DeploymentProfileSpec",
+            "spec_slug": "credential.deployment_profile",
         },
     )
     return cred_type
@@ -198,8 +198,9 @@ class TestCredentialsListViewIntegration:
         response = authenticated_client.get("/mission-control/credentials/")
 
         assert response.status_code == 200
-        # Context should have counts (we verify via rendered content)
-        # The template uses these counts for UI badges
+        content = response.content.decode()
+        assert "SCM (3)" in content
+        assert "Profiles (2)" in content
 
 
 # =============================================================================

--- a/shifter/shifter_platform/tests/mission_control/conftest.py
+++ b/shifter/shifter_platform/tests/mission_control/conftest.py
@@ -247,11 +247,11 @@ def _ensure_ngfw_catalog():
 
     InstanceType.objects.get_or_create(
         slug="panw-ngfw",
-        defaults={"name": "PAN-OS NGFW", "spec_class": "shared.schemas.range.InstanceSpec"},
+        defaults={"name": "PAN-OS NGFW", "spec_slug": "instance.panw-ngfw"},
     )
     AppType.objects.get_or_create(
         slug="panw-ngfw",
-        defaults={"name": "PANW NGFW", "spec_class": "shared.schemas.app.NGFWAppSpec"},
+        defaults={"name": "PANW NGFW", "spec_slug": "app.panw-ngfw"},
     )
 
 
@@ -308,10 +308,10 @@ def ngfw_credentials(db):
 
         dp_ct, _ = CredentialType.objects.get_or_create(
             slug="deployment_profile",
-            defaults={"name": "deployment_profile", "spec_class": "shared.schemas.DeploymentProfileSpec"},
+            defaults={"name": "deployment_profile", "spec_slug": "credential.deployment_profile"},
         )
         scm_ct, _ = CredentialType.objects.get_or_create(
-            slug="scm", defaults={"name": "scm", "spec_class": "shared.schemas.SCMCredentialSpec"}
+            slug="scm", defaults={"name": "scm", "spec_slug": "credential.scm"}
         )
         deployment_profile = Credential.objects.create(
             user=user, credential_type=dp_ct, name="dp-cred", data={"name": "dp", "authcode": "AUTH-XYZ"}

--- a/shifter/shifter_platform/tests/shared/schemas/test_persistence.py
+++ b/shifter/shifter_platform/tests/shared/schemas/test_persistence.py
@@ -1,0 +1,67 @@
+"""Tests for shared.schemas.persistence."""
+
+import pytest
+
+from shared.schemas import RangeSpec
+from shared.schemas.persistence import (
+    SPEC_VERSION,
+    unwrap_persisted_spec,
+    validate_persisted_spec,
+    wrap_persisted_spec,
+)
+
+
+def test_wrap_adds_discriminator():
+    spec = RangeSpec(scenario_id="basic", user_id=1, subnets=[])
+    wrapped = wrap_persisted_spec("range_spec", spec)
+
+    assert wrapped["spec_schema"] == "range_spec"
+    assert wrapped["spec_version"] == SPEC_VERSION
+    assert wrapped["payload"]["scenario_id"] == "basic"
+
+
+def test_unwrap_round_trip():
+    spec = RangeSpec(scenario_id="basic", user_id=1, subnets=[])
+    wrapped = wrap_persisted_spec("range_spec", spec)
+    payload = unwrap_persisted_spec(wrapped)
+
+    assert payload["scenario_id"] == "basic"
+    assert "spec_schema" not in payload
+
+
+def test_legacy_blob_passthrough():
+    legacy = {"scenario_id": "basic", "user_id": 1, "subnets": []}
+    assert unwrap_persisted_spec(legacy) == legacy
+
+
+def test_validate_persisted_spec_new_format():
+    spec = RangeSpec(scenario_id="basic", user_id=1, subnets=[])
+    wrapped = wrap_persisted_spec("range_spec", spec)
+    validated = validate_persisted_spec(wrapped, "range_spec")
+
+    assert isinstance(validated, RangeSpec)
+    assert validated.scenario_id == "basic"
+
+
+def test_validate_persisted_spec_legacy_format():
+    legacy = {"scenario_id": "basic", "user_id": 1, "subnets": []}
+    validated = validate_persisted_spec(legacy, "range_spec")
+
+    assert isinstance(validated, RangeSpec)
+
+
+def test_validate_wrong_slug_raises():
+    spec = RangeSpec(scenario_id="basic", user_id=1, subnets=[])
+    wrapped = wrap_persisted_spec("range_spec", spec)
+
+    with pytest.raises(ValueError, match="spec_schema mismatch"):
+        validate_persisted_spec(wrapped, "instance_spec")
+
+
+def test_validate_unsupported_version_raises():
+    spec = RangeSpec(scenario_id="basic", user_id=1, subnets=[])
+    wrapped = wrap_persisted_spec("range_spec", spec)
+    wrapped["spec_version"] = "999"
+
+    with pytest.raises(ValueError, match="Unsupported spec_version"):
+        validate_persisted_spec(wrapped, "range_spec")

--- a/shifter/shifter_platform/tests/shared/schemas/test_registry.py
+++ b/shifter/shifter_platform/tests/shared/schemas/test_registry.py
@@ -1,0 +1,50 @@
+"""Tests for shared.schemas.registry."""
+
+import pytest
+
+from shared.schemas.registry import (
+    LEGACY_DOTTED_PATH_TO_SLUG,
+    UnknownSpecSlugError,
+    get_model_for_slug,
+    resolve_catalog_slug,
+)
+
+
+def test_get_model_for_catalog_slugs():
+    from shared.schemas import DeploymentProfileSpec, InstanceSpec, NGFWAppSpec, SCMCredentialSpec
+
+    assert get_model_for_slug("credential.scm") is SCMCredentialSpec
+    assert get_model_for_slug("credential.deployment_profile") is DeploymentProfileSpec
+    assert get_model_for_slug("instance.panw-ngfw") is InstanceSpec
+    assert get_model_for_slug("app.panw-ngfw") is NGFWAppSpec
+
+
+def test_get_model_for_persisted_blob_slugs():
+    from shared.schemas import InstanceSpec, NGFWAppSpec, RangeSpec, SubnetSpec
+
+    assert get_model_for_slug("range_spec") is RangeSpec
+    assert get_model_for_slug("instance_spec") is InstanceSpec
+    assert get_model_for_slug("subnet_spec") is SubnetSpec
+    assert get_model_for_slug("ngfw_app_spec") is NGFWAppSpec
+
+
+def test_unknown_slug_raises():
+    with pytest.raises(UnknownSpecSlugError):
+        get_model_for_slug("does.not.exist")
+
+
+def test_resolve_catalog_slug_from_legacy_path():
+    assert resolve_catalog_slug("shared.schemas.SCMCredentialSpec") == "credential.scm"
+    assert resolve_catalog_slug("shared.schemas.DeploymentProfileSpec") == "credential.deployment_profile"
+    assert resolve_catalog_slug("shared.schemas.range.InstanceSpec") == "instance.panw-ngfw"
+    assert resolve_catalog_slug("shared.schemas.app.NGFWAppSpec") == "app.panw-ngfw"
+
+
+def test_legacy_path_map_covers_seed_migration_paths():
+    seed_paths = {
+        "shared.schemas.SCMCredentialSpec",
+        "shared.schemas.DeploymentProfileSpec",
+        "shared.schemas.range.InstanceSpec",
+        "shared.schemas.app.NGFWAppSpec",
+    }
+    assert seed_paths <= set(LEGACY_DOTTED_PATH_TO_SLUG)


### PR DESCRIPTION
## Summary

Replace dotted Python import paths in catalog rows with stable registry slugs, and wrap persisted cyberscript spec JSON with schema/version discriminators so a future aces-sdl backend swap can dual-read legacy blobs without a big-bang migration.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #951

## ADR Impact

- ADR-021

## Changes

- Add cyberscript schema slug registry and persisted-spec envelope helpers
- Rename catalog spec_class to spec_slug with data migration
- Wrap range_config and Instantiation.spec JSON with spec_schema/spec_version at write sites
- Unwrap persisted specs at engine, CMS, and provisioner read paths
- Add CMS and engine data migrations for existing rows
- **Migration reminder:** update version lists in `MigrationSmokeTest.java` and `RequirementsE2EIntegrationTest.java` (per `.gc/plan-rules.md`).

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused pytest: shared/schemas registry+persistence, cms credentials/models, engine create_range, provisioner config/db coupling, integration credential list counts.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/951.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

Made with [Cursor](https://cursor.com)