### PR TITLE
fix(proof): disable portal inspection on the single-AZ proof portal

### DIFF
--- a/changelog.d/1130.fixed.md
+++ b/changelog.d/1130.fixed.md
@@ -1,0 +1,1 @@
+Disabled portal east-west inspection on proof. proof runs a single-AZ portal but the ALB spans two AZs; per-AZ Network Firewall inspection makes the cross-AZ ALB->portal flow asymmetric, so the stateful firewall drops it and the cross-AZ ALB node returns 504. Inspection needs the portal in every ALB AZ; re-enable only with a multi-AZ portal.

--- a/platform/terraform/environments/proof/portal/terraform.tfvars
+++ b/platform/terraform/environments/proof/portal/terraform.tfvars
@@ -163,7 +163,13 @@ enable_waf_logging     = true
 # Portal east-west inspection (#122)
 # ------------------------------------------------------------------------------
 
-enable_portal_inspection    = true
+# Disabled on proof: per-AZ Network Firewall inspection requires the portal in
+# every AZ the ALB spans. proof runs a single instance (enable_autoscaling =
+# false) in one AZ, so the cross-AZ ALB node routes ALB->portal through the
+# firewall endpoint in one AZ and the return path through the other, and the
+# stateful firewall drops the asymmetric flow (intermittent 504s on the
+# cross-AZ ALB node). Re-enable only alongside a multi-AZ portal.
+enable_portal_inspection    = false
 firewall_log_retention_days = 365
 
 # proof: allow intentional teardown; apply once with this false before destroying


### PR DESCRIPTION
Closes #1130.

The proof portal is healthy but the domain 504s ~30-50% of the time. Diagnosed deterministically by ALB node: us-east-2a node -> 200, us-east-2b node -> 504. The portal is a single instance in us-east-2a; with enable_portal_inspection=true the cross-AZ ALB node routes the ALB->portal flow asymmetrically through the per-AZ firewall endpoints and the stateful firewall drops it.

Per-AZ NetworkFirewall inspection requires the workload in every AZ the ALB spans. proof is single-AZ, so disable inspection (re-enable only with a multi-AZ portal).

Note: if the TF_VARS_PROOF_PORTAL secret also sets enable_portal_inspection it would override this; I will verify the firewall is destroyed after deploy and update the secret if needed.