### PR TITLE
chore: enable review-cap disposition gate in shadow mode (judge on)

### DIFF
--- a/.ground-control.yaml
+++ b/.ground-control.yaml
@@ -8,6 +8,12 @@ workflow:
   # test_command and completion_command intentionally omitted; the
   # implement skill will fall back to asking the agent which sub-project
   # to test. A follow-up can add a top-level runner script.
+  review_disposition:
+    enabled: true
+    mode: shadow
+    max_auto_overrides: 1
+    judge:
+      enabled: true
 sonarcloud:
   project_key: Brad-Edwards_shifter
   organization: brad-edwards


### PR DESCRIPTION
Enables the Ground Control review-cap **disposition gate in SHADOW mode** for this repo by adding `workflow.review_disposition` to `.ground-control.yaml`:

```yaml
review_disposition:
  enabled: true
  mode: shadow
  max_auto_overrides: 1
  judge:
    enabled: true
```

In shadow mode the gate records the disposition it *would* take at the review-cap boundary (including the LLM-judge's gray-zone calls) but still escalates to the human and takes no auto-action. This collects readiness data without changing behaviour. `judge.enabled: true` turns on the LLM-judge so its gray-zone calls are captured too.

**DO NOT MERGE until autarchy-ai/Ground-Control#1246 is merged and the MCP server is restarted on that code — until then the older .ground-control.yaml parser rejects the review_disposition key and breaks gc_get_repo_ground_control_context.**

Do not merge until the above condition is satisfied.
