### PR TITLE
Refactor CMS↔Engine boundary to use Range DSL schemas (#268)

### DIFF
--- a/changelog.d/268.changed.md
+++ b/changelog.d/268.changed.md
@@ -1,0 +1,3 @@
+### Changed
+
+CMS↔Engine range lifecycle now uses `RangeRef` at service and channel boundaries: `engine.create_range` returns `RangeRef`, destroy/cancel accept `RangeRef`, and Mission Control WebSocket broadcasts carry a validated `range_ref` payload.

--- a/shifter/shifter_platform/engine/services/_range.py
+++ b/shifter/shifter_platform/engine/services/_range.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from shared.enums import CANCELLABLE_STATUSES, ResourceStatus
-from shared.schemas import RangeContext, RangeSpec, RequestSpec
+from shared.schemas import RangeRef, RangeSpec, RequestSpec
 from shared.schemas.persistence import wrap_persisted_spec
 
 from ._common import EngineError, _resolve_instance_host
@@ -30,7 +30,7 @@ def _atomic() -> ContextManager[None]:
     return _es.transaction.atomic()
 
 
-def create_range(request_spec: RequestSpec) -> UUID:
+def create_range(request_spec: RequestSpec) -> RangeRef:
     """Provision infrastructure for range.
 
     Interprets the RequestSpec into Engine models (Request, Instance),
@@ -70,7 +70,12 @@ def create_range(request_spec: RequestSpec) -> UUID:
         range_obj.save(update_fields=["step_function_execution_arn"])
         logger.info("create_range: started ECS task=%s", task_arn)
 
-    return request_spec.request_id
+    return RangeRef(
+        request_id=request_spec.request_id,
+        range_id=range_obj.id,
+        user_id=range_spec.user_id,
+        status=ResourceStatus(range_obj.status),
+    )
 
 
 def _persist_range_atomically(
@@ -137,7 +142,7 @@ def _persist_range_atomically(
     return range_obj
 
 
-def destroy_range(request: RangeContext) -> bool:
+def destroy_range(range_ref: RangeRef) -> bool:
     """Tear down range infrastructure.
 
     Sets status to DESTROYING and triggers async ECS teardown.
@@ -148,16 +153,19 @@ def destroy_range(request: RangeContext) -> bool:
     from engine.ecs import start_teardown
     from engine.models import Range
 
-    if request.range_id is None:
-        return _destroy_via_request_id(request.request_id)
+    if not isinstance(range_ref, RangeRef):
+        raise TypeError(f"range_ref must be RangeRef, got {type(range_ref).__name__}")
 
-    logger.debug("destroy_range: range_id=%s", request.range_id)
+    if range_ref.range_id is None:
+        return _destroy_via_request_id(range_ref.request_id)
+
+    logger.debug("destroy_range: range_id=%s", range_ref.range_id)
     try:
-        range_obj = Range.objects.get(id=request.range_id)
+        range_obj = Range.objects.get(id=range_ref.range_id)
     except Range.DoesNotExist:
-        logger.warning("destroy_range: range not found range_id=%s", request.range_id)
+        logger.warning("destroy_range: range not found range_id=%s", range_ref.range_id)
         return False
-    return _apply_destroy_to_range(range_obj, request.range_id, request.user_id, start_teardown)
+    return _apply_destroy_to_range(range_obj, range_ref.range_id, range_ref.user_id, start_teardown)
 
 
 def _destroy_via_request_id(request_id: UUID | None) -> bool:
@@ -194,54 +202,53 @@ def _apply_destroy_to_range(
     return True
 
 
-def cancel_range(range_ctx: RangeContext) -> None:
+def cancel_range(range_ref: RangeRef) -> None:
     """Cancel in-progress provisioning.
 
     Only works for ranges in PENDING or PROVISIONING status.
     Sets status directly to DESTROYING without triggering teardown.
     """
-    if range_ctx is None:
-        logger.error("cancel_range called with None range_ctx")
-        raise TypeError("range_ctx cannot be None")
-    if not isinstance(range_ctx, RangeContext):
-        logger.error("cancel_range called with invalid type: %s", type(range_ctx).__name__)
-        raise TypeError(f"range_ctx must be RangeContext, got {type(range_ctx).__name__}")
+    if range_ref is None:
+        logger.error("cancel_range called with None range_ref")
+        raise TypeError("range_ref cannot be None")
+    if not isinstance(range_ref, RangeRef):
+        logger.error("cancel_range called with invalid type: %s", type(range_ref).__name__)
+        raise TypeError(f"range_ref must be RangeRef, got {type(range_ref).__name__}")
 
-    if range_ctx.range_id is None:
-        if range_ctx.request_id:
-            cancel_range_by_request(range_ctx.request_id)
+    if range_ref.range_id is None:
+        if range_ref.request_id:
+            cancel_range_by_request(range_ref.request_id)
             return
         logger.error("cancel_range called with both range_id and request_id as None")
-        raise ValueError("range_ctx must have either range_id or request_id")
+        raise ValueError("range_ref must have either range_id or request_id")
 
-    if not isinstance(range_ctx.range_id, int) or range_ctx.range_id < 0:
-        logger.error("cancel_range called with invalid range_id: %s", range_ctx.range_id)
-        raise ValueError("range_ctx.range_id must be a non-negative integer")
+    if not isinstance(range_ref.range_id, int) or range_ref.range_id < 0:
+        logger.error("cancel_range called with invalid range_id: %s", range_ref.range_id)
+        raise ValueError("range_ref.range_id must be a non-negative integer")
 
     logger.debug(
         "cancel_range: range_id=%s user_id=%s status=%s",
-        range_ctx.range_id,
-        range_ctx.user_id,
-        range_ctx.status,
+        range_ref.range_id,
+        range_ref.user_id,
+        range_ref.status,
     )
     from engine.models import Range
 
-    range_id = range_ctx.range_id
+    range_id = range_ref.range_id
     try:
         range_obj = Range.objects.get(id=range_id)
     except Range.DoesNotExist:
         logger.warning("cancel_range: range not found range_id=%s", range_id)
         return
 
-    if range_ctx.status not in CANCELLABLE_STATUSES:
+    if ResourceStatus(range_obj.status) not in CANCELLABLE_STATUSES:
         logger.warning(
             "cancel_range: range not cancellable range_id=%s status=%s",
             range_id,
-            range_ctx.status,
+            range_obj.status,
         )
         return
 
-    range_ctx.status = ResourceStatus.DESTROYING
     range_obj.status = Range.Status.DESTROYING
     range_obj.save(update_fields=["status"])
     # Provisioner will poll for status and destroy when it sees DESTROYING

--- a/shifter/shifter_platform/mission_control/handlers.py
+++ b/shifter/shifter_platform/mission_control/handlers.py
@@ -19,6 +19,40 @@ from shared.schemas import RangeRef
 logger = logging.getLogger(__name__)
 
 
+def _range_ref_from_status_event(event: dict) -> RangeRef | None:
+    """Build RangeRef from a range.status.updated event payload, or None when invalid."""
+    request_id = event.get("request_id")
+    range_id = event.get("range_id")
+    user_id = event.get("user_id")
+    new_status = event.get("new_status")
+    event_id = event.get("event_id", "unknown")
+
+    if not request_id:
+        logger.error("Missing request_id in range event: event_id=%s", event_id)
+        return None
+    if new_status is None:
+        logger.error("Missing new_status in range event: event_id=%s", event_id)
+        return None
+    if user_id is None:
+        logger.error("Missing user_id in range event: event_id=%s", event_id)
+        return None
+
+    try:
+        return RangeRef(
+            request_id=request_id,
+            range_id=range_id,
+            user_id=user_id,
+            status=ResourceStatus(new_status),
+        )
+    except (ValueError, TypeError):
+        logger.error(
+            "Invalid range status event payload: event_id=%s request_id=%s",
+            event_id,
+            request_id,
+        )
+        return None
+
+
 def process_event(message: str | dict) -> None:
     """Route event to appropriate handler based on event_type.
 
@@ -71,39 +105,12 @@ def process_range_event(message: str | dict) -> None:
         logger.debug("Ignoring event_type=%s", event_type)
         return
 
-    request_id = event.get("request_id")
-    range_id = event.get("range_id")
-    user_id = event.get("user_id")
-    new_status = event.get("new_status")
+    range_ref = _range_ref_from_status_event(event)
+    if range_ref is None:
+        return
+
     error_message = event.get("error_message")
     event_id = event.get("event_id", "unknown")
-
-    if not request_id:
-        logger.error("Missing request_id in range event: event_id=%s", event_id)
-        return
-
-    if new_status is None:
-        logger.error("Missing new_status in range event: event_id=%s", event_id)
-        return
-
-    if user_id is None:
-        logger.error("Missing user_id in range event: event_id=%s", event_id)
-        return
-
-    try:
-        range_ref = RangeRef(
-            request_id=request_id,
-            range_id=range_id,
-            user_id=user_id,
-            status=ResourceStatus(new_status),
-        )
-    except (ValueError, TypeError):
-        logger.error(
-            "Invalid range status event payload: event_id=%s request_id=%s",
-            event_id,
-            request_id,
-        )
-        return
 
     channel_layer = get_channel_layer()
     group_name = range_event_group(str(range_ref.request_id))

--- a/shifter/shifter_platform/mission_control/handlers.py
+++ b/shifter/shifter_platform/mission_control/handlers.py
@@ -11,8 +11,10 @@ from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 
 from shared.channels.groups import ngfw_event_group, range_event_group
+from shared.enums import ResourceStatus
 from shared.messages.envelope import parse_sns_message
 from shared.messages.events import EVENT_TYPE_NGFW
+from shared.schemas import RangeRef
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +72,8 @@ def process_range_event(message: str | dict) -> None:
         return
 
     request_id = event.get("request_id")
+    range_id = event.get("range_id")
+    user_id = event.get("user_id")
     new_status = event.get("new_status")
     error_message = event.get("error_message")
     event_id = event.get("event_id", "unknown")
@@ -78,15 +82,39 @@ def process_range_event(message: str | dict) -> None:
         logger.error("Missing request_id in range event: event_id=%s", event_id)
         return
 
+    if new_status is None:
+        logger.error("Missing new_status in range event: event_id=%s", event_id)
+        return
+
+    if user_id is None:
+        logger.error("Missing user_id in range event: event_id=%s", event_id)
+        return
+
+    try:
+        range_ref = RangeRef(
+            request_id=request_id,
+            range_id=range_id,
+            user_id=user_id,
+            status=ResourceStatus(new_status),
+        )
+    except (ValueError, TypeError):
+        logger.error(
+            "Invalid range status event payload: event_id=%s request_id=%s",
+            event_id,
+            request_id,
+        )
+        return
+
     channel_layer = get_channel_layer()
-    group_name = range_event_group(str(request_id))
+    group_name = range_event_group(str(range_ref.request_id))
 
     async_to_sync(channel_layer.group_send)(
         group_name,
         {
             "type": "range.status",
-            "request_id": str(request_id),
-            "new_status": new_status,
+            "range_ref": range_ref.model_dump(mode="json"),
+            "request_id": str(range_ref.request_id),
+            "new_status": range_ref.status.value,
             "error_message": error_message,
         },
     )
@@ -94,8 +122,8 @@ def process_range_event(message: str | dict) -> None:
     logger.info(
         "MC broadcast to group %s: request_id=%s status=%s event_id=%s",
         group_name,
-        request_id,
-        new_status,
+        range_ref.request_id,
+        range_ref.status.value,
         event_id,
     )
 

--- a/shifter/shifter_platform/mission_control/handlers.py
+++ b/shifter/shifter_platform/mission_control/handlers.py
@@ -6,6 +6,7 @@ These handlers process range and NGFW status updates and broadcast them to WebSo
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -19,28 +20,27 @@ from shared.schemas import RangeRef
 logger = logging.getLogger(__name__)
 
 
-def _range_ref_from_status_event(event: dict) -> RangeRef | None:
+def _range_ref_from_status_event(event: dict[str, Any]) -> RangeRef | None:
     """Build RangeRef from a range.status.updated event payload, or None when invalid."""
-    request_id = event.get("request_id")
-    range_id = event.get("range_id")
-    user_id = event.get("user_id")
-    new_status = event.get("new_status")
     event_id = event.get("event_id", "unknown")
+    request_id = event.get("request_id")
+    new_status = event.get("new_status")
+    user_id = event.get("user_id")
 
-    if not request_id:
-        logger.error("Missing request_id in range event: event_id=%s", event_id)
-        return None
-    if new_status is None:
-        logger.error("Missing new_status in range event: event_id=%s", event_id)
-        return None
-    if user_id is None:
-        logger.error("Missing user_id in range event: event_id=%s", event_id)
+    if not request_id or new_status is None or user_id is None:
+        logger.error(
+            "Invalid range status event payload: event_id=%s request_id=%s new_status=%s user_id=%s",
+            event_id,
+            request_id,
+            new_status,
+            user_id,
+        )
         return None
 
     try:
         return RangeRef(
             request_id=request_id,
-            range_id=range_id,
+            range_id=event.get("range_id"),
             user_id=user_id,
             status=ResourceStatus(new_status),
         )

--- a/shifter/shifter_platform/mission_control/status_consumers.py
+++ b/shifter/shifter_platform/mission_control/status_consumers.py
@@ -17,6 +17,7 @@ from channels.generic.websocket import AsyncWebsocketConsumer
 from django.contrib.auth.models import AnonymousUser
 
 from shared.enums import WebSocketCloseCode
+from shared.schemas import RangeRef
 
 logger = logging.getLogger(__name__)
 
@@ -101,12 +102,23 @@ class RangeStatusConsumer(AsyncWebsocketConsumer):
 
         Called when a status update is broadcast to the range group.
         """
+        range_ref_payload = event.get("range_ref")
+        request_id: str
+        status: str
+        if range_ref_payload:
+            range_ref = RangeRef.model_validate(range_ref_payload)
+            request_id = str(range_ref.request_id)
+            status = range_ref.status.value
+        else:
+            request_id = str(event.get("request_id", ""))
+            status = str(event.get("new_status", ""))
+
         await self.send(
             text_data=json.dumps(
                 {
                     "type": "status",
-                    "request_id": event.get("request_id"),
-                    "status": event.get("new_status"),
+                    "request_id": request_id,
+                    "status": status,
                     "error_message": event.get("error_message"),
                 }
             )

--- a/shifter/shifter_platform/tests/engine/services/test_cancel_range.py
+++ b/shifter/shifter_platform/tests/engine/services/test_cancel_range.py
@@ -15,7 +15,7 @@ from django.contrib.auth import get_user_model
 from engine import cancel_range, cancel_range_by_request, create_range
 from engine.models import Range
 from shared.enums import ResourceStatus
-from shared.schemas import InstanceSpec, RangeContext, RangeSpec, RequestSpec, SubnetSpec
+from shared.schemas import InstanceSpec, RangeRef, RangeSpec, RequestSpec, SubnetSpec
 
 pytestmark = pytest.mark.django_db
 
@@ -27,9 +27,12 @@ def user(db):
     return User.objects.create_user(username="engine-cancel@example.com", email="engine-cancel@example.com")
 
 
-def _ctx(*, range_id, user_id, status=ResourceStatus.PENDING):
-    return RangeContext(
-        request_id=uuid4(), range_id=range_id, user_id=user_id, scenario_id="s", status=status, instances=[]
+def _ref(*, range_id, user_id, status=ResourceStatus.PENDING, request_id=None):
+    return RangeRef(
+        request_id=request_id or uuid4(),
+        range_id=range_id,
+        user_id=user_id,
+        status=status,
     )
 
 
@@ -60,36 +63,54 @@ class TestCancelRange:
         with pytest.raises(TypeError, match="cannot be None"):
             cancel_range(None)
 
-    def test_rejects_non_rangecontext(self):
-        with pytest.raises(TypeError, match="must be RangeContext"):
-            cancel_range("not-a-context")
+    def test_rejects_non_rangeref(self):
+        with pytest.raises(TypeError, match="must be RangeRef"):
+            cancel_range("not-a-ref")
 
     def test_pydantic_rejects_negative_range_id(self):
         with pytest.raises(ValueError):
-            RangeContext(
-                request_id=uuid4(), range_id=-1, user_id=1, scenario_id="s", status=ResourceStatus.PENDING, instances=[]
+            RangeRef(
+                request_id=uuid4(),
+                range_id=-1,
+                user_id=1,
+                status=ResourceStatus.PENDING,
             )
 
     def test_cancels_provisioning_range(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.PROVISIONING)
-        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PROVISIONING))
+        cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PROVISIONING))
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
 
     def test_does_not_cancel_ready_range(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)
-        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.READY))
+        cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.READY))
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.READY
 
