### PR TITLE
ci: add advisory trivy and osv-scanner jobs

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -1523,6 +1523,112 @@ jobs:
           compact: true
           soft_fail: true
 
+  # Issue #708: advisory container/IaC and lockfile CVE signal. Exit code 0
+  # and artifact-only SARIF — findings do not block merge; gitleaks/bandit/
+  # checkov/Sonar remain the enforcement gates.
+  security-trivy-advisory:
+    permissions:
+      contents: read
+    name: Security (trivy advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Trivy (hermetic, version-pinned, checksum-verified)
+        env:
+          TRIVY_VERSION: 0.71.2
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/trivy-bin"
+          curl -fsSL -o "${RUNNER_TEMP}/trivy.tar.gz" \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          curl -fsSL -o "${RUNNER_TEMP}/trivy_checksums.txt" \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
+          expected=$(grep "trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" "${RUNNER_TEMP}/trivy_checksums.txt" | awk '{print $1}')
+          echo "${expected}  ${RUNNER_TEMP}/trivy.tar.gz" | sha256sum -c -
+          tar -xzf "${RUNNER_TEMP}/trivy.tar.gz" -C "${RUNNER_TEMP}/trivy-bin" trivy
+          echo "${RUNNER_TEMP}/trivy-bin" >> "${GITHUB_PATH}"
+          trivy --version
+
+      - name: Scan first-party Dockerfiles and Terraform (advisory)
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/trivy-results"
+          # Trivy config accepts one target root per invocation. Scan each
+          # first-party tree separately (skip temp/ via path exclusion).
+          for target in shifter/engine shifter/shifter_platform shifter/packer; do
+            slug=$(echo "$target" | tr '/' '-')
+            trivy config \
+              --exit-code 0 \
+              --format sarif \
+              --output "${RUNNER_TEMP}/trivy-results/${slug}.sarif" \
+              --skip-dirs '**/temp/**' \
+              "$target"
+          done
+          trivy config \
+            --exit-code 0 \
+            --format sarif \
+            --output "${RUNNER_TEMP}/trivy-results/terraform.sarif" \
+            platform/terraform/
+
+      - name: Upload Trivy SARIF artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-advisory-sarif
+          path: ${{ runner.temp }}/trivy-results/*.sarif
+          if-no-files-found: error
+          retention-days: 14
+
+  security-osv-advisory:
+    permissions:
+      contents: read
+    name: Security (osv-scanner advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install OSV-Scanner (hermetic, version-pinned, checksum-verified)
+        env:
+          OSV_VERSION: v2.4.0
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/osv-bin"
+          curl -fsSL -o "${RUNNER_TEMP}/osv-scanner" \
+            "https://github.com/google/osv-scanner/releases/download/${OSV_VERSION}/osv-scanner_linux_amd64"
+          curl -fsSL -o "${RUNNER_TEMP}/osv-scanner_SHA256SUMS" \
+            "https://github.com/google/osv-scanner/releases/download/${OSV_VERSION}/osv-scanner_SHA256SUMS"
+          expected=$(grep 'osv-scanner_linux_amd64$' "${RUNNER_TEMP}/osv-scanner_SHA256SUMS" | awk '{print $1}')
+          echo "${expected}  ${RUNNER_TEMP}/osv-scanner" | sha256sum -c -
+          chmod +x "${RUNNER_TEMP}/osv-scanner"
+          echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
+          osv-scanner --version
+
+      - name: Scan repo-root lockfiles (advisory)
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/osv-results"
+          sarif_out="${RUNNER_TEMP}/osv-results/package-lock.sarif"
+          empty_sarif='{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}'
+          # Issue #708 scope: repo-root lockfiles (package-lock.json today).
+          if [ -f package-lock.json ]; then
+            osv-scanner scan source \
+              --lockfile=package-lock.json \
+              --format sarif \
+              --output-file "${sarif_out}" \
+              ./ || true
+          fi
+          if [ ! -s "${sarif_out}" ]; then
+            printf '%s\n' "${empty_sarif}" > "${sarif_out}"
+          fi
+
+      - name: Upload OSV-Scanner SARIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: osv-scanner-advisory-sarif
+          path: ${{ runner.temp }}/osv-results/*.sarif
+          if-no-files-found: error
+          retention-days: 14
+
   secrets-gitleaks:
     permissions:
       contents: read

--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -1548,7 +1548,7 @@ jobs:
           echo "${expected}  ${RUNNER_TEMP}/trivy.tar.gz" | sha256sum -c -
           tar -xzf "${RUNNER_TEMP}/trivy.tar.gz" -C "${RUNNER_TEMP}/trivy-bin" trivy
           echo "${RUNNER_TEMP}/trivy-bin" >> "${GITHUB_PATH}"
-          trivy --version
+          "${RUNNER_TEMP}/trivy-bin/trivy" --version
 
       - name: Scan first-party Dockerfiles and Terraform (advisory)
         run: |
@@ -1601,14 +1601,13 @@ jobs:
           echo "${expected}  ${RUNNER_TEMP}/osv-scanner" | sha256sum -c -
           chmod +x "${RUNNER_TEMP}/osv-scanner"
           echo "${RUNNER_TEMP}" >> "${GITHUB_PATH}"
-          osv-scanner --version
+          "${RUNNER_TEMP}/osv-scanner" --version
 
       - name: Scan repo-root lockfiles (advisory)
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/osv-results"
           sarif_out="${RUNNER_TEMP}/osv-results/package-lock.sarif"
-          empty_sarif='{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}'
           # Issue #708 scope: repo-root lockfiles (package-lock.json today).
           if [ -f package-lock.json ]; then
             osv-scanner scan source \
@@ -1618,7 +1617,7 @@ jobs:
               ./ || true
           fi
           if [ ! -s "${sarif_out}" ]; then
-            printf '%s\n' "${empty_sarif}" > "${sarif_out}"
+            SARIF_OUT="${sarif_out}" python3 -c 'import json, os, pathlib; pathlib.Path(os.environ["SARIF_OUT"]).write_text(json.dumps({"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}))'
           fi
 
       - name: Upload OSV-Scanner SARIF artifact

--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -1617,6 +1617,7 @@ jobs:
               ./ || true
           fi
           if [ ! -s "${sarif_out}" ]; then
+            # shellcheck disable=SC2016
             SARIF_OUT="${sarif_out}" python3 -c 'import json, os, pathlib; pathlib.Path(os.environ["SARIF_OUT"]).write_text(json.dumps({"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}))'
           fi
 

--- a/changelog.d/708.changed.md
+++ b/changelog.d/708.changed.md
@@ -1,0 +1,1 @@
+Add advisory Trivy (first-party Dockerfiles and Terraform) and OSV-Scanner (repo-root lockfiles) CI jobs that upload SARIF artifacts without blocking merge.


### PR DESCRIPTION
## Summary

Add advisory Trivy and OSV-scanner jobs to the Quality workflow. Trivy scans first-party Dockerfiles under `shifter/engine`, `shifter/shifter_platform`, and `shifter/packer` (excluding `temp/`) plus first-party Terraform under `platform/terraform/`, uploading SARIF artifacts with exit code 0. OSV-Scanner scans the repo-root `package-lock.json` and uploads a SARIF artifact without blocking merge.

## Requirement UIDs

- (none — quickfix / maintenance run; see Traceability section below)

## Related Issues

Closes #708

## ADR Impact

- [x] No ADR impact

ADRs touched:

## Guardrail Changes

- [x] Guardrail files changed and matching docs were updated

Guardrail files changed:

- `.github/workflows/_quality.yml`

## Changes

- Add `security-trivy-advisory` job (pinned Trivy 0.71.2, checksum-verified install, per-tree config scans)
- Add `security-osv-advisory` job (pinned OSV-Scanner v2.4.0, repo-root lockfile scan)
- Add `changelog.d/708.changed.md` fragment

## Test Plan

- [x] `actionlint .github/workflows/_quality.yml`
- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- [x] Local smoke: Trivy config scan on `shifter/engine`; OSV-scanner stub path for empty root lockfile

## Ground Control Checks

- [x] Changelog fragment present (`changelog.d/708.changed.md`)
- [x] No-defer language in commit/PR
- [x] Pre-commit clean on touched files

## Traceability

- IMPLEMENTS: (none — quickfix / maintenance run)
- TESTS: (none — CI workflow wiring)

## Checklist

- [x] Changelog fragment added at `changelog.d/708.changed.md`

Made with [Cursor](https://cursor.com)