### PR TITLE
fixed: xampp unattended install in windows services

### DIFF
--- a/changelog.d/372.fixed.md
+++ b/changelog.d/372.fixed.md
@@ -1,0 +1,1 @@
+Fix XAMPP unattended install in Windows services.ps1: remove unsupported `--launchapps 0` argument and add exit-code guard that fails the Packer build on installer failure.

--- a/shifter/packer/scripts/windows/services.ps1
+++ b/shifter/packer/scripts/windows/services.ps1
@@ -38,7 +38,11 @@ if ($Role -eq "victim") {
 
     # Install XAMPP silently
     Write-Host "Installing XAMPP..."
-    Start-Process -FilePath "C:\Windows\Temp\$xamppInstaller" -ArgumentList "--mode unattended --launchapps 0" -Wait -NoNewWindow
+    $proc = Start-Process -FilePath "C:\Windows\Temp\$xamppInstaller" -ArgumentList "--mode unattended" -Wait -NoNewWindow -PassThru
+    if ($proc.ExitCode -ne 0) {
+        Write-Error "FATAL: XAMPP installation failed with exit code $($proc.ExitCode)"
+        exit 1
+    }
 
     # Configure XAMPP services to start automatically
     if (Test-Path "$xamppPath\apache\bin\httpd.exe") {

--- a/shifter/packer/tests/test_packer.py
+++ b/shifter/packer/tests/test_packer.py
@@ -327,3 +327,28 @@ class TestUbuntuClaudeCode:
         """Bedrock environment variables should be set."""
         assert "CLAUDE_CODE_USE_BEDROCK=1" in claude_content
         assert "AWS_REGION" in claude_content
+
+
+class TestWindowsServices:
+    """Test that Windows services.ps1 has correct XAMPP install invocation."""
+
+    @pytest.fixture
+    def services_content(self):
+        return (SCRIPTS_DIR / "windows" / "services.ps1").read_text()
+
+    def test_no_launchapps_arg(self, services_content):
+        """--launchapps is not a supported XAMPP unattended arg and must be absent."""
+        assert "--launchapps" not in services_content
+
+    def test_unattended_mode_present(self, services_content):
+        """XAMPP installer must be called with --mode unattended."""
+        assert "--mode unattended" in services_content
+
+    def test_passhru_used(self, services_content):
+        """Start-Process for XAMPP must capture the process object via -PassThru."""
+        assert "-PassThru" in services_content
+
+    def test_exitcode_guard(self, services_content):
+        """Script must check XAMPP exit code and call exit 1 on failure."""
+        assert "ExitCode" in services_content
+        assert "exit 1" in services_content


### PR DESCRIPTION
## Summary

Fix XAMPP unattended install in services.ps1: remove unsupported --launchapps 0 arg and add exit-code guard that fails the Packer build on installer failure.

## Changes

- Removed unsupported `--launchapps 0` argument from XAMPP installer invocation
- Added `-PassThru` flag to `Start-Process` to capture installer exit code
- Added exit-code guard that fails the build if installation fails
- Added tests to verify no --launchapps arg, unattended mode present, -PassThru used, and exit-code guard in place

## Traceability

### Implements

- (none - bug/refactor/maintenance run; see Traceability section below)

### Tests

- shifter/packer/tests/test_packer.py::TestWindowsServices (4 tests)

## Test Plan

- Verify Packer build for Windows victim AMI succeeds with XAMPP installation
- Verify that if XAMPP installer fails in future, the build fails fast (exit code 1)
- Verify existing XAMPP service configuration tests still pass

## Related Issues

Closes #372

### ADR Impact

- ADR-021: Gated Agentic Development Loop