### PR TITLE
feat(mcp): add build_ami and promote_ami ops tools

### DIFF
--- a/.shifter.yaml
+++ b/.shifter.yaml
@@ -121,6 +121,9 @@ mcp_ops:
     - tool: restart_ecs_service
       env: prod
       operation_kind: execute
+    - tool: promote_ami
+      env: prod
+      operation_kind: execute
     - class: db_arbitrary
       env: prod
       operation_kind: execute

--- a/changelog.d/411.added.md
+++ b/changelog.d/411.added.md
@@ -1,0 +1,1 @@
+Added `build_ami` and `promote_ami` tools to the shifter-ops MCP server, mirroring `./scripts/ami.sh` by triggering the `packer.yml` and `packer-promote.yml` GitHub Actions workflows.

--- a/mcp/ops/index.js
+++ b/mcp/ops/index.js
@@ -29,6 +29,12 @@ import {
   buildSsmSendCommandArgs,
   buildRunManageArgs,
   buildPoolConfig,
+  DEFAULT_GITHUB_REPO,
+  BASE_AMI_TYPES,
+  PROMOTE_AMI_REF,
+  buildGhWorkflowRunArgs,
+  ghExec,
+  resolveGitRef,
 } from "./lib.js";
 import {
   loadPolicy,
@@ -48,6 +54,9 @@ function spawnAws(profile, args, options = {}) {
 }
 
 const { Pool } = pg;
+
+const _HERE = path.dirname(fileURLToPath(import.meta.url));
+const _REPO_ROOT = path.resolve(_HERE, "..", "..");
 
 const PROFILES = {
   dev: process.env.PANW_SHIFTER_DEV_PROFILE,
@@ -422,6 +431,9 @@ const SafePath = z
   .string()
   .regex(/^[\w\/.:\-\[\]#, ]+$/, "Contains invalid characters");
 const SafeName = z.string().regex(/^[\w.*?-]+$/, "Contains invalid characters");
+const AmiTypeSchema = z
+  .enum(BASE_AMI_TYPES)
+  .describe("AMI type (kali, ubuntu, windows, dc, brokenbk)");
 const SecretIdSchema = z
   .string()
   .regex(/^[\w/+=.@-]+$/, "Contains invalid characters");
@@ -2434,6 +2446,80 @@ registerTool(ctx, {
 });
 
 // ==========================================================================
+// GitHub Actions — AMI build / promote (issue #411)
+// ==========================================================================
+
+function triggerAmiWorkflow({ workflow, ami_type, ref, actionsPath }) {
+  const branch = ref ?? resolveGitRef(_REPO_ROOT);
+  ghExec(
+    buildGhWorkflowRunArgs({
+      workflow,
+      repo: DEFAULT_GITHUB_REPO,
+      ref: branch,
+      inputs: { ami_type },
+    }),
+  );
+  return (
+    `Triggered ${workflow} for ${ami_type} on ref ${branch}. ` +
+    `View at: https://github.com/${DEFAULT_GITHUB_REPO}/actions/workflows/${actionsPath}`
+  );
+}
+
+registerTool(ctx, {
+  name: "build_ami",
+  klass: "infra_mutation",
+  description:
+    "Trigger packer.yml to build an AMI in dev (equivalent to ./scripts/ami.sh -b <type>). Requires GH_TOKEN or GITHUB_TOKEN.",
+  schema: {
+    ami_type: AmiTypeSchema,
+    ref: SafePath.optional().describe(
+      "Branch to build from (default: current git branch, else dev)",
+    ),
+  },
+  handler: async ({ ami_type, ref }) => {
+    try {
+      return ok(
+        triggerAmiWorkflow({
+          workflow: "packer.yml",
+          ami_type,
+          ref,
+          actionsPath: "packer.yml",
+        }),
+      );
+    } catch (e) {
+      return err(e);
+    }
+  },
+});
+
+registerTool(ctx, {
+  name: "promote_ami",
+  klass: "infra_mutation",
+  description:
+    "Trigger packer-promote.yml to promote an AMI to prod (equivalent to ./scripts/ami.sh -p <type>). Requires GH_TOKEN or GITHUB_TOKEN.",
+  schema: {
+    env: z
+      .literal("prod")
+      .describe("Must be prod — promotion updates production AMIs."),
+    ami_type: AmiTypeSchema,
+  },
+  handler: async ({ ami_type }) => {
+    try {
+      return ok(
+        triggerAmiWorkflow({
+          workflow: "packer-promote.yml",
+          ami_type,
+          ref: PROMOTE_AMI_REF,
+          actionsPath: "packer-promote.yml",
+        }),
+      );
+    } catch (e) {
+      return err(e);
+    }
+  },
+});
+
+// ==========================================================================
 // S3
 // ==========================================================================
 
@@ -3054,8 +3140,6 @@ registerTool(ctx, {
 // registered — fail closed is the only correct path.
 async function main() {
   installLiveProcessHandlers();
-  const _HERE = path.dirname(fileURLToPath(import.meta.url));
-  const _REPO_ROOT = path.resolve(_HERE, "..", "..");
   const server = new McpServer({ name: "shifter-ops", version: "1.0.0" });
   const policy = loadPolicy({
     path: path.join(_REPO_ROOT, ".shifter.yaml"),

--- a/mcp/ops/lib.js
+++ b/mcp/ops/lib.js
@@ -8,6 +8,7 @@
 // module governs the argv-array contract that ADR-010 enforces;
 // see `mcp/ngfw/lib.js` and `mcp/ops/SECURITY.md` for context.
 
+import { spawnSync } from "node:child_process";
 import { buildSsmSendCommandArgs } from "../shared/aws-helpers.js";
 
 export {
@@ -19,6 +20,121 @@ export {
   awsText,
   buildSsmSendCommandArgs,
 } from "../shared/aws-helpers.js";
+
+// --- GitHub Actions (gh CLI) ---
+
+export const DEFAULT_GITHUB_REPO = "Brad-Edwards/shifter";
+
+/** Protected integration branch for prod AMI promotion workflows. */
+export const PROMOTE_AMI_REF = "dev";
+
+export const BASE_AMI_TYPES = Object.freeze([
+  "kali",
+  "ubuntu",
+  "windows",
+  "dc",
+  "brokenbk",
+]);
+
+/**
+ * Build argv for `gh workflow run`. User-controlled values land as
+ * literal argv elements; no shell interpolation (ADR-010).
+ */
+export function buildGhWorkflowRunArgs({ workflow, repo, ref, inputs = {} }) {
+  if (typeof workflow !== "string" || workflow.trim() === "") {
+    throw new TypeError("buildGhWorkflowRunArgs: workflow is required");
+  }
+  if (typeof repo !== "string" || repo.trim() === "") {
+    throw new TypeError("buildGhWorkflowRunArgs: repo is required");
+  }
+  if (typeof ref !== "string" || ref.trim() === "") {
+    throw new TypeError("buildGhWorkflowRunArgs: ref is required");
+  }
+  if (inputs === null || typeof inputs !== "object" || Array.isArray(inputs)) {
+    throw new TypeError("buildGhWorkflowRunArgs: inputs must be an object");
+  }
+  const args = ["workflow", "run", workflow, "--repo", repo, "--ref", ref];
+  for (const [key, value] of Object.entries(inputs)) {
+    args.push("-f", `${key}=${String(value)}`);
+  }
+  return args;
+}
+
+export function resolveGhToken(env = process.env) {
+  const token = env.GH_TOKEN || env.GITHUB_TOKEN;
+  if (typeof token !== "string" || token.trim() === "") {
+    throw new Error(
+      "GitHub token not configured. Set GH_TOKEN or GITHUB_TOKEN in the MCP environment.",
+    );
+  }
+  return token.trim();
+}
+
+function ghOperationLabel(args) {
+  if (!Array.isArray(args) || args.length < 2) return "gh";
+  return `gh ${args.slice(0, 2).join(" ")}`;
+}
+
+function defaultGhRunner(argv, options) {
+  return spawnSync("gh", argv, options); // NOSONAR
+}
+
+export function ghExec(args, options = {}) {
+  if (!Array.isArray(args)) {
+    throw new TypeError(
+      "gh CLI args must be an argv array, not a shell string.",
+    );
+  }
+  const {
+    env = process.env,
+    runner = defaultGhRunner,
+    timeoutMs = 60000,
+    token,
+  } = options;
+  const ghToken = token ?? resolveGhToken(env);
+  const label = ghOperationLabel(args);
+  const result = runner(args, {
+    encoding: "utf-8",
+    timeout: timeoutMs,
+    env: { ...env, GH_TOKEN: ghToken, GITHUB_TOKEN: ghToken },
+  });
+  if (result.error) {
+    const wrapped = new Error(`${label}: ${result.error.message}`);
+    wrapped.cause = result.error;
+    throw wrapped;
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").trim();
+    const detail = stderr || `exited with status ${result.status}`;
+    throw new Error(`${label}: ${detail}`);
+  }
+  return (result.stdout || "").trim();
+}
+
+function defaultGitRunner(argv, options) {
+  return spawnSync("git", argv, options); // NOSONAR
+}
+
+/**
+ * Resolve the current git branch for workflow `--ref`, mirroring
+ * `scripts/ami.sh`. Falls back to `defaultRef` when git is unavailable.
+ */
+export function resolveGitRef(cwd, options = {}) {
+  const { runner = defaultGitRunner, defaultRef = "dev" } = options;
+  const result = runner(["rev-parse", "--abbrev-ref", "HEAD"], {
+    cwd,
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+  if (result.error || result.status !== 0) {
+    return defaultRef;
+  }
+  const ref = (result.stdout || "").trim();
+  if (!ref || ref === "HEAD") {
+    return defaultRef;
+  }
+  return ref;
+}
 
 // --- AWS ---
 

--- a/mcp/ops/lib.test.js
+++ b/mcp/ops/lib.test.js
@@ -29,6 +29,13 @@ import {
   buildSsmSendCommandArgs,
   buildRunManageArgs,
   buildPoolConfig,
+  DEFAULT_GITHUB_REPO,
+  BASE_AMI_TYPES,
+  PROMOTE_AMI_REF,
+  buildGhWorkflowRunArgs,
+  resolveGhToken,
+  ghExec,
+  resolveGitRef,
 } from "./lib.js";
 
 // ---------------------------------------------------------------------------
@@ -1048,5 +1055,130 @@ describe("buildPoolConfig", () => {
       () => buildPoolConfig({ ...validArgs(), port: "5444" }),
       /port must be a positive integer/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHub workflow helpers (issue #411)
+// ---------------------------------------------------------------------------
+describe("buildGhWorkflowRunArgs", () => {
+  it("builds argv for gh workflow run with workflow inputs", () => {
+    assert.deepEqual(
+      buildGhWorkflowRunArgs({
+        workflow: "packer.yml",
+        repo: DEFAULT_GITHUB_REPO,
+        ref: "dev",
+        inputs: { ami_type: "kali" },
+      }),
+      [
+        "workflow",
+        "run",
+        "packer.yml",
+        "--repo",
+        DEFAULT_GITHUB_REPO,
+        "--ref",
+        "dev",
+        "-f",
+        "ami_type=kali",
+      ],
+    );
+  });
+
+  it("preserves metacharacters in input values as literal argv elements", () => {
+    const args = buildGhWorkflowRunArgs({
+      workflow: "packer.yml",
+      repo: DEFAULT_GITHUB_REPO,
+      ref: "feature/foo; rm -rf /",
+      inputs: { ami_type: "kali" },
+    });
+    assert.equal(args[args.indexOf("--ref") + 1], "feature/foo; rm -rf /");
+  });
+});
+
+describe("resolveGhToken", () => {
+  it("prefers GH_TOKEN over GITHUB_TOKEN", () => {
+    assert.equal(
+      resolveGhToken({ GH_TOKEN: "a", GITHUB_TOKEN: "b" }),
+      "a",
+    );
+  });
+
+  it("falls back to GITHUB_TOKEN", () => {
+    assert.equal(resolveGhToken({ GITHUB_TOKEN: "tok" }), "tok");
+  });
+
+  it("throws when no token is configured", () => {
+    assert.throws(() => resolveGhToken({}), /GitHub token not configured/);
+  });
+});
+
+describe("ghExec", () => {
+  it("invokes gh with token injected into the child env", () => {
+    const runner = makeRecordingRunner({ stdout: "ok\n" });
+    ghExec(["workflow", "run", "packer.yml"], {
+      runner,
+      token: "test-token",
+      env: { PATH: "/usr/bin" },
+    });
+    assert.equal(runner.calls.length, 1);
+    assert.deepEqual(runner.calls[0].argv, ["workflow", "run", "packer.yml"]);
+    assert.equal(runner.calls[0].options.env.GH_TOKEN, "test-token");
+    assert.equal(runner.calls[0].options.env.GITHUB_TOKEN, "test-token");
+  });
+
+  it("throws with stderr on non-zero exit", () => {
+    const runner = makeRecordingRunner({
+      status: 1,
+      stderr: "HTTP 403: forbidden",
+    });
+    assert.throws(
+      () =>
+        ghExec(["workflow", "run", "packer.yml"], {
+          runner,
+          token: "t",
+        }),
+      /HTTP 403: forbidden/,
+    );
+  });
+});
+
+describe("resolveGitRef", () => {
+  it("returns git branch when rev-parse succeeds", () => {
+    const calls = [];
+    const runner = (argv, options) => {
+      calls.push({ argv, options });
+      return {
+        status: 0,
+        stdout: "411-ops-mcp-ami\n",
+        stderr: "",
+        error: null,
+      };
+    };
+    assert.equal(resolveGitRef("/repo", { runner }), "411-ops-mcp-ami");
+    assert.deepEqual(calls[0].argv, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    assert.equal(calls[0].options.cwd, "/repo");
+  });
+
+  it("falls back to dev when git fails", () => {
+    const runner = () => ({ status: 128, stdout: "", stderr: "fatal", error: null });
+    assert.equal(resolveGitRef("/repo", { runner, defaultRef: "dev" }), "dev");
+  });
+});
+
+describe("PROMOTE_AMI_REF", () => {
+  it("pins prod promotion to the protected integration branch", () => {
+    assert.equal(PROMOTE_AMI_REF, "dev");
+  });
+});
+
+describe("BASE_AMI_TYPES", () => {
+  it("matches packer-promote base AMI choices", () => {
+    assert.deepEqual([...BASE_AMI_TYPES], [
+      "kali",
+      "ubuntu",
+      "windows",
+      "dc",
+      "brokenbk",
+    ]);
   });
 });

--- a/mcp/ops/tool-surface.test.js
+++ b/mcp/ops/tool-surface.test.js
@@ -200,6 +200,8 @@ const TWO_PHASE_INFRA_MUTATION_BASES = [
   "terminate_ec2_instance",
   "restart_ecs_service",
   "reconcile_ranges",
+  "build_ami",
+  "promote_ami",
 ];
 
 const EXPECTED_DEV_BYPASS_TUNNEL_TOOLS = [


### PR DESCRIPTION
## Summary

Adds build_ami and promote_ami to the shifter-ops MCP server so operators can trigger the existing packer GitHub Actions workflows from an agent session, matching ./scripts/ami.sh while reusing ADR-014 policy gates (two-phase execution, audit, prod apex approval for promotion).

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #411

## ADR Impact

- ADR-014
- ADR-021

## Changes

- Add gh workflow argv helpers in mcp/ops/lib.js (buildGhWorkflowRunArgs, ghExec, resolveGhToken, resolveGitRef)
- Register build_ami and promote_ami as infra_mutation tools with two-phase plan/execute gates
- Pin promote_ami to the protected dev ref; add apex_operations rule in .shifter.yaml
- Add lib and surface tests; changelog fragment 411.added.md

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

cd mcp/ops && npm test && npm run lint; python3 scripts/adr_guard/adr_guard.py --files mcp/ops/lib.js mcp/ops/index.js --level fast

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: 411 ← mcp/ops/lib.test.js, 411 ← mcp/ops/tool-surface.test.js

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/411.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

Made with [Cursor](https://cursor.com)