### PR TITLE
chore: remove stale unused type: ignore in cyberscript persistence wrapper

### DIFF
--- a/shifter/cyberscript/schemas/persistence.py
+++ b/shifter/cyberscript/schemas/persistence.py
@@ -27,7 +27,7 @@ def wrap_persisted_spec(slug: str, model: BaseModel, *, mode: str = "json") -> d
     return {
         SPEC_SCHEMA_KEY: slug,
         SPEC_VERSION_KEY: SPEC_VERSION,
-        PAYLOAD_KEY: model.model_dump(mode=mode),  # type: ignore[arg-type]
+        PAYLOAD_KEY: model.model_dump(mode=mode),
     }
 
 


### PR DESCRIPTION
## Summary

`mypy`'s `warn_unused_ignores` flags the `# type: ignore[arg-type]` on `model.model_dump(mode=mode)` in `shifter/cyberscript/schemas/persistence.py` as **unused** — `model_dump` accepts a `str` `mode`, so the suppression no longer covers any error. This removes the dead comment.

No behavior change; surfaced while working on #886 (it reproduces on any file that imports the `shared.script_context` → `cyberscript` chain).

## Verification

- `mypy` passes on the file (import-chain and direct) with no new diagnostics.
- ADR guard + pre-commit hooks pass.

No requirement (pure cleanup); no changelog fragment (behavior-neutral).