### PR TITLE
fix(ctf): dedupe team scores by challenge to stop double-counting

### DIFF
--- a/changelog.d/1138.fixed.md
+++ b/changelog.d/1138.fixed.md
@@ -1,0 +1,1 @@
+Fixed CTF team scores double-counting a challenge solved by more than one teammate. The team aggregation summed every correct submission rather than counting each challenge once, so two teammates solving the same challenge inflated the team score. Both the materialized leaderboard and the frozen/bracket scoreboard now count each challenge once, at its best (max) points (#1138).

--- a/shifter/shifter_platform/ctf/services/scoring/_maintenance.py
+++ b/shifter/shifter_platform/ctf/services/scoring/_maintenance.py
@@ -103,20 +103,25 @@ def recompute_team_score(team_id: UUID | None) -> None:
         )
 
         if member_ids:
-            submissions = CTFSubmission.objects.filter(
+            correct = CTFSubmission.objects.filter(
                 participant_id__in=member_ids,
                 is_correct=True,
-            ).aggregate(
-                points=Coalesce(Sum("points_awarded"), 0),
-                solves=Count("challenge_id", distinct=True),
-                last_solve=Max("submitted_at"),
             )
+            # Dedupe by challenge: a challenge solved by more than one teammate
+            # counts once for the team, at its best (max) points. A plain
+            # Sum("points_awarded") double-counted shared solves (#1138). Summed
+            # in Python over the per-challenge maxes to avoid a nested DB
+            # aggregate; the distinct-challenge set is small.
+            per_challenge = list(
+                correct.values("challenge_id").annotate(best=Max("points_awarded")).values_list("best", flat=True)
+            )
+            challenge_points = sum(per_challenge)
+            last_solve = correct.aggregate(last_solve=Max("submitted_at"))["last_solve"]
             award_points = CTFAward.objects.filter(participant_id__in=member_ids).aggregate(
                 points=Coalesce(Sum("points"), 0),
             )["points"]
-            score = submissions["points"] + award_points
-            solve_count = submissions["solves"]
-            last_solve = submissions["last_solve"]
+            score = challenge_points + award_points
+            solve_count = len(per_challenge)
         else:
             score = 0
             solve_count = 0

--- a/shifter/shifter_platform/ctf/services/scoring/_read.py
+++ b/shifter/shifter_platform/ctf/services/scoring/_read.py
@@ -21,6 +21,7 @@ rebuildable from the authoritative rows, so the two strategies agree.
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
@@ -357,48 +358,61 @@ def _recompute_team_scoreboard(
     if bracket_id is not None:
         member_count_filter &= Q(members__bracket_id=bracket_id)
 
-    teams = (
-        CTFTeam.objects.filter(event_id=event_id)
-        .annotate(
-            submission_score=Coalesce(
-                Subquery(
-                    submission_qs.order_by()
-                    .values("participant__team_id")
-                    .annotate(total=Coalesce(Sum("points_awarded"), 0))
-                    .values("total"),
-                    output_field=IntegerField(),
-                ),
-                0,
+    teams_qs = CTFTeam.objects.filter(event_id=event_id).annotate(
+        award_points=Coalesce(
+            Subquery(
+                award_qs.order_by()
+                .values("participant__team_id")
+                .annotate(total=Coalesce(Sum("points"), 0))
+                .values("total"),
+                output_field=IntegerField(),
             ),
-            award_points=Coalesce(
-                Subquery(
-                    award_qs.order_by()
-                    .values("participant__team_id")
-                    .annotate(total=Coalesce(Sum("points"), 0))
-                    .values("total"),
-                    output_field=IntegerField(),
-                ),
-                0,
+            0,
+        ),
+        solve_count=Coalesce(
+            Subquery(
+                submission_qs.order_by()
+                .values("participant__team_id")
+                .annotate(c=Count("challenge_id", distinct=True))
+                .values("c"),
+                output_field=IntegerField(),
             ),
-            computed_score=F("submission_score") + F("award_points"),
-            solve_count=Coalesce(
-                Subquery(
-                    submission_qs.order_by()
-                    .values("participant__team_id")
-                    .annotate(c=Count("challenge_id", distinct=True))
-                    .values("c"),
-                    output_field=IntegerField(),
-                ),
-                0,
-            ),
-            computed_member_count=Count("members", filter=member_count_filter, distinct=True),
-            last_solve_time=Subquery(
-                submission_qs.order_by().values("participant__team_id").annotate(m=Max("submitted_at")).values("m"),
-            ),
-        )
-        .annotate(order_last_solve=_nulls_last(F("last_solve_time")))
-        .order_by("-computed_score", "order_last_solve")
+            0,
+        ),
+        computed_member_count=Count("members", filter=member_count_filter, distinct=True),
+        last_solve_time=Subquery(
+            submission_qs.order_by().values("participant__team_id").annotate(m=Max("submitted_at")).values("m"),
+        ),
+        # Placeholder; the real, challenge-deduped score is set in Python below
+        # (the DB cannot Sum a per-challenge Max in one query).
+        computed_score=Value(0, output_field=IntegerField()),
     )
+
+    # Deduped submission points per team: a challenge solved by more than one
+    # teammate counts once, at its best (max) points (#1138). The DB cannot
+    # Sum() a Max() annotation in one query, so group by (team, challenge) ->
+    # max in the DB and sum the per-challenge maxes per team in Python. This is
+    # the cold (frozen / bracket) path, so per-team iteration is acceptable.
+    dedupe_qs = CTFSubmission.objects.filter(
+        is_correct=True,
+        participant__team__event_id=event_id,
+    ).filter(eligible_participant_q("participant__"))
+    if freeze_at:
+        dedupe_qs = dedupe_qs.filter(submitted_at__lt=freeze_at)
+    if bracket_id is not None:
+        dedupe_qs = dedupe_qs.filter(participant__bracket_id=bracket_id)
+    team_submission_points: dict[Any, int] = defaultdict(int)
+    for row in dedupe_qs.values("participant__team_id", "challenge_id").annotate(best=Max("points_awarded")):
+        team_submission_points[row["participant__team_id"]] += row["best"]
+
+    # Combine deduped submission points with awards, then rank in Python (the
+    # DB ordering used the flat submission_score annotation we removed). Ties
+    # break on earliest last solve, nulls last — matching the materialized path.
+    _MIN_AWARE = datetime.min.replace(tzinfo=UTC)
+    teams = list(teams_qs)
+    for team in teams:
+        team.computed_score = team_submission_points.get(team.id, 0) + team.award_points
+    teams.sort(key=lambda t: (-t.computed_score, t.last_solve_time is None, t.last_solve_time or _MIN_AWARE))
 
     if limit:
         teams = teams[:limit]

--- a/shifter/shifter_platform/tests/ctf/test_scoring.py
+++ b/shifter/shifter_platform/tests/ctf/test_scoring.py
@@ -204,6 +204,33 @@ class TestMaterializedEquivalence:
         assert stats["Empty"]["score"] == 0
         assert stats["Empty"]["member_count"] == 0
 
+    def test_team_score_dedupes_shared_challenge_solves(self, organizer_user):
+        # #1138: two teammates solving the SAME challenge count once for the
+        # team, at the best (max) points — not summed twice. Asserts both the
+        # materialized and the frozen/authoritative recompute paths agree.
+        event = _make_event(organizer_user, team_mode=True)
+        c1 = _make_challenge(event, points=100)
+        now = timezone.now()
+
+        team = CTFTeam.objects.create(event=event, name="Dup")
+        m1 = _make_participant(event, "M1", team=team)
+        m2 = _make_participant(event, "M2", team=team)
+
+        _solve(m1, c1, points=100, at=now - timedelta(minutes=20))
+        # Same challenge, fewer points (e.g. a hint penalty) for the second solver.
+        _solve(m2, c1, points=80, at=now - timedelta(minutes=10))
+
+        recompute_event_leaderboard(event.id)
+
+        materialized = get_team_scoreboard(event.id)
+        authoritative = get_team_scoreboard(event.id, freeze_at=_FAR_FUTURE)
+        assert _by_team(materialized) == _by_team(authoritative)
+
+        stats = {r["name"]: r for r in materialized}
+        # Counted once at the max (100), not 100 + 80.
+        assert stats["Dup"]["score"] == 100
+        assert stats["Dup"]["solve_count"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Scoreboard behavior contract
@@ -415,12 +442,15 @@ class TestMaintenance:
         from ctf.services.participant import disqualify_participant
 
         event = _make_event(organizer_user, team_mode=True)
-        c = _make_challenge(event, points=100)
+        # Distinct challenges so each member's contribution is independent; a
+        # shared challenge would dedupe to a single count (see #1138).
+        c1 = _make_challenge(event, points=100)
+        c2 = _make_challenge(event, points=100)
         team = CTFTeam.objects.create(event=event, name="Alpha")
         keep = _make_participant(event, "Keep", team=team)
         drop = _make_participant(event, "Drop", team=team)
-        _solve(keep, c, points=100)
-        _solve(drop, c, points=100)
+        _solve(keep, c1, points=100)
+        _solve(drop, c2, points=100)
         recompute_event_leaderboard(event.id)
         team.refresh_from_db()
         assert team.cached_score == 200


### PR DESCRIPTION
Closes #1138.

## Problem
Team score aggregation summed `points_awarded` across **every** correct submission while `solve_count` used `Count(distinct challenge)`. In team mode two teammates can each legitimately solve the same challenge, so the team **score double-counted** shared solves (points doubled; solve count showed one).

## Fix
Count each challenge once for the team, at its best (max) points, on **both** paths:
- **`recompute_team_score`** (materialized `cached_score`, the live board): group correct submissions by challenge, take the max points, sum.
- **`_recompute_team_scoreboard`** (frozen/bracket cold path): the DB can't `Sum` a per-challenge `Max` in one query (`'best' is an aggregate`), so group by `(team, challenge)` → max in the DB and sum per team in Python, then rank in Python (ties on earliest last-solve, nulls last) to match the materialized path.

## Tests
`test_team_score_dedupes_shared_challenge_solves`: two teammates solve the same challenge (100 and 80 pts) → team scores it **once at 100**, solve_count 1, and the materialized vs authoritative paths **agree**. Fixed `test_disqualify_drops_team_contribution`, which had encoded the double-count (two members on one challenge expecting 200), to use distinct challenges. 137 scoring/award/bracket tests pass fresh-DB. ruff/mypy/complexity-gate/pre-commit pass.

Native-CTF audit fix (after #1155, #1157, #1159).