+    def test_ignores_stale_cancellable_ref_when_db_is_ready(self, user):
+        """RangeRef.status is a snapshot; persisted Range.status is authoritative."""
+        range_obj = Range.objects.create(user=user, status=Range.Status.READY)
+        cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PROVISIONING))
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.READY
+
+    def test_cancels_when_db_is_cancellable_despite_stale_ref_status(self, user):
+        range_obj = Range.objects.create(user=user, status=Range.Status.PROVISIONING)
+        cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.READY))
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
+
     def test_missing_range_is_silent(self, user):
-        cancel_range(_ctx(range_id=999999, user_id=user.id, status=ResourceStatus.PENDING))
+        cancel_range(_ref(range_id=999999, user_id=user.id, status=ResourceStatus.PENDING))
 
     def test_logs_cancellation(self, user, caplog):
         range_obj = Range.objects.create(user=user, status=Range.Status.PENDING)
         with caplog.at_level(logging.INFO, logger="engine"):
-            cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PENDING))
+            cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PENDING))
         assert "cancelled" in caplog.text.lower()
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
 
 
 class TestCancelRangeByRequest:

--- a/shifter/shifter_platform/tests/engine/services/test_cancel_range.py
+++ b/shifter/shifter_platform/tests/engine/services/test_cancel_range.py
@@ -112,6 +112,40 @@ class TestCancelRange:
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
 
