### PR TITLE
fix(tests): use freezegun for deterministic upload token expiry

### DIFF
--- a/changelog.d/252.fixed.md
+++ b/changelog.d/252.fixed.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Deterministic upload-token expiry tests using freezegun instead of timing-sensitive TTL hacks ([#252](https://github.com/Brad-Edwards/shifter/issues/252)).

--- a/shifter/shifter_platform/pyproject.toml
+++ b/shifter/shifter_platform/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pre-commit>=4.5.0",
     "pytest-asyncio>=1.3.0",
     "pytest-xdist>=3.5.0",
+    "freezegun>=1.5.5",
     "mypy>=2.1.0",
     "django-stubs>=6.0.4",
     "types-requests>=2.33.0.20260513",

--- a/shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py
+++ b/shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py
@@ -3,7 +3,10 @@
 Tests the HMAC token logic -- no real S3 calls needed.
 """
 
+from datetime import timedelta
+
 import pytest
+from freezegun import freeze_time
 
 from cms.experiments.s3 import (
     _normalize_script_filename_segment,
@@ -56,10 +59,14 @@ class TestUploadToken:
             verify_upload_token("no-dot-separator", user_id=1)
 
     def test_expired_token_raises(self, settings):
-        settings.SCRIPT_UPLOAD_URL_EXPIRES = -1
-        token = generate_upload_token(user_id=1, s3_key="scripts/1/x.py", name="Test", filename="x.py", file_size=100)
-        with pytest.raises(ValueError, match="expired"):
-            verify_upload_token(token, user_id=1)
+        settings.SCRIPT_UPLOAD_URL_EXPIRES = 60
+        with freeze_time("2024-06-01T12:00:00Z") as frozen:
+            token = generate_upload_token(
+                user_id=1, s3_key="scripts/1/x.py", name="Test", filename="x.py", file_size=100
+            )
+            frozen.tick(timedelta(seconds=61))
+            with pytest.raises(ValueError, match="expired"):
+                verify_upload_token(token, user_id=1)
 
 
 class TestScriptFilenameNormalization:

--- a/shifter/shifter_platform/tests/cms/test_services_upload_cancel.py
+++ b/shifter/shifter_platform/tests/cms/test_services_upload_cancel.py
@@ -7,11 +7,13 @@ and ``shared.cloud`` AWS adapter mocked only at the ``boto3`` boundary, instead
 of patching ``verify_upload_token`` / ``delete_agent``.
 """
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.exceptions import ClientError
 from django.contrib.auth import get_user_model
+from freezegun import freeze_time
 
 from cms import services
 from cms.assets.upload_token import generate_upload_token
@@ -89,9 +91,12 @@ class TestCancelUploadTokenValidation:
             services.cancel_upload(user, "not-a-valid-token")
 
     def test_raises_cmserror_on_expired_token(self, user, settings):
-        settings.AGENT_UPLOAD_URL_EXPIRES = -100  # token expires immediately
-        with pytest.raises(CMSError, match="Invalid upload token"):
-            services.cancel_upload(user, _token(user))
+        settings.AGENT_UPLOAD_URL_EXPIRES = 60
+        with freeze_time("2024-06-01T12:00:00Z") as frozen:
+            token = _token(user)
+            frozen.tick(timedelta(seconds=61))
+            with pytest.raises(CMSError, match="Invalid upload token"):
+                services.cancel_upload(user, token)
 
 
 class TestCancelUploadBestEffortDelete:

--- a/shifter/shifter_platform/tests/cms/test_services_upload_complete.py
+++ b/shifter/shifter_platform/tests/cms/test_services_upload_complete.py
@@ -9,11 +9,13 @@ against the persisted ``AgentConfig`` / ``AuditLog`` rows, instead of patching
 ``tag_s3_object`` / ``create_agent``.
 """
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 from botocore.exceptions import ClientError
 from django.contrib.auth import get_user_model
+from freezegun import freeze_time
 
 from cms import services
 from cms.assets.upload_token import generate_upload_token
@@ -124,9 +126,12 @@ class TestCompleteUploadUserAndTokenValidation:
             services.complete_upload(user, "not-a-valid-token")
 
     def test_raises_cmserror_on_expired_token(self, user, settings):
-        settings.AGENT_UPLOAD_URL_EXPIRES = -100
-        with pytest.raises(CMSError, match="Invalid upload token"):
-            services.complete_upload(user, _token(user))
+        settings.AGENT_UPLOAD_URL_EXPIRES = 60
+        with freeze_time("2024-06-01T12:00:00Z") as frozen:
+            token = _token(user)
+            frozen.tick(timedelta(seconds=61))
+            with pytest.raises(CMSError, match="Invalid upload token"):
+                services.complete_upload(user, token)
 
 
 class TestCompleteUploadObjectValidation:

--- a/shifter/shifter_platform/uv.lock
+++ b/shifter/shifter_platform/uv.lock
@@ -818,6 +818,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.30.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2135,6 +2147,7 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "django-stubs" },
+    { name = "freezegun" },
     { name = "import-linter" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -2181,6 +2194,7 @@ requires-dist = [
 dev = [
     { name = "bandit", specifier = ">=1.9.2" },
     { name = "django-stubs", specifier = ">=6.0.4" },
+    { name = "freezegun", specifier = ">=1.5.5" },
     { name = "import-linter", specifier = ">=2.7.0" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pre-commit", specifier = ">=4.5.0" },


### PR DESCRIPTION
## Summary

Upload-token expiry tests no longer rely on negative TTL hacks or real-time sleeps. freezegun advances the clock deterministically so expired tokens fail before S3 finalize paths, fixing the flake described in the migrated #428 issue.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #252

## ADR Impact

- ADR-021

## Changes

- Add freezegun dev dependency to shifter_platform
- Replace negative-TTL upload token expiry tests with freeze_time + tick() in agent complete/cancel and script token suites
- Add changelog fragment for the test flake fix

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

uv run pytest tests/cms/test_services_upload_complete.py tests/cms/test_services_upload_cancel.py tests/cms/experiments/test_s3_tokens.py -n0

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: issue #252 ← shifter/shifter_platform/tests/cms/test_services_upload_complete.py, issue #252 ← shifter/shifter_platform/tests/cms/test_services_upload_cancel.py, issue #252 ← shifter/shifter_platform/tests/cms/experiments/test_s3_tokens.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/252.fixed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

Made with [Cursor](https://cursor.com)