### PR TITLE
changed: pin provisioner rangespec key-walks to cyberscript wire contract

### DIFF
--- a/changelog.d/952.changed.md
+++ b/changelog.d/952.changed.md
@@ -1,0 +1,3 @@
+### Changed
+
+Pin ECS provisioner RangeSpec JSON key-walks to the cyberscript wire contract with cross-package drift tests, completing the #273/#952 process-boundary guardrails alongside existing event/status canaries.

--- a/shifter/cyberscript/tests/test_wire_contract.py
+++ b/shifter/cyberscript/tests/test_wire_contract.py
@@ -12,7 +12,10 @@ import pytest
 
 from cyberscript.channels import groups
 from cyberscript.enums import ResourceStatus
+from cyberscript.schemas.range import AgentDetails, InstanceSpec, RangeSpec
+from cyberscript.schemas.subnet import SubnetSpec
 from cyberscript import wire_constants as event_types
+from cyberscript import wire_spec_keys as spec_keys
 
 
 class TestResourceStatusCanary:
@@ -67,3 +70,23 @@ class TestChannelGroupCanary:
         assert name == expected
         assert len(name) <= 100
         assert ":" not in name
+
+
+class TestWireSpecKeysAlignWithSchemas:
+    def test_range_spec_schema_keys_are_model_fields(self) -> None:
+        assert spec_keys.RANGE_SPEC_TOP_LEVEL_SCHEMA_KEYS <= set(RangeSpec.model_fields)
+
+    def test_subnet_schema_keys_are_model_fields(self) -> None:
+        assert spec_keys.SUBNET_SCHEMA_KEYS <= set(SubnetSpec.model_fields)
+
+    def test_instance_schema_keys_are_model_fields(self) -> None:
+        assert spec_keys.INSTANCE_SCHEMA_KEYS <= set(InstanceSpec.model_fields)
+
+    def test_agent_schema_keys_are_model_fields(self) -> None:
+        assert spec_keys.AGENT_SCHEMA_KEYS <= set(AgentDetails.model_fields)
+
+    def test_runtime_keys_are_not_dsl_kernel_fields(self) -> None:
+        subnet_fields = set(SubnetSpec.model_fields)
+        instance_fields = set(InstanceSpec.model_fields)
+        assert not spec_keys.SUBNET_RUNTIME_KEYS & subnet_fields
+        assert not spec_keys.INSTANCE_RUNTIME_KEYS & instance_fields

--- a/shifter/cyberscript/wire_spec_keys.py
+++ b/shifter/cyberscript/wire_spec_keys.py
@@ -1,0 +1,39 @@
+"""Canonical JSON keys the ECS provisioner dict-walks on persisted range specs.
+
+Schema-aligned keys must exist on the cyberscript Pydantic models. Runtime keys
+are assigned during provisioning and are intentionally not part of the DSL
+kernel; they are listed here so renames fail contract tests instead of shipping
+silently across the process boundary.
+"""
+
+from __future__ import annotations
+
+RANGE_SPEC_TOP_LEVEL_SCHEMA_KEYS = frozenset({"subnets", "ngfw"})
+
+SUBNET_SCHEMA_KEYS = frozenset({"name", "uuid", "instances", "connected_to"})
+SUBNET_RUNTIME_KEYS = frozenset({"cidr", "provider_metadata"})
+
+INSTANCE_SCHEMA_KEYS = frozenset(
+    {
+        "name",
+        "uuid",
+        "role",
+        "os_type",
+        "agent",
+        "join_domain",
+        "ami_key",
+        "instance_type",
+    }
+)
+INSTANCE_RUNTIME_KEYS = frozenset({"asset_type"})
+
+AGENT_SCHEMA_KEYS = frozenset({"s3_key", "filename", "sha256"})
+
+__all__ = [
+    "AGENT_SCHEMA_KEYS",
+    "INSTANCE_RUNTIME_KEYS",
+    "INSTANCE_SCHEMA_KEYS",
+    "RANGE_SPEC_TOP_LEVEL_SCHEMA_KEYS",
+    "SUBNET_RUNTIME_KEYS",
+    "SUBNET_SCHEMA_KEYS",
+]

