### PR TITLE
fix(portal): force-remove containers so redeploys are idempotent

### DIFF
--- a/changelog.d/1127.fixed.md
+++ b/changelog.d/1127.fixed.md
@@ -1,0 +1,1 @@
+Made portal redeploys idempotent. `deploy_portal.sh` removed old containers with a plain `docker rm` that fails for any container `docker stop` did not fully stop; the failure was swallowed and the next `docker run --name` aborted with "name already in use" (seen as ctf-scheduler on proof redeploys). Now `docker rm -f`, after the graceful `docker stop` drain.

--- a/scripts/portal-deploy/deploy_portal.sh
+++ b/scripts/portal-deploy/deploy_portal.sh
@@ -269,7 +269,13 @@ run_containers() {
   local stop_timeout="${DOCKER_STOP_TIMEOUT:-35}"
   docker pull "$image"
   docker stop --time "$stop_timeout" portal worker-cms worker-engine worker-mc ctf-scheduler guacamole-bootstrap-prune 2>/dev/null || true
-  docker rm portal worker-cms worker-engine worker-mc ctf-scheduler guacamole-bootstrap-prune 2>/dev/null || true
+  # Force-remove so a redeploy is idempotent. `docker stop` above does the
+  # graceful drain (#931); a plain `docker rm` then fails for any container
+  # still running (e.g. one the stop did not fully stop / a restart-policy
+  # race), the failure is swallowed by `|| true`, and the subsequent
+  # `docker run --name <x>` aborts with "name already in use". `-f` removes
+  # regardless of state so the new containers always get their names.
+  docker rm -f portal worker-cms worker-engine worker-mc ctf-scheduler guacamole-bootstrap-prune 2>/dev/null || true
   docker run -d --name portal --restart unless-stopped -p 8000:8000 "${common_env[@]}" "$image"
   docker run -d --name worker-cms --restart unless-stopped "${worker_health_base[@]}" \
     "--health-cmd=find /tmp/worker-cms-heartbeat -mmin -2 | grep -q ." \


### PR DESCRIPTION
Closes #1127.

The proof redeploy got past the ALLOWED_HOSTS fix (migrate ran clean, portal + 3 workers started) then failed:

```
docker: Error response from daemon: Conflict. The container name "/ctf-scheduler" is already in use ...
failed to run commands: exit status 125
```

run_containers does docker stop then a plain docker rm then docker run --name. When stop does not fully stop a container, rm fails (swallowed by || true) and the run aborts on the name conflict. The rm output listed only 4 of 6 containers.

Fix: docker rm -f (the #931 graceful drain still runs first via docker stop --time). 12 tests pass.