### PR TITLE
Fix Checkov module inline skip local/CI parity (#147)

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -295,6 +295,12 @@ jobs:
             platform/terraform/modules/portal/rds/main.tf \
             platform/terraform/modules/guacamole/rds.tf
 
+      # ADR-004-R11 / issue #147: Checkov pre-commit hook args must match
+      # the security-iac job (config, directory, download_external_modules,
+      # soft_fail=false).
+      - name: Run check-checkov-invocation-parity
+        run: python3 scripts/check_checkov_invocation_parity/check_checkov_invocation_parity.py
+
       # #911 NET-2 / #933: the portal target-service SGs (Django:8000,
       # Guacamole client:8080) must source ingress only from a security-group
       # reference or the ALB-only alb_ingress_subnet_cidrs output, never the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -257,6 +257,16 @@ repos:
         files: ^(platform/terraform/modules/portal/rds/main\.tf|platform/terraform/modules/guacamole/rds\.tf)$
         pass_filenames: false
 
+      # ADR-004-R11 / issue #147: pre-commit Checkov args must match the
+      # security-iac job (config path, scan directory, download_external_modules,
+      # soft_fail=false) so module inline skips behave the same locally and in CI.
+      - id: check-checkov-invocation-parity
+        name: Checkov pre-commit / CI invocation parity
+        entry: python3 scripts/check_checkov_invocation_parity/check_checkov_invocation_parity.py
+        language: system
+        files: ^(\.pre-commit-config\.yaml|\.github/workflows/_quality\.yml|platform/terraform/\.checkov\.yaml)$
+        pass_filenames: false
+
       # Pin the behavior of the custom check_tf_* IAM/security
       # checkers themselves. Their test suites (synthetic HCL fixtures
       # covering wildcards, list resources, scoped conditions, missing
@@ -382,7 +392,7 @@ repos:
         files: ^platform/terraform/
         pass_filenames: false
         args:
-          [--config-file, platform/terraform/.checkov.yaml, --directory, platform/terraform/]
+          [--config-file, platform/terraform/.checkov.yaml, --directory, platform/terraform/, --download-external-modules, "true"]
 
   # Kubernetes security and best practices
   - repo: local

--- a/changelog.d/147.fixed.md
+++ b/changelog.d/147.fixed.md
@@ -1,0 +1,4 @@
+Pre-commit Checkov now passes `--download-external-modules` to match the
+`security-iac` CI job, and a repo-native parity checker enforces that both
+surfaces share the same config path, scan directory, and blocking posture.
+Closes the module inline-skip local/CI divergence tracked in #147.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -184,6 +184,7 @@
       "scripts/check_tf_kms_secrets_grant/check_tf_kms_secrets_grant.py",
       "scripts/check_tf_rds_security/check_tf_rds_security.py",
       "scripts/check_portal_target_sg_sources/check_portal_target_sg_sources.py",
+      "scripts/check_checkov_invocation_parity/check_checkov_invocation_parity.py",
       "platform/terraform/.checkov.yaml",
       "docs/adr/exceptions.yaml",
       "docs/architecture/checkov-soft-fail-preflight-757.md",

--- a/docs/architecture/checkov-soft-fail-preflight-757.md
+++ b/docs/architecture/checkov-soft-fail-preflight-757.md
@@ -74,6 +74,23 @@ unwaived. The work split as follows:
 Every waiver maps 1:1 to a `docs/adr/exceptions.yaml` entry with owner,
 reason, expiry, and affected paths.
 
+## Module inline skips (issue #147)
+
+Checkov does not propagate inline `# checkov:skip=CKV_*` comments from a
+module **definition** to the **module call site** in an environment root.
+That upstream limitation is tracked in bridgecrewio/checkov#610.
+
+Repo posture:
+
+- Put inline skips on the **resource block** inside
+  `platform/terraform/modules/**` when the waiver is resource-specific.
+- Run Checkov with `--download-external-modules` on both pre-commit and
+  CI so relative `module { source = ... }` paths load module files into
+  the scan graph (enforced by `scripts/check_checkov_invocation_parity/`).
+- When a rule must be waived repo-wide or Checkov cannot see the module
+  file, add `skip-check` here and an ADR-004-R11 exception — do not re-enable
+  Terraform `--soft-fail`.
+
 ## Anti-patterns
 
 - Do not add a Checkov `skip-check` or inline `# checkov:skip=…` without

--- a/platform/terraform/.checkov.yaml
+++ b/platform/terraform/.checkov.yaml
@@ -5,6 +5,15 @@
 # (.github/workflows/_quality.yml). soft-fail is OFF: first-party
 # Terraform under platform/terraform/ is a blocking Checkov path.
 #
+# Module inline skips (issue #147): place `# checkov:skip=CKV_X:reason`
+# on the resource block inside `platform/terraform/modules/**`. Checkov
+# honors those comments when the module file is loaded into the scan
+# graph. Both surfaces pass `--download-external-modules` so relative
+# module sources from environment roots resolve the same way as in CI.
+# When Checkov still flags a finding at a module call site, use a
+# repo-wide `skip-check` entry here plus ADR-004-R11 exception metadata
+# — not `--soft-fail`.
+#
 # Every skip-check entry below MUST point to a matching ADR exception
 # in docs/adr/exceptions.yaml (rule_id: ADR-004-R11) with owner,
 # reason, expires_on, and the relevant Checkov policy identifier.

--- a/scripts/check_checkov_invocation_parity/check_checkov_invocation_parity.py
+++ b/scripts/check_checkov_invocation_parity/check_checkov_invocation_parity.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Ensure Checkov Terraform invocation parity between pre-commit and CI.
+
+ADR-004-R11 requires one canonical policy at platform/terraform/.checkov.yaml
+and blocking (non-soft-fail) execution. Issue #147: inline module skips only
+apply when Checkov loads module sources; CI already sets
+download_external_modules while pre-commit must match.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+EXPECTED_CONFIG = "platform/terraform/.checkov.yaml"
+EXPECTED_DIRECTORY = "platform/terraform/"
+
+
+def _parse_precommit_checkov_args(precommit_text: str) -> list[str]:
+    """Return flattened checkov hook args from .pre-commit-config.yaml."""
+    in_checkov_hook = False
+    in_args = False
+    args: list[str] = []
+
+    for line in precommit_text.splitlines():
+        stripped = line.strip()
+        if re.match(r"-\s+id:\s+checkov\s*$", stripped):
+            in_checkov_hook = True
+            in_args = False
+            continue
+        if not in_checkov_hook:
+            continue
+        if re.match(r"-\s+id:\s+", stripped):
+            break
+        if stripped.startswith("args:"):
+            in_args = True
+            bracket = stripped.split("[", 1)
+            if len(bracket) == 2 and bracket[1].strip().endswith("]"):
+                inner = bracket[1].rsplit("]", 1)[0]
+                args.extend(_split_args(inner))
+                in_args = False
+            continue
+        if in_args:
+            if stripped.startswith("[") and stripped.endswith("]"):
+                args.extend(_split_args(stripped[1:-1]))
+                in_args = False
+            elif stripped.endswith("]"):
+                args.extend(_split_args(stripped.rstrip("]")))
+                in_args = False
+
+    return args
+
+
+def _split_args(raw: str) -> list[str]:
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _precommit_download_external_modules(args: list[str]) -> bool:
+    for idx, token in enumerate(args):
+        if token in ("--download-external-modules", "download-external-modules"):
+            if idx + 1 < len(args) and args[idx + 1].lower() == "false":
+                return False
+            return True
+    return False
+
+
+def _precommit_soft_fail_enabled(args: list[str]) -> bool:
+    for idx, token in enumerate(args):
+        if token in ("--soft-fail", "soft-fail", "--soft_fail", "soft_fail"):
+            if idx + 1 >= len(args):
+                return True
+            value = args[idx + 1].lower()
+            if value in ("false", "0", "no"):
+                return False
+            return True
+    return False
+
+
+def _parse_ci_checkov_step(workflow_text: str) -> dict[str, str]:
+    """Parse the security-iac Checkov action inputs from _quality.yml."""
+    lines = workflow_text.splitlines()
+    in_security_iac = False
+    in_checkov_step = False
+    inputs: dict[str, str] = {}
+
+    for line in lines:
+        if re.match(r"^  security-iac:\s*$", line):
+            in_security_iac = True
+            in_checkov_step = False
+            continue
+        if in_security_iac and re.match(r"^  [a-z][\w-]*:\s*$", line):
+            if not line.strip().startswith("security-iac"):
+                in_security_iac = False
+                in_checkov_step = False
+        if not in_security_iac:
+            continue
+        if "Checkov IaC Security" in line:
+            in_checkov_step = True
+            continue
+        if in_checkov_step and line.strip().startswith("- name:") and "Checkov IaC Security" not in line:
+            in_checkov_step = False
+        if not in_checkov_step:
+            continue
+        match = re.match(r"\s+(\w+):\s*(.+)\s*$", line)
+        if match:
+            inputs[match.group(1)] = match.group(2).strip()
+
+    return inputs
+
+
+def check_repo(repo_root: Path) -> list[str]:
+    violations: list[str] = []
+
+    precommit_path = repo_root / ".pre-commit-config.yaml"
+    workflow_path = repo_root / ".github" / "workflows" / "_quality.yml"
+
+    if not precommit_path.is_file():
+        return ["missing .pre-commit-config.yaml"]
+    if not workflow_path.is_file():
+        return ["missing .github/workflows/_quality.yml"]
+
+    precommit_args = _parse_precommit_checkov_args(precommit_path.read_text(encoding="utf-8"))
+    ci_inputs = _parse_ci_checkov_step(workflow_path.read_text(encoding="utf-8"))
+
+    config_tokens = [t for t in precommit_args if "checkov.yaml" in t]
+    if EXPECTED_CONFIG not in config_tokens:
+        violations.append(
+            f"pre-commit checkov must use config-file {EXPECTED_CONFIG!r}, got args {precommit_args!r}"
+        )
+
+    directory_tokens = [t for t in precommit_args if t.endswith("platform/terraform/")]
+    if EXPECTED_DIRECTORY not in directory_tokens:
+        violations.append(
+            f"pre-commit checkov must scan directory {EXPECTED_DIRECTORY!r}, got args {precommit_args!r}"
+        )
+
+    if not _precommit_download_external_modules(precommit_args):
+        violations.append(
+            "pre-commit checkov args must include --download-external-modules "
+            "(issue #147 / ADR-004-R11 CI parity)"
+        )
+
+    if _precommit_soft_fail_enabled(precommit_args):
+        violations.append(
+            "pre-commit checkov args must not include --soft-fail "
+            "(ADR-004-R11 blocking gate; parity with CI soft_fail: false)"
+        )
+
+    if ci_inputs.get("config_file") != EXPECTED_CONFIG:
+        violations.append(
+            f"CI Checkov config_file must be {EXPECTED_CONFIG!r}, got {ci_inputs.get('config_file')!r}"
+        )
+    if ci_inputs.get("directory") != EXPECTED_DIRECTORY:
+        violations.append(
+            f"CI Checkov directory must be {EXPECTED_DIRECTORY!r}, got {ci_inputs.get('directory')!r}"
+        )
+    if ci_inputs.get("download_external_modules") != "true":
+        violations.append(
+            "CI Checkov download_external_modules must be true "
+            f"(got {ci_inputs.get('download_external_modules')!r})"
+        )
+    if ci_inputs.get("soft_fail") != "false":
+        violations.append(
+            f"CI Checkov soft_fail must be false (got {ci_inputs.get('soft_fail')!r})"
+        )
+
+    return violations
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    violations = check_repo(repo_root)
+    if violations:
+        for item in violations:
+            print(item)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_checkov_invocation_parity/test_check_checkov_invocation_parity.py
+++ b/scripts/check_checkov_invocation_parity/test_check_checkov_invocation_parity.py
@@ -1,0 +1,337 @@
+"""Tests for check_checkov_invocation_parity.py.
+
+Run from the repo root:
+    python3 -m unittest scripts.check_checkov_invocation_parity.test_check_checkov_invocation_parity -v
+"""
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from .check_checkov_invocation_parity import check_repo
+
+
+class CheckCheckovInvocationParityTest(unittest.TestCase):
+    def test_repo_root_passes_when_precommit_and_ci_match(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+        violations = check_repo(repo_root)
+        self.assertEqual(violations, [], f"unexpected violations: {violations}")
+
+    def test_missing_download_external_modules_in_precommit_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    repos:
+                      - repo: https://github.com/bridgecrewio/checkov
+                        hooks:
+                          - id: checkov
+                            args:
+                              [--config-file, platform/terraform/.checkov.yaml, --directory, platform/terraform/]
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                textwrap.dedent(
+                    """
+                    jobs:
+                      security-iac:
+                        steps:
+                          - name: Checkov IaC Security
+                            uses: bridgecrewio/checkov-action@v12
+                            with:
+                              directory: platform/terraform/
+                              config_file: platform/terraform/.checkov.yaml
+                              download_external_modules: true
+                              soft_fail: false
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("download-external-modules" in v for v in violations),
+            f"expected download-external-modules violation, got: {violations}",
+        )
+
+    def test_precommit_soft_fail_arg_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    repos:
+                      - repo: https://github.com/bridgecrewio/checkov
+                        hooks:
+                          - id: checkov
+                            args:
+                              [--config-file, platform/terraform/.checkov.yaml, --directory, platform/terraform/, --download-external-modules, --soft-fail]
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                textwrap.dedent(
+                    """
+                    jobs:
+                      security-iac:
+                        steps:
+                          - name: Checkov IaC Security
+                            uses: bridgecrewio/checkov-action@v12
+                            with:
+                              directory: platform/terraform/
+                              config_file: platform/terraform/.checkov.yaml
+                              download_external_modules: true
+                              soft_fail: false
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("soft-fail" in v for v in violations),
+            f"expected soft-fail violation, got: {violations}",
+        )
+
+    def test_ci_soft_fail_true_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    repos:
+                      - repo: https://github.com/bridgecrewio/checkov
+                        hooks:
+                          - id: checkov
+                            args:
+                              [--config-file, platform/terraform/.checkov.yaml, --directory, platform/terraform/, --download-external-modules, "true"]
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                textwrap.dedent(
+                    """
+                    jobs:
+                      security-iac:
+                        steps:
+                          - name: Checkov IaC Security
+                            uses: bridgecrewio/checkov-action@v12
+                            with:
+                              directory: platform/terraform/
+                              config_file: platform/terraform/.checkov.yaml
+                              download_external_modules: true
+                              soft_fail: true
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("soft_fail" in v for v in violations),
+            f"expected soft_fail violation, got: {violations}",
+        )
+
+    def test_wrong_config_file_in_precommit_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    repos:
+                      - repo: https://github.com/bridgecrewio/checkov
+                        hooks:
+                          - id: checkov
+                            args:
+                              [--config-file, wrong/.checkov.yaml, --directory, platform/terraform/, --download-external-modules, "true"]
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                _valid_ci_workflow(),
+                encoding="utf-8",
+            )
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("config-file" in v and "pre-commit" in v for v in violations),
+            f"expected pre-commit config violation, got: {violations}",
+        )
+
+    def test_wrong_directory_in_precommit_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                textwrap.dedent(
+                    """
+                    repos:
+                      - repo: https://github.com/bridgecrewio/checkov
+                        hooks:
+                          - id: checkov
+                            args:
+                              [--config-file, platform/terraform/.checkov.yaml, --directory, wrong/, --download-external-modules, "true"]
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                _valid_ci_workflow(),
+                encoding="utf-8",
+            )
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("directory" in v and "pre-commit" in v for v in violations),
+            f"expected pre-commit directory violation, got: {violations}",
+        )
+
+    def test_wrong_config_file_in_ci_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                _valid_precommit_config(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                textwrap.dedent(
+                    """
+                    jobs:
+                      security-iac:
+                        steps:
+                          - name: Checkov IaC Security
+                            uses: bridgecrewio/checkov-action@v12
+                            with:
+                              directory: platform/terraform/
+                              config_file: wrong/.checkov.yaml
+                              download_external_modules: true
+                              soft_fail: false
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("config_file" in v for v in violations),
+            f"expected CI config_file violation, got: {violations}",
+        )
+
+    def test_wrong_directory_in_ci_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                _valid_precommit_config(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                textwrap.dedent(
+                    """
+                    jobs:
+                      security-iac:
+                        steps:
+                          - name: Checkov IaC Security
+                            uses: bridgecrewio/checkov-action@v12
+                            with:
+                              directory: wrong/
+                              config_file: platform/terraform/.checkov.yaml
+                              download_external_modules: true
+                              soft_fail: false
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("directory" in v and "CI" in v for v in violations),
+            f"expected CI directory violation, got: {violations}",
+        )
+
+    def test_missing_download_external_modules_in_ci_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".pre-commit-config.yaml").write_text(
+                _valid_precommit_config(),
+                encoding="utf-8",
+            )
+            (root / ".github").mkdir()
+            (root / ".github" / "workflows").mkdir()
+            (root / ".github" / "workflows" / "_quality.yml").write_text(
+                textwrap.dedent(
+                    """
+                    jobs:
+                      security-iac:
+                        steps:
+                          - name: Checkov IaC Security
+                            uses: bridgecrewio/checkov-action@v12
+                            with:
+                              directory: platform/terraform/
+                              config_file: platform/terraform/.checkov.yaml
+                              download_external_modules: false
+                              soft_fail: false
+                    """
+                ).lstrip(),
+                encoding="utf-8",
+            )
+            violations = check_repo(root)
+
+        self.assertTrue(
+            any("download_external_modules" in v for v in violations),
+            f"expected CI download_external_modules violation, got: {violations}",
+        )
+
+
+def _valid_precommit_config() -> str:
+    return textwrap.dedent(
+        """
+        repos:
+          - repo: https://github.com/bridgecrewio/checkov
+            hooks:
+              - id: checkov
+                args:
+                  [--config-file, platform/terraform/.checkov.yaml, --directory, platform/terraform/, --download-external-modules, "true"]
+        """
+    ).lstrip()
+
+
+def _valid_ci_workflow() -> str:
+    return textwrap.dedent(
+        """
+        jobs:
+          security-iac:
+            steps:
+              - name: Checkov IaC Security
+                uses: bridgecrewio/checkov-action@v12
+                with:
+                  directory: platform/terraform/
+                  config_file: platform/terraform/.checkov.yaml
+                  download_external_modules: true
+                  soft_fail: false
+        """
+    ).lstrip()


### PR DESCRIPTION
## Summary

Close the Checkov module inline-skip local/CI gap: pre-commit now downloads external modules like CI, documents the waiver model for first-party module resources, and adds a parity checker with negative tests so invocation drift fails in pre-commit and Quality.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #147

## ADR Impact

- ADR-004-R11

## Changes

- Add --download-external-modules true to pre-commit checkov hook
- Add scripts/check_checkov_invocation_parity checker + negative tests
- Document module inline-skip waiver model in .checkov.yaml and checkov-soft-fail preflight doc
- Wire parity checker into pre-commit and Quality workflow

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

python3 -m unittest scripts.check_checkov_invocation_parity.test_check_checkov_invocation_parity -v

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: scripts/check_checkov_invocation_parity/check_checkov_invocation_parity.py, .pre-commit-config.yaml, .github/workflows/_quality.yml
- TESTS: scripts/check_checkov_invocation_parity/test_check_checkov_invocation_parity.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/147.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

Made with [Cursor](https://cursor.com)