### PR TITLE
fix(ctf): lock the team row when joining to enforce team_size_limit

### DIFF
--- a/changelog.d/1140.fixed.md
+++ b/changelog.d/1140.fixed.md
@@ -1,0 +1,1 @@
+Fixed a CTF team-join race: concurrent joins using the same invite code could push a team past `team_size_limit` because the capacity check and the membership write were not atomic. The join now locks the team row (`select_for_update`) and re-checks capacity before adding the participant (#1140).

--- a/shifter/shifter_platform/ctf/views/participant.py
+++ b/shifter/shifter_platform/ctf/views/participant.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -315,19 +316,26 @@ def team_join(request: HttpRequest) -> HttpResponse:
             team = CTFTeam.objects.filter(event=event, invite_code=invite_code).first()
             if not team:
                 error = "Invalid invite code."
-            elif team.is_full:
-                error = "This team is full."
             elif participant.team_id == team.id:
                 error = "You are already on this team."
             else:
-                _join_team_and_recompute(participant, team)
-                logger.info(
-                    "Participant %s joined team %s in event %s",
-                    participant.id,
-                    team.id,
-                    event.id,
-                )
-                return redirect("ctf:participant_team")
+                # Serialize concurrent joins on the team so the capacity check and
+                # the membership write cannot race past team_size_limit (#1140):
+                # lock the team row, then re-check is_full under the lock.
+                with transaction.atomic():
+                    locked_team = CTFTeam.objects.select_for_update().get(pk=team.pk)
+                    if locked_team.is_full:
+                        error = "This team is full."
+                    else:
+                        _join_team_and_recompute(participant, locked_team)
+                if error is None:
+                    logger.info(
+                        "Participant %s joined team %s in event %s",
+                        participant.id,
+                        team.id,
+                        event.id,
+                    )
+                    return redirect("ctf:participant_team")
 
     context = {
         "participant": participant,

--- a/shifter/shifter_platform/tests/ctf/test_participant_views.py
+++ b/shifter/shifter_platform/tests/ctf/test_participant_views.py
@@ -11,11 +11,19 @@ from __future__ import annotations
 
 from datetime import timedelta
 
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
 from ctf.enums import ParticipantStatus
 from ctf.models import CTFParticipant
+
+# The team_join error path renders a template that uses {% static %}; force the
+# non-manifest static storage so the render does not require a built manifest.
+_SIMPLE_STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"},
+}
 
 
 class TestAdminParticipantListView:
@@ -559,3 +567,57 @@ class TestAPIParticipantResendInvite:
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
+
+
+class TestTeamJoinCapacityGuard:
+    """#1140: team_join enforces team_size_limit under a team row lock — a full
+    team is rejected and the joining participant is not added."""
+
+    def _active_joiner(self, user, event):
+        from management.services import set_active_ctf_event
+
+        joiner = CTFParticipant.objects.create(
+            event=event,
+            user=user,
+            email=user.email,
+            name="Joiner",
+            status=ParticipantStatus.ACTIVE.value,
+            registered_at=timezone.now(),
+        )
+        set_active_ctf_event(user, event.pk)
+        return joiner
+
+    @override_settings(STORAGES=_SIMPLE_STORAGES)
+    def test_rejects_join_when_team_full(self, authenticated_participant_client, participant_user, ctf_event_team):
+        from ctf.models import CTFTeam
+
+        team = CTFTeam.objects.create(event=ctf_event_team, name="Full Team", invite_code="FULL01")
+        for i in range(ctf_event_team.team_size_limit):
+            CTFParticipant.objects.create(
+                event=ctf_event_team,
+                email=f"member{i}@test.com",
+                name=f"Member {i}",
+                team=team,
+                status=ParticipantStatus.ACTIVE.value,
+                registered_at=timezone.now(),
+            )
+        joiner = self._active_joiner(participant_user, ctf_event_team)
+
+        response = authenticated_participant_client.post(reverse("ctf:team_join"), {"invite_code": "FULL01"})
+
+        assert response.status_code == 200
+        assert "This team is full" in response.content.decode()
+        joiner.refresh_from_db()
+        assert joiner.team_id is None
+
+    def test_allows_join_when_not_full(self, authenticated_participant_client, participant_user, ctf_event_team):
+        from ctf.models import CTFTeam
+
+        team = CTFTeam.objects.create(event=ctf_event_team, name="Open Team", invite_code="OPEN01")
+        joiner = self._active_joiner(participant_user, ctf_event_team)
+
+        response = authenticated_participant_client.post(reverse("ctf:team_join"), {"invite_code": "OPEN01"})
+
+        assert response.status_code == 302
+        joiner.refresh_from_db()
+        assert joiner.team_id == team.id


### PR DESCRIPTION
Closes #1140.

## Problem
`team_join` checked `CTFTeam.is_full` and then added the participant in a separate, unlocked step. Concurrent joins with the same invite code all passed the capacity check before any committed → team overflows `team_size_limit`, recorded permanently by the `cached_member_count` recompute.

## Fix
Move the capacity re-check and the membership write into one `transaction.atomic()` that takes `select_for_update()` on the team row, so joins for a given team serialize and the cap holds under the lock. The already-on-team short-circuit stays before the lock (it's participant state, not capacity).

## Tests
`TestTeamJoinCapacityGuard`: a full team is rejected (participant not added) and a non-full team join succeeds (302 + team set). Full participant-views suite green against a fresh DB (30 passed). ruff/mypy/pre-commit pass.

Third of the native-CTF TOCTOU-class fixes (after #1155); same pattern (select_for_update + re-check under lock).