+    def test_cancels_via_request_id_when_range_id_none(self, user):
+        spec = _request_spec(user.id)
+        create_range(spec)
+        cancel_range(
+            RangeRef(
+                request_id=spec.request_id,
+                range_id=None,
+                user_id=user.id,
+                status=ResourceStatus.PROVISIONING,
+            )
+        )
+        range_obj = Range.objects.get(request__request_id=spec.request_id)
+        assert range_obj.status == Range.Status.DESTROYING
+
+    def test_raises_when_ids_missing_after_construct(self, user):
+        ref = RangeRef.model_construct(
+            request_id=None,
+            range_id=None,
+            user_id=user.id,
+            status=ResourceStatus.PENDING,
+        )
+        with pytest.raises(ValueError, match="range_id or request_id"):
+            cancel_range(ref)
+
+    def test_raises_for_invalid_range_id_type(self, user):
+        ref = RangeRef.model_construct(
+            request_id=uuid4(),
+            range_id="not-an-int",
+            user_id=user.id,
+            status=ResourceStatus.PENDING,
+        )
+        with pytest.raises(ValueError, match="non-negative integer"):
+            cancel_range(ref)
+
 
 class TestCancelRangeByRequest:
     def test_returns_true_and_destroys_cancellable_range(self, user):

--- a/shifter/shifter_platform/tests/engine/services/test_create_range.py
+++ b/shifter/shifter_platform/tests/engine/services/test_create_range.py
@@ -8,7 +8,7 @@ on persisted state and return values, not on mocked ORM/interpreter/ECS calls.
 """
 
 import logging
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -16,7 +16,7 @@ from django.test import override_settings
 
 from engine import create_range
 from engine.models import Range
-from shared.schemas import InstanceSpec, RangeSpec, RequestSpec, SubnetSpec
+from shared.schemas import InstanceSpec, RangeRef, RangeSpec, RequestSpec, SubnetSpec
 
 pytestmark = pytest.mark.django_db
 
@@ -46,11 +46,14 @@ def user(db):
 
 
 class TestCreateRangePersistence:
-    def test_returns_request_id_as_uuid(self, user):
+    def test_returns_range_ref(self, user):
         spec = make_request_spec(user_id=user.id)
         result = create_range(spec)
-        assert isinstance(result, UUID)
-        assert result == spec.request_id
+        assert isinstance(result, RangeRef)
+        assert result.request_id == spec.request_id
+        assert result.user_id == user.id
+        assert result.range_id is not None
+        assert result.range_id > 0
 
     def test_persists_range_for_the_looked_up_user(self, user):
         create_range(make_request_spec(user_id=user.id))
@@ -135,12 +138,14 @@ class TestCreateRangeErrorValidation:
 class TestCreateRangeLogging:
     def test_logs_scenario_and_user_on_entry(self, user, caplog):
         with caplog.at_level(logging.DEBUG, logger="engine"):
-            create_range(make_request_spec(user_id=user.id, scenario_id="advanced-persistent-threat"))
+            ref = create_range(make_request_spec(user_id=user.id, scenario_id="advanced-persistent-threat"))
+        assert isinstance(ref, RangeRef)
         assert "advanced-persistent-threat" in caplog.text
         assert str(user.id) in caplog.text
 
     def test_logs_range_creation(self, user, caplog):
         with caplog.at_level(logging.INFO, logger="engine"):
-            create_range(make_request_spec(user_id=user.id))
+            ref = create_range(make_request_spec(user_id=user.id))
         range_obj = Range.objects.get()
+        assert isinstance(ref, RangeRef)
         assert str(range_obj.id) in caplog.text

--- a/shifter/shifter_platform/tests/engine/services/test_destroy_range.py
+++ b/shifter/shifter_platform/tests/engine/services/test_destroy_range.py
@@ -60,6 +60,10 @@ def _request_spec(user_id):
 
 
 class TestDestroyRange:
+    def test_rejects_non_rangeref(self):
+        with pytest.raises(TypeError, match="must be RangeRef"):
+            destroy_range("not-a-ref")
+
     def test_destroyable_range_returns_true_and_sets_destroying(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)
         assert destroy_range(_ref(range_id=range_obj.id, user_id=user.id)) is True
@@ -78,6 +82,18 @@ class TestDestroyRange:
 
     def test_returns_false_when_not_found(self, user):
         assert destroy_range(_ref(range_id=999999, user_id=user.id)) is False
+
+    def test_destroys_via_request_id_when_range_id_none(self, user):
+        spec = _request_spec(user.id)
+        create_range(spec)
+        ref = RangeRef(
+            request_id=spec.request_id,
+            range_id=None,
+            user_id=user.id,
+            status=ResourceStatus.PROVISIONING,
+        )
+        assert destroy_range(ref) is True
+        assert Range.objects.get(request__request_id=spec.request_id).status == Range.Status.DESTROYING
 
     def test_logs_status_change(self, user, caplog):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)

--- a/shifter/shifter_platform/tests/engine/services/test_destroy_range.py
+++ b/shifter/shifter_platform/tests/engine/services/test_destroy_range.py
@@ -16,7 +16,7 @@ from django.contrib.auth import get_user_model
 from engine import create_range, destroy_range, destroy_range_by_request
 from engine.models import Range
 from shared.enums import ResourceStatus
-from shared.schemas import InstanceSpec, RangeContext, RangeSpec, RequestSpec, SubnetSpec
+from shared.schemas import InstanceSpec, RangeRef, RangeSpec, RequestSpec, SubnetSpec
 
 pytestmark = pytest.mark.django_db
 
@@ -28,14 +28,12 @@ def user(db):
     return User.objects.create_user(username="engine-destroy@example.com", email="engine-destroy@example.com")
 
 
-def _ctx(*, range_id, user_id):
-    return RangeContext(
-        request_id=uuid4(),
+def _ref(*, range_id, user_id, request_id=None, status=ResourceStatus.READY):
+    return RangeRef(
+        request_id=request_id or uuid4(),
         range_id=range_id,
         user_id=user_id,
-        scenario_id="s",
-        status=ResourceStatus.READY,
-        instances=[],
+        status=status,
     )
 
 
@@ -64,32 +62,34 @@ def _request_spec(user_id):
 class TestDestroyRange:
     def test_destroyable_range_returns_true_and_sets_destroying(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)
-        assert destroy_range(_ctx(range_id=range_obj.id, user_id=user.id)) is True
+        assert destroy_range(_ref(range_id=range_obj.id, user_id=user.id)) is True
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
 
     def test_idempotent_when_already_destroying(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.DESTROYING)
-        assert destroy_range(_ctx(range_id=range_obj.id, user_id=user.id)) is True
+        assert destroy_range(_ref(range_id=range_obj.id, user_id=user.id)) is True
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
 
     def test_returns_false_when_already_destroyed(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.DESTROYED)
-        assert destroy_range(_ctx(range_id=range_obj.id, user_id=user.id)) is False
+        assert destroy_range(_ref(range_id=range_obj.id, user_id=user.id)) is False
 
     def test_returns_false_when_not_found(self, user):
-        assert destroy_range(_ctx(range_id=999999, user_id=user.id)) is False
+        assert destroy_range(_ref(range_id=999999, user_id=user.id)) is False
 
     def test_logs_status_change(self, user, caplog):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)
         with caplog.at_level(logging.INFO, logger="engine"):
-            destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+            destroy_range(_ref(range_id=range_obj.id, user_id=user.id))
         assert "DESTROYING" in caplog.text
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
 
     def test_logs_warning_when_not_found(self, user, caplog):
         with caplog.at_level(logging.WARNING, logger="engine"):
-            destroy_range(_ctx(range_id=999999, user_id=user.id))
+            destroy_range(_ref(range_id=999999, user_id=user.id))
         assert "not found" in caplog.text.lower()
 
 

--- a/shifter/shifter_platform/tests/integration/engine/test_range_lifecycle.py
+++ b/shifter/shifter_platform/tests/integration/engine/test_range_lifecycle.py
@@ -21,27 +21,25 @@ from engine.services import (
     get_rdp_connection_info,
 )
 from shared.enums import RequestType, ResourceStatus
-from shared.schemas import RangeContext
+from shared.schemas import RangeRef
 
 User = get_user_model()
 
 
-def make_range_context(
+def make_range_ref(
     range_id: int | None = None,
     request_id=None,
     user_id: int = 1,
     status: str = "ready",
-) -> RangeContext:
-    """Create a valid RangeContext with all required fields."""
+) -> RangeRef:
+    """Create a valid RangeRef for lifecycle operations."""
     import uuid as uuid_module
 
-    return RangeContext(
+    return RangeRef(
         request_id=request_id or uuid_module.uuid4(),
         range_id=range_id,
-        scenario_id="test_scenario",
         user_id=user_id,
         status=ResourceStatus(status),
-        instances=[],
     )
 
 
@@ -194,7 +192,7 @@ class TestDestroyRangeIntegration:
 
     def test_sets_status_to_destroying(self, range_ready):
         """destroy_range updates status in database."""
-        context = make_range_context(
+        context = make_range_ref(
             range_id=range_ready.id,
             request_id=range_ready.request.request_id,
             user_id=range_ready.user.id,
@@ -213,7 +211,7 @@ class TestDestroyRangeIntegration:
 
     def test_returns_false_for_nonexistent_range(self):
         """destroy_range returns False for missing range."""
-        context = make_range_context(range_id=99999, user_id=1, status="ready")
+        context = make_range_ref(range_id=99999, user_id=1, status="ready")
 
         result = destroy_range(context)
         assert result is False
@@ -228,7 +226,7 @@ class TestDestroyRangeIntegration:
             subnet_index=10,
         )
 
-        context = make_range_context(
+        context = make_range_ref(
             range_id=range_obj.id,
             request_id=range_obj.request.request_id,
             user_id=user.id,
@@ -248,7 +246,7 @@ class TestDestroyRangeIntegration:
             subnet_index=11,
         )
 
-        context = make_range_context(
+        context = make_range_ref(
             range_id=range_obj.id,
             request_id=range_obj.request.request_id,
             user_id=user.id,
@@ -260,7 +258,7 @@ class TestDestroyRangeIntegration:
 
     def test_delegates_to_request_id_when_range_id_none(self, range_ready):
         """destroy_range delegates to destroy_range_by_request."""
-        context = make_range_context(
+        context = make_range_ref(
             range_id=None,
             request_id=range_ready.request.request_id,
             user_id=range_ready.user.id,
@@ -288,7 +286,7 @@ class TestCancelRangeIntegration:
 
     def test_cancels_pending_range(self, range_pending):
         """cancel_range sets DESTROYING status for PENDING range."""
-        context = make_range_context(
+        context = make_range_ref(
             range_id=range_pending.id,
             request_id=range_pending.request.request_id,
             user_id=range_pending.user.id,
@@ -302,7 +300,7 @@ class TestCancelRangeIntegration:
 
     def test_cancels_provisioning_range(self, range_provisioning):
         """cancel_range sets DESTROYING status for PROVISIONING range."""
-        context = make_range_context(
+        context = make_range_ref(
             range_id=range_provisioning.id,
             user_id=range_provisioning.user.id,
             status=range_provisioning.status,
@@ -315,7 +313,7 @@ class TestCancelRangeIntegration:
 
     def test_does_not_cancel_ready_range(self, range_ready):
         """cancel_range does not affect READY range."""
-        context = make_range_context(
+        context = make_range_ref(
             range_id=range_ready.id,
             request_id=range_ready.request.request_id,
             user_id=range_ready.user.id,
@@ -333,17 +331,17 @@ class TestCancelRangeIntegration:
             cancel_range(None)
 
     def test_raises_type_error_for_invalid_context_type(self):
-        """cancel_range raises TypeError for non-RangeContext."""
-        with pytest.raises(TypeError, match="must be RangeContext"):
+        """cancel_range raises TypeError for non-RangeRef."""
+        with pytest.raises(TypeError, match="must be RangeRef"):
             cancel_range({"range_id": 1})
 
     def test_raises_validation_error_for_negative_range_id(self, user):
-        """RangeContext raises ValidationError for negative range_id."""
+        """RangeRef raises ValidationError for negative range_id."""
         from pydantic import ValidationError
 
         # Validation happens at schema level, not in cancel_range
         with pytest.raises(ValidationError, match="range_id must be a positive"):
-            make_range_context(range_id=-1, user_id=user.id, status="pending")
+            make_range_ref(range_id=-1, user_id=user.id, status="pending")
 
 
 # =============================================================================

--- a/shifter/shifter_platform/tests/mission_control/consumers/test_range_status_consumer.py
+++ b/shifter/shifter_platform/tests/mission_control/consumers/test_range_status_consumer.py
@@ -125,6 +125,29 @@ class TestRangeStatusConsumerRangeStatus:
         }
 
     @pytest.mark.asyncio
+    async def test_prefers_range_ref_payload(self, consumer):
+        """range_status() hydrates from RangeRef when range_ref is present."""
+        consumer.request_id = TEST_REQUEST_ID
+
+        event = {
+            "type": "range_status",
+            "range_ref": {
+                "request_id": TEST_REQUEST_ID,
+                "range_id": 7,
+                "user_id": 42,
+                "status": ResourceStatus.PROVISIONING.value,
+            },
+            "request_id": TEST_REQUEST_ID,
+            "new_status": ResourceStatus.READY.value,
+            "error_message": None,
+        }
+        await consumer.range_status(event)
+
+        message = json.loads(consumer.send.call_args[1]["text_data"])
+        assert message["request_id"] == TEST_REQUEST_ID
+        assert message["status"] == ResourceStatus.PROVISIONING.value
+
+    @pytest.mark.asyncio
     async def test_includes_error_message_on_failure(self, consumer):
         """range_status() includes error message for failed ranges."""
         consumer.request_id = TEST_REQUEST_ID

--- a/shifter/shifter_platform/tests/mission_control/test_engine_services.py
+++ b/shifter/shifter_platform/tests/mission_control/test_engine_services.py
@@ -14,7 +14,7 @@ from django.contrib.auth import get_user_model
 
 from engine import create_range, get_range_status
 from engine.models import Range
-from shared.schemas import InstanceSpec, RangeSpec, RequestSpec, SubnetSpec
+from shared.schemas import InstanceSpec, RangeRef, RangeSpec, RequestSpec, SubnetSpec
 
 pytestmark = pytest.mark.django_db
 
@@ -83,21 +83,27 @@ class TestCreateRange:
 
         result = create_range(spec)
 
-        assert result == spec.request_id
+        assert isinstance(result, RangeRef)
+        assert result.request_id == spec.request_id
+        assert result.user_id == user.id
+        assert result.range_id is not None
         range_obj = Range.objects.get()
         assert range_obj.user_id == user.id
         # A subnet index was allocated.
         assert range_obj.subnet_index is not None
         assert range_obj.subnet_index >= Range.SUBNET_INDEX_MIN
 
-    def test_returns_request_id(self, user):
+    def test_returns_range_ref(self, user):
         spec = _request_spec(user.id)
-        assert create_range(spec) == spec.request_id
+        ref = create_range(spec)
+        assert isinstance(ref, RangeRef)
+        assert ref.request_id == spec.request_id
 
     def test_logs_range_creation(self, user, caplog):
         spec = _request_spec(user.id)
         with caplog.at_level(logging.INFO, logger="engine"):
-            create_range(spec)
+            result = create_range(spec)
+        assert isinstance(result, RangeRef)
         assert "create_range" in caplog.text
 
     def test_allocates_distinct_indices_for_concurrent_ranges(self, user, db, django_user_model):

--- a/shifter/shifter_platform/tests/mission_control/test_engine_services_lifecycle.py
+++ b/shifter/shifter_platform/tests/mission_control/test_engine_services_lifecycle.py
@@ -14,7 +14,7 @@ from django.contrib.auth import get_user_model
 from engine import cancel_range, destroy_range
 from engine.models import Range
 from shared.enums import ResourceStatus
-from shared.schemas import RangeContext
+from shared.schemas import RangeRef
 
 pytestmark = pytest.mark.django_db
 
@@ -26,42 +26,40 @@ def user(db):
     return User.objects.create_user(username="lifecycle@example.com", email="lifecycle@example.com")
 
 
-def _ctx(*, range_id, user_id, status=ResourceStatus.READY):
-    return RangeContext(
-        request_id=uuid4(),
+def _ref(*, range_id, user_id, status=ResourceStatus.READY, request_id=None):
+    return RangeRef(
+        request_id=request_id or uuid4(),
         range_id=range_id,
         user_id=user_id,
-        scenario_id="test-scenario",
         status=status,
-        instances=[],
     )
 
 
 class TestDestroyRange:
     def test_sets_status_to_destroying_and_returns_true(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)
-        result = destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+        result = destroy_range(_ref(range_id=range_obj.id, user_id=user.id))
         assert result is True
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
 
     def test_returns_false_when_range_not_found(self, user, caplog):
         with caplog.at_level(logging.WARNING, logger="engine"):
-            result = destroy_range(_ctx(range_id=999999, user_id=user.id))
+            result = destroy_range(_ref(range_id=999999, user_id=user.id))
         assert result is False
         assert "not found" in caplog.text.lower()
 
     def test_returns_false_when_already_destroyed(self, user, caplog):
         range_obj = Range.objects.create(user=user, status=Range.Status.DESTROYED)
         with caplog.at_level(logging.WARNING, logger="engine"):
-            result = destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+            result = destroy_range(_ref(range_id=range_obj.id, user_id=user.id))
         assert result is False
         assert "already destroyed" in caplog.text.lower()
 
     def test_idempotent_when_already_destroying(self, user, caplog):
         range_obj = Range.objects.create(user=user, status=Range.Status.DESTROYING)
         with caplog.at_level(logging.INFO, logger="engine"):
-            result = destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+            result = destroy_range(_ref(range_id=range_obj.id, user_id=user.id))
         assert result is True
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
@@ -70,30 +68,33 @@ class TestDestroyRange:
     def test_logs_range_id_on_entry(self, user, caplog):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)
         with caplog.at_level(logging.DEBUG, logger="engine"):
-            destroy_range(_ctx(range_id=range_obj.id, user_id=user.id))
+            result = destroy_range(_ref(range_id=range_obj.id, user_id=user.id))
+        assert result is True
         assert str(range_obj.id) in caplog.text
+        range_obj.refresh_from_db()
+        assert range_obj.status == Range.Status.DESTROYING
 
 
 class TestCancelRange:
     def test_cancels_pending_range(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.PENDING)
-        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PENDING))
+        cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PENDING))
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
 
     def test_cancels_provisioning_range(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.PROVISIONING)
-        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PROVISIONING))
+        cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.PROVISIONING))
         range_obj.refresh_from_db()
         assert range_obj.status == Range.Status.DESTROYING
 
     def test_does_not_cancel_ready_range(self, user):
         range_obj = Range.objects.create(user=user, status=Range.Status.READY)
-        cancel_range(_ctx(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.READY))
+        cancel_range(_ref(range_id=range_obj.id, user_id=user.id, status=ResourceStatus.READY))
         range_obj.refresh_from_db()
         # READY is not cancellable; status is unchanged.
         assert range_obj.status == Range.Status.READY
 
     def test_cancel_missing_range_is_silent(self, user):
         # No row exists; cancel returns without raising.
-        cancel_range(_ctx(range_id=999999, user_id=user.id, status=ResourceStatus.PENDING))
+        cancel_range(_ref(range_id=999999, user_id=user.id, status=ResourceStatus.PENDING))

--- a/shifter/shifter_platform/tests/mission_control/test_handlers.py
+++ b/shifter/shifter_platform/tests/mission_control/test_handlers.py
@@ -94,6 +94,9 @@ class TestProcessRangeEvent:
         assert msg["request_id"] == str(request_id)
         assert msg["new_status"] == ResourceStatus.PROVISIONING.value
         assert msg["error_message"] is None
+        assert msg["range_ref"]["request_id"] == str(request_id)
+        assert msg["range_ref"]["user_id"] == 42
+        assert msg["range_ref"]["status"] == ResourceStatus.PROVISIONING.value
 
     def test_includes_error_message_when_present(self):
         request_id = uuid4()
@@ -104,6 +107,7 @@ class TestProcessRangeEvent:
                     "event_type": "range.status.updated",
                     "request_id": str(request_id),
                     "new_status": ResourceStatus.FAILED.value,
+                    "user_id": 42,
                     "error_message": "Subnet exhausted",
                 }
             )
@@ -153,6 +157,7 @@ class TestProcessEventRouting:
                     "event_type": "range.status.updated",
                     "request_id": str(request_id),
                     "new_status": ResourceStatus.READY.value,
+                    "user_id": 42,
                 }
             )
         )

--- a/shifter/shifter_platform/tests/mission_control/test_handlers.py
+++ b/shifter/shifter_platform/tests/mission_control/test_handlers.py
@@ -129,6 +129,35 @@ class TestProcessRangeEvent:
         process_range_event(_sns({"event_type": "range.status.updated", "new_status": "ready"}))
         assert _receive(layer, channel) is None
 
+    def test_does_not_broadcast_when_user_id_missing(self):
+        request_id = uuid4()
+        layer, channel = _subscribe(range_event_group(str(request_id)))
+        process_range_event(
+            _sns(
+                {
+                    "event_type": "range.status.updated",
+                    "request_id": str(request_id),
+                    "new_status": ResourceStatus.READY.value,
+                }
+            )
+        )
+        assert _receive(layer, channel) is None
+
+    def test_does_not_broadcast_when_status_invalid(self):
+        request_id = uuid4()
+        layer, channel = _subscribe(range_event_group(str(request_id)))
+        process_range_event(
+            _sns(
+                {
+                    "event_type": "range.status.updated",
+                    "request_id": str(request_id),
+                    "new_status": "bogus_status",
+                    "user_id": 42,
+                }
+            )
+        )
+        assert _receive(layer, channel) is None
+
 
 class TestProcessNgfwEvent:
     def test_broadcasts_to_app_group(self):


### PR DESCRIPTION
## Summary

Complete Range DSL boundary typing for issue #268: engine create_range returns RangeRef, destroy/cancel accept RangeRef with DB-authoritative lifecycle checks, and Mission Control WebSocket broadcasts carry validated range_ref payloads. Related Mission Control wiring context: issue #266.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #268

## ADR Impact

- No ADR required

## Changes

- engine.create_range returns RangeRef instead of bare request_id UUID
- engine.destroy_range / cancel_range accept RangeRef; cancel uses persisted Range.status
- Mission Control handlers validate SNS events into RangeRef for channel group_send
- WebSocket consumer prefers range_ref payload; tests updated

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Range lifecycle boundary refactor supporting CTF-902 and Mission Control range status streaming.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: shifter/shifter_platform/tests/engine/services/test_create_range.py, shifter/shifter_platform/tests/engine/services/test_destroy_range.py, shifter/shifter_platform/tests/engine/services/test_cancel_range.py, shifter/shifter_platform/tests/mission_control/test_handlers.py, shifter/shifter_platform/tests/integration/engine/test_range_lifecycle.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/268.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Verified unchanged: no documentation surface in scope.

Made with [Cursor](https://cursor.com)