### PR TITLE
refactor: enforce cyberscript shared-only import boundary in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ reconciliation.
 
 - Cross-layer access goes through service boundaries.
 - Shared contracts live under `shared`.
+- Only `shared` may import `cyberscript` directly; all other `shifter_platform` layers must use `shared` shims. New non-DSL contracts belong in `shared` natively — `cyberscript` is for scenario DSL contracts only and should shrink over time ahead of the `aces-sdl` swap.
 - Do not weaken CI or local enforcement silently.
 - If a rule needs an exception, record it in `docs/adr/exceptions.yaml` with an owner and expiry.
 - Guardrail-file changes should also update the ADR enforcement docs or registry in the same change.

--- a/changelog.d/950.changed.md
+++ b/changelog.d/950.changed.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Enforce the cyberscript shared-only import boundary in CI: only `shared` may import `cyberscript` directly; `cms/experiments` now routes through `shared.script_context` and `shared.template_vars` shims.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -8,7 +8,7 @@
     "rules": [
       {
         "id": "ADR-001-R1",
-        "description": "Cross-layer imports must conform to scripts/check_layer_imports/layer_imports.yaml.",
+        "description": "Cross-layer imports must conform to scripts/check_layer_imports/layer_imports.yaml; only shared may import cyberscript directly.",
         "checks": ["layer-imports"]
       },
       {

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -24,6 +24,11 @@ IMPORT_PATTERN = re.compile(
     r"^\s*(?:from|import)\s+((?:shared|engine|cms|management|mission_control|ctf)(?:\.\w+)*)",
     re.MULTILINE,
 )
+CYBERSCRIPT_IMPORT_PATTERN = re.compile(
+    r"^\s*(?:from|import)\s+(cyberscript(?:\.\w+)*)",
+    re.MULTILINE,
+)
+CYBERSCRIPT_ALLOWED_LAYER = "shared"
 REQUIRED_ADR_KEYS = {
     "id",
     "title",
@@ -383,6 +388,16 @@ def check_layer_imports(repo_root: Path, files: list[str] | None) -> list[Violat
                         "ADR-001-R1",
                         rel,
                         f"{from_layer} may not import {module}",
+                    )
+                )
+        if from_layer != CYBERSCRIPT_ALLOWED_LAYER:
+            for module in sorted(set(CYBERSCRIPT_IMPORT_PATTERN.findall(text))):
+                violations.append(
+                    Violation(
+                        "layer-imports",
+                        "ADR-001-R1",
+                        rel,
+                        f"{from_layer} may not import {module}; use shared shims",
                     )
                 )
 

--- a/scripts/check_layer_imports/check_layer_imports.py
+++ b/scripts/check_layer_imports/check_layer_imports.py
@@ -34,6 +34,14 @@ IMPORT_PATTERN = re.compile(
     re.MULTILINE,
 )
 
+# Direct cyberscript imports — only the shared layer may import cyberscript.
+CYBERSCRIPT_IMPORT_PATTERN = re.compile(
+    r"^\s*(?:from|import)\s+(cyberscript(?:\.\w+)*)",
+    re.MULTILINE,
+)
+
+CYBERSCRIPT_ALLOWED_LAYER = "shared"
+
 
 def load_allowed_imports(config_path: Path) -> dict[str, list[str]]:
     """Load allowed imports from YAML config file.
@@ -110,6 +118,44 @@ def get_imports(layer_path: Path) -> dict[str, set[str]]:
     return imports
 
 
+def get_cyberscript_imports(layer_path: Path) -> set[str]:
+    """Return cyberscript module paths imported under a layer directory."""
+    imports: set[str] = set()
+
+    if not layer_path.exists():
+        return imports
+
+    for py_file in layer_path.rglob("*.py"):
+        try:
+            content = py_file.read_text()
+        except Exception:  # nosec B112 - skip unreadable files
+            continue
+
+        imports.update(CYBERSCRIPT_IMPORT_PATTERN.findall(content))
+
+    return imports
+
+
+def compute_cyberscript_violations(from_layer: str, modules: set[str]) -> list[str]:
+    """Return cyberscript imports that violate the shared-only rule."""
+    if from_layer == CYBERSCRIPT_ALLOWED_LAYER or not modules:
+        return []
+    return sorted(modules)
+
+
+def analyze_cyberscript_imports(base_path: Path) -> dict[str, list[str]]:
+    """Analyze direct cyberscript imports per layer."""
+    result: dict[str, list[str]] = {}
+
+    for from_layer in ALL_LAYERS:
+        modules = get_cyberscript_imports(base_path / from_layer)
+        violations = compute_cyberscript_violations(from_layer, modules)
+        if violations:
+            result[from_layer] = violations
+
+    return result
+
+
 def analyze_imports(base_path: Path) -> dict:
     """Analyze all cross-layer imports and return structured result."""
     result = {}
@@ -132,7 +178,11 @@ def analyze_imports(base_path: Path) -> dict:
     return result
 
 
-def compute_stats(imports: dict, allowed: dict[str, list[str]]) -> dict:
+def compute_stats(
+    imports: dict,
+    allowed: dict[str, list[str]],
+    cyberscript: dict[str, list[str]] | None = None,
+) -> dict:
     """Compute summary statistics from import analysis."""
     stats = {
         "total_cross_layer_imports": 0,
@@ -163,6 +213,19 @@ def compute_stats(imports: dict, allowed: dict[str, list[str]]) -> dict:
 
         if layer_has_violation:
             stats["layers_with_violations"].append(from_layer)
+
+    if cyberscript:
+        for from_layer, modules in cyberscript.items():
+            stats["violations"] += len(modules)
+            if from_layer not in stats["layers_with_violations"]:
+                stats["layers_with_violations"].append(from_layer)
+            stats["violation_details"].append(
+                {
+                    "from": from_layer,
+                    "to": "cyberscript",
+                    "modules": modules,
+                }
+            )
 
     # Determine clean layers (no violations)
     for layer in ALL_LAYERS:
@@ -220,11 +283,13 @@ def main():
 
     # Analyze imports
     imports = analyze_imports(base_path)
-    stats = compute_stats(imports, allowed)
+    cyberscript = analyze_cyberscript_imports(base_path)
+    stats = compute_stats(imports, allowed, cyberscript)
 
     # Build output
     output = {
         "imports": imports,
+        "cyberscript_imports": cyberscript,
         "stats": stats,
     }
 

--- a/scripts/check_layer_imports/check_layer_imports.py
+++ b/scripts/check_layer_imports/check_layer_imports.py
@@ -107,7 +107,8 @@ def get_imports(layer_path: Path) -> dict[str, set[str]]:
     for py_file in layer_path.rglob("*.py"):
         try:
             content = py_file.read_text()
-        except Exception:  # nosec B112 - skip unreadable files
+        except Exception:
+            # nosec B112 - skip unreadable files
             continue
 
         for match in set(IMPORT_PATTERN.findall(content)):
@@ -128,7 +129,8 @@ def get_cyberscript_imports(layer_path: Path) -> set[str]:
     for py_file in layer_path.rglob("*.py"):
         try:
             content = py_file.read_text()
-        except Exception:  # nosec B112 - skip unreadable files
+        except Exception:
+            # nosec B112 - skip unreadable files
             continue
 
         imports.update(CYBERSCRIPT_IMPORT_PATTERN.findall(content))
@@ -178,11 +180,28 @@ def analyze_imports(base_path: Path) -> dict:
     return result
 
 
+def _apply_cyberscript_violations(stats: dict[str, object], cyberscript: dict[str, list[str]]) -> None:
+    """Roll cyberscript boundary violations into summary stats."""
+    for from_layer, modules in cyberscript.items():
+        stats["violations"] = int(stats["violations"]) + len(modules)
+        layers_with_violations = stats["layers_with_violations"]
+        if from_layer not in layers_with_violations:
+            layers_with_violations.append(from_layer)
+        violation_details = stats["violation_details"]
+        violation_details.append(
+            {
+                "from": from_layer,
+                "to": "cyberscript",
+                "modules": modules,
+            }
+        )
+
+
 def compute_stats(
-    imports: dict,
+    imports: dict[str, dict[str, list[str]]],
     allowed: dict[str, list[str]],
     cyberscript: dict[str, list[str]] | None = None,
-) -> dict:
+) -> dict[str, object]:
     """Compute summary statistics from import analysis."""
     stats = {
         "total_cross_layer_imports": 0,
@@ -215,17 +234,7 @@ def compute_stats(
             stats["layers_with_violations"].append(from_layer)
 
     if cyberscript:
-        for from_layer, modules in cyberscript.items():
-            stats["violations"] += len(modules)
-            if from_layer not in stats["layers_with_violations"]:
-                stats["layers_with_violations"].append(from_layer)
-            stats["violation_details"].append(
-                {
-                    "from": from_layer,
-                    "to": "cyberscript",
-                    "modules": modules,
-                }
-            )
+        _apply_cyberscript_violations(stats, cyberscript)
 
     # Determine clean layers (no violations)
     for layer in ALL_LAYERS:

--- a/scripts/check_layer_imports/layer_imports.yaml
+++ b/scripts/check_layer_imports/layer_imports.yaml
@@ -4,6 +4,11 @@
 # shared is freely importable by all layers (contracts layer).
 # No model imports, no internal submodule imports, no __init__.py shortcuts.
 #
+# Direct cyberscript imports: only `shared` may import `cyberscript` (enforced
+# by scripts/check_layer_imports/check_layer_imports.py and adr_guard). All other
+# layers must consume cyberscript contracts through shared shims. New non-DSL
+# contracts belong in shared natively; cyberscript is for scenario DSL only.
+#
 # Any import not matching this config is a violation.
 
 allowed:

--- a/scripts/check_layer_imports/pyproject.toml
+++ b/scripts/check_layer_imports/pyproject.toml
@@ -33,7 +33,7 @@ ignore = ["S101", "T201", "S112"]  # T201: print allowed (CLI tool), S112: try-e
 max-complexity = 15
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S101", "S105", "S106"]
+"tests/**/*.py" = ["S101", "S105", "S106", "S603"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/scripts/check_layer_imports/tests/test_check_layer_imports.py
+++ b/scripts/check_layer_imports/tests/test_check_layer_imports.py
@@ -1,15 +1,17 @@
 """Tests for check_layer_imports module."""
 
+import json
+import subprocess
 import sys
 from pathlib import Path
 
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from check_layer_imports import (
     ALL_LAYERS,
     CYBERSCRIPT_IMPORT_PATTERN,
     IMPORT_PATTERN,
+    analyze_cyberscript_imports,
     analyze_imports,
     compute_cyberscript_violations,
     compute_stats,
@@ -17,7 +19,10 @@ from check_layer_imports import (
     get_imports,
     is_import_allowed,
     load_allowed_imports,
+    print_summary,
 )
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check_layer_imports.py"
 
 
 class TestLayerConfiguration:
@@ -299,3 +304,160 @@ class TestAnalyzeImports:
 
         result = analyze_imports(tmp_path)
         assert "shared" not in result["shared"]
+
+    def test_returns_empty_for_missing_layer(self, tmp_path):
+        assert get_cyberscript_imports(tmp_path / "missing") == set()
+
+
+class TestAnalyzeCyberscriptImports:
+    def test_detects_violations_across_layers(self, tmp_path):
+        for layer in ALL_LAYERS:
+            (tmp_path / layer).mkdir()
+        (tmp_path / "cms" / "bad.py").write_text("from cyberscript.template_vars import TemplateString\n")
+
+        result = analyze_cyberscript_imports(tmp_path)
+        assert result == {"cms": ["cyberscript.template_vars"]}
+
+
+class TestPrintSummary:
+    def test_prints_violation_details(self, capsys):
+        stats = {
+            "total_cross_layer_imports": 1,
+            "violations": 1,
+            "clean_layers": ["shared"],
+            "layers_with_violations": ["cms"],
+            "violation_details": [{"from": "cms", "to": "cyberscript", "modules": ["cyberscript.template_vars"]}],
+        }
+        print_summary(stats, file=sys.stdout)
+        captured = capsys.readouterr().out
+        assert "cms -> cyberscript" in captured
+        assert "Violations detected" in captured
+
+    def test_prints_clean_message_when_no_violations(self, capsys):
+        stats = {
+            "total_cross_layer_imports": 0,
+            "violations": 0,
+            "clean_layers": ALL_LAYERS,
+            "layers_with_violations": [],
+            "violation_details": [],
+        }
+        print_summary(stats, file=sys.stdout)
+        assert "No violations detected" in capsys.readouterr().out
+
+
+class TestMain:
+    def test_cli_exits_zero_on_clean_repo(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "-q"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert "cyberscript_imports" in payload
+        assert payload["stats"]["violations"] == 0
+
+    def test_cli_writes_output_file(self, tmp_path):
+        output_file = tmp_path / "report.json"
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "-o", str(output_file), "-q"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert output_file.exists()
+        payload = json.loads(output_file.read_text())
+        assert "stats" in payload
+
+    def test_cli_prints_summary_when_not_quiet(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "LAYER IMPORT SUMMARY" in result.stdout
+
+    def test_cli_exits_one_when_cyberscript_violation_present(self, tmp_path):
+        checker_dir = tmp_path / "scripts" / "check_layer_imports"
+        checker_dir.mkdir(parents=True)
+        config = checker_dir / "layer_imports.yaml"
+        config.write_text("allowed:\n  cms:\n    - shared\n")
+        platform = tmp_path / "shifter" / "shifter_platform"
+        for layer_name in ALL_LAYERS:
+            (platform / layer_name).mkdir(parents=True)
+        (platform / "cms" / "bad.py").write_text("from cyberscript.template_vars import TemplateString\n")
+
+        script = checker_dir / "check_layer_imports.py"
+        script.write_text(
+            SCRIPT_PATH.read_text().replace(
+                'base_path = script_dir.parent.parent / "shifter" / "shifter_platform"',
+                f'base_path = Path("{platform}")',
+            )
+        )
+
+        result = subprocess.run(
+            [sys.executable, str(script), "-q"],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=checker_dir,
+        )
+        assert result.returncode == 1, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["cyberscript_imports"] == {"cms": ["cyberscript.template_vars"]}
+
+
+class TestMainInProcess:
+    def test_main_missing_config(self, tmp_path, monkeypatch):
+        import check_layer_imports as cli
+
+        script_dir = tmp_path / "scripts" / "check_layer_imports"
+        script_dir.mkdir(parents=True)
+        monkeypatch.setattr(cli, "__file__", str(script_dir / "check_layer_imports.py"))
+        monkeypatch.setattr(sys, "argv", ["check_layer_imports", "-q"])
+        assert cli.main() == 1
+
+    def test_main_missing_platform_path(self, tmp_path, monkeypatch):
+        import check_layer_imports as cli
+
+        script_dir = tmp_path / "scripts" / "check_layer_imports"
+        script_dir.mkdir(parents=True)
+        (script_dir / "layer_imports.yaml").write_text("allowed: {}\n")
+        monkeypatch.setattr(cli, "__file__", str(script_dir / "check_layer_imports.py"))
+        monkeypatch.setattr(sys, "argv", ["check_layer_imports", "-q"])
+        assert cli.main() == 1
+
+    def test_main_success_with_output_file(self, tmp_path, monkeypatch):
+        import check_layer_imports as cli
+
+        repo_root = tmp_path
+        script_dir = repo_root / "scripts" / "check_layer_imports"
+        script_dir.mkdir(parents=True)
+        (script_dir / "layer_imports.yaml").write_text("allowed:\n  cms:\n    - shared\n")
+        platform = repo_root / "shifter" / "shifter_platform"
+        for layer_name in ALL_LAYERS:
+            (platform / layer_name).mkdir(parents=True)
+        output_file = tmp_path / "report.json"
+
+        monkeypatch.setattr(cli, "__file__", str(script_dir / "check_layer_imports.py"))
+        monkeypatch.setattr(sys, "argv", ["check_layer_imports", "-o", str(output_file)])
+        assert cli.main() == 0
+        assert output_file.exists()
+
+
+class TestGetImportsEdgeCases:
+    def test_skips_unreadable_python_files(self, tmp_path):
+        layer = tmp_path / "cms"
+        layer.mkdir()
+        unreadable = layer / "secret.py"
+        unreadable.write_text("from shared.schemas import RangeSpec\n")
+        unreadable.chmod(0o000)
+        try:
+            assert get_cyberscript_imports(layer) == set()
+            assert get_imports(layer) == {}
+        finally:
+            unreadable.chmod(0o644)

--- a/scripts/check_layer_imports/tests/test_check_layer_imports.py
+++ b/scripts/check_layer_imports/tests/test_check_layer_imports.py
@@ -8,9 +8,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from check_layer_imports import (
     ALL_LAYERS,
+    CYBERSCRIPT_IMPORT_PATTERN,
     IMPORT_PATTERN,
     analyze_imports,
+    compute_cyberscript_violations,
     compute_stats,
+    get_cyberscript_imports,
     get_imports,
     is_import_allowed,
     load_allowed_imports,
@@ -217,6 +220,57 @@ class TestComputeStats:
         assert stats["violation_details"][0]["from"] == "engine"
         assert stats["violation_details"][0]["to"] == "cms"
         assert "cms.models" in stats["violation_details"][0]["modules"]
+
+    def test_cyberscript_violations_counted(self):
+        """Cyberscript boundary violations roll up into exit-code-driving stats."""
+        stats = compute_stats({}, {}, cyberscript={"cms": ["cyberscript.script_context"]})
+        assert stats["violations"] == 1
+        assert "cms" in stats["layers_with_violations"]
+        assert stats["violation_details"] == [
+            {
+                "from": "cms",
+                "to": "cyberscript",
+                "modules": ["cyberscript.script_context"],
+            }
+        ]
+
+
+class TestCyberscriptImportPattern:
+    """Tests for direct cyberscript import detection."""
+
+    def test_matches_from_import(self):
+        code = "from cyberscript.script_context import ScriptExecutionContext"
+        matches = CYBERSCRIPT_IMPORT_PATTERN.findall(code)
+        assert matches == ["cyberscript.script_context"]
+
+    def test_matches_simple_import(self):
+        code = "import cyberscript.template_vars"
+        matches = CYBERSCRIPT_IMPORT_PATTERN.findall(code)
+        assert matches == ["cyberscript.template_vars"]
+
+
+class TestCyberscriptViolations:
+    """Tests for the cyberscript-only-via-shared rule."""
+
+    def test_cms_direct_cyberscript_import_is_violation(self, tmp_path):
+        cms_path = tmp_path / "cms" / "experiments"
+        cms_path.mkdir(parents=True)
+        (cms_path / "orchestrator.py").write_text("from cyberscript.script_context import ScriptExecutionContext\n")
+        imports = get_cyberscript_imports(cms_path.parent)
+        assert imports == {"cyberscript.script_context"}
+        violations = compute_cyberscript_violations("cms", imports)
+        assert violations == ["cyberscript.script_context"]
+
+    def test_shared_may_import_cyberscript(self, tmp_path):
+        shared_path = tmp_path / "shared"
+        shared_path.mkdir()
+        (shared_path / "script_context.py").write_text(
+            "from cyberscript.script_context import ScriptExecutionContext\n"
+        )
+        imports = get_cyberscript_imports(shared_path)
+        assert "cyberscript.script_context" in imports
+        violations = compute_cyberscript_violations("shared", imports)
+        assert violations == []
 
 
 class TestAnalyzeImports:

--- a/shifter/shifter_platform/cms/experiments/orchestrator.py
+++ b/shifter/shifter_platform/cms/experiments/orchestrator.py
@@ -17,11 +17,6 @@ from dataclasses import dataclass, field
 from typing import Any
 from uuid import uuid4
 
-from cyberscript.script_context import (
-    ScriptExecutionContext,
-    build_ai_execution_policy_payload,
-)
-from cyberscript.template_vars import build_instance_data
 from pydantic import ValidationError
 
 from cms.experiments.ecs import start_experiment_task
@@ -39,6 +34,11 @@ from cms.experiments.schemas import (
 from engine.services import create_range as engine_create_range
 from risk_register.models import AuditLog
 from risk_register.services import StateChange, audit_log_system_event
+from shared.script_context import (
+    ScriptExecutionContext,
+    build_ai_execution_policy_payload,
+)
+from shared.template_vars import build_instance_data
 
 logger = logging.getLogger(__name__)
 

--- a/shifter/shifter_platform/cms/experiments/schemas.py
+++ b/shifter/shifter_platform/cms/experiments/schemas.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from cyberscript.template_vars import TemplateString
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+from shared.template_vars import TemplateString
 
 # ---------------------------------------------------------------------------
 # Enums

--- a/shifter/shifter_platform/shared/script_context.py
+++ b/shifter/shifter_platform/shared/script_context.py
@@ -1,0 +1,11 @@
+"""Experiment script execution context. Re-exports from cyberscript.script_context."""
+
+from cyberscript.script_context import (
+    ScriptExecutionContext,
+    build_ai_execution_policy_payload,
+)
+
+__all__ = [
+    "ScriptExecutionContext",
+    "build_ai_execution_policy_payload",
+]

--- a/shifter/shifter_platform/shared/template_vars.py
+++ b/shifter/shifter_platform/shared/template_vars.py
@@ -1,0 +1,19 @@
+"""Template variable parsing and validation. Re-exports from cyberscript.template_vars."""
+
+from cyberscript.template_vars import (
+    ALLOWED_PROPERTIES,
+    TemplateString,
+    build_instance_data,
+    extract_variables,
+    resolve_template,
+    validate_template,
+)
+
+__all__ = [
+    "ALLOWED_PROPERTIES",
+    "TemplateString",
+    "build_instance_data",
+    "extract_variables",
+    "resolve_template",
+    "validate_template",
+]

--- a/shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py
@@ -4,7 +4,6 @@ Tests the HMAC token logic -- no real S3 calls needed.
 """
 
 import pytest
-from cyberscript.script_context import ScriptExecutionContext
 
 from cms.experiments.s3 import (
     _normalize_script_filename_segment,
@@ -12,6 +11,7 @@ from cms.experiments.s3 import (
     normalize_legacy_script_s3_key,
     verify_upload_token,
 )
+from shared.script_context import ScriptExecutionContext
 
 
 class TestUploadToken:

--- a/shifter/shifter_platform/tests/cms/experiments/test_template_vars.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_template_vars.py
@@ -1,7 +1,8 @@
 """Tests for template variable parsing, validation, and resolution."""
 
 import pytest
-from cyberscript.template_vars import (
+
+from shared.template_vars import (
     build_instance_data,
     extract_variables,
     resolve_template,

--- a/shifter/shifter_platform/tests/cms/test_credential_encryption.py
+++ b/shifter/shifter_platform/tests/cms/test_credential_encryption.py
@@ -189,7 +189,7 @@ class TestSensitiveKeysContract:
                 )
 
     def test_listed_secrets_actually_exist_on_instance_specs(self):
-        from cyberscript.schemas.app import NGFWAppSpec
+        from shared.schemas.app import NGFWAppSpec
 
         spec_classes = {"NGFWAppSpec": NGFWAppSpec}
         for spec_name, keys in _INSTANCE_SPEC_SECRET_KEYS.items():


### PR DESCRIPTION
## Summary

Enforces the cyberscript shared-only import boundary ahead of the aces-sdl swap: the layer-import checker and ADR guard now reject direct cyberscript imports outside shared, cms/experiments routes through new shared shims, and AGENTS.md documents the DSL-only growth rule.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #950

## ADR Impact

- ADR-001
- ADR-021

## Changes

- Add dedicated cyberscript import scanning to check_layer_imports and adr_guard (only shared may import cyberscript directly)
- Add shared/script_context.py and shared/template_vars.py shims; reroute cms/experiments orchestrator and schemas
- Document the boundary in layer_imports.yaml, AGENTS.md, and ADR-001-R1
- Add unit tests for cyberscript violation detection and stats roll-up

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Layer-import checker tests and existing cms/experiments test suite pass locally; pre-commit and adr_guard --all --level ci green.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: issue ← scripts/check_layer_imports/tests/test_check_layer_imports.py, issue ← shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py, issue ← shifter/shifter_platform/tests/cms/experiments/test_template_vars.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/950.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

Made with [Cursor](https://cursor.com)