--- a/shifter/engine/provisioner/tests/test_wire_contract.py
+++ b/shifter/engine/provisioner/tests/test_wire_contract.py
@@ -2,8 +2,46 @@
 
 from __future__ import annotations
 
+import ast
+from pathlib import Path
+
 from cyberscript import wire_constants as event_types
+from cyberscript import wire_spec_keys as spec_keys
 from cyberscript.enums import ResourceStatus
+
+_TERRAFORM_VARS = Path(__file__).resolve().parents[1] / "terraform_vars.py"
+_SPEC_KEY_WALK_FUNCTIONS = frozenset(
+    {
+        "_build_tf_instance",
+        "_build_tf_subnets",
+        "_build_range_terraform_variables",
+        "_resolve_agent_presigned_url",
+    }
+)
+
+
+_SPEC_DICT_RECEIVERS = frozenset({"agent_data", "inst", "range_spec", "subnet"})
+
+
+def _dict_get_literal_keys_in_functions(module_path: Path, function_names: frozenset[str]) -> set[str]:
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    keys: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in function_names:
+            continue
+        for sub in ast.walk(node):
+            if not isinstance(sub, ast.Call):
+                continue
+            func = sub.func
+            if not isinstance(func, ast.Attribute) or func.attr != "get" or not sub.args:
+                continue
+            receiver = func.value
+            if not isinstance(receiver, ast.Name) or receiver.id not in _SPEC_DICT_RECEIVERS:
+                continue
+            key_arg = sub.args[0]
+            if isinstance(key_arg, ast.Constant) and isinstance(key_arg.value, str):
+                keys.add(key_arg.value)
+    return keys
 
 
 class TestProvisionerEventsMatchesCyberscript:
@@ -19,3 +57,18 @@ class TestProvisionerEventsMatchesCyberscript:
         for status in ResourceStatus:
             alias = f"STATUS_{status.name}"
             assert getattr(provisioner_events, alias) == status.value
+
+
+class TestTerraformVarsRangeSpecKeyWalk:
+    def test_dict_get_keys_are_registered_in_wire_spec_keys(self) -> None:
+        allowed = (
+            spec_keys.RANGE_SPEC_TOP_LEVEL_SCHEMA_KEYS
+            | spec_keys.SUBNET_SCHEMA_KEYS
+            | spec_keys.SUBNET_RUNTIME_KEYS
+            | spec_keys.INSTANCE_SCHEMA_KEYS
+            | spec_keys.INSTANCE_RUNTIME_KEYS
+            | spec_keys.AGENT_SCHEMA_KEYS
+        )
+        used = _dict_get_literal_keys_in_functions(_TERRAFORM_VARS, _SPEC_KEY_WALK_FUNCTIONS)
+        unknown = used - allowed
+        assert not unknown, f"Unregistered dict.get keys in terraform_vars.py: {sorted(unknown)}"


### PR DESCRIPTION
## Summary

Completes issue #952 by pinning the ECS provisioner's RangeSpec JSON key-walks to the cyberscript wire contract. Event/status canaries and provisioner constant consolidation landed in #273; this change adds the missing RangeSpec key registry and cross-package drift tests so renames of persisted JSON fields fail CI instead of silently breaking the process boundary.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #952

## ADR Impact

- ADR-021

## Changes

- Add cyberscript/wire_spec_keys.py registry for provisioner RangeSpec JSON key-walks (schema vs runtime keys)
- Extend cyberscript canary tests to assert schema/runtime key alignment with Pydantic models
- Add provisioner AST contract test pinning terraform_vars.py dict.get keys to the registry
- Add changelog.d/952.changed.md release fragment

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Provisioner: uv run pytest tests/test_wire_contract.py. Cyberscript: uv run --with pytest pytest tests/test_wire_contract.py.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: issue #952 ← shifter/cyberscript/wire_spec_keys.py
- TESTS: issue #952 ← shifter/cyberscript/tests/test_wire_contract.py, issue #952 ← shifter/engine/provisioner/tests/test_wire_contract.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/952.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.

Made with [Cursor](https://cursor.com)