### PR TITLE
docs: add ACES migration ADR and inventory

### DIFF
--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -1013,5 +1013,48 @@
       "mcp/ops/policy.js",
       "mcp/ops/audit.js"
     ]
+  },
+  {
+    "id": "ADR-024",
+    "title": "ACES migration uses a parity-gated parallel cutover",
+    "status": "accepted",
+    "scope": "repository",
+    "decision": "Shifter migrates toward ACES through a parallel path, a row-based parity inventory, explicit ACES manifest/conformance gates, and archive-after-cutover cleanup. Current Shifter behavior remains authoritative until the ACES path proves parity through the normal portal, CMS, engine, provisioner, CTF, experiment, Mission Control, artifact, status, and validation surfaces.",
+    "rules": [
+      {
+        "id": "ADR-024-R1",
+        "description": "ACES adoption must not replace current Shifter runtime behavior until a parallel ACES path has passed parity, manifest/conformance, portal/engine/provisioner, Polaris, CTF, experiment, Mission Control, artifact, status, and ADR guard validation.",
+        "checks": []
+      },
+      {
+        "id": "ADR-024-R2",
+        "description": "Every legacy migration surface tracked for ACES cutover must map to exactly one category in docs/architecture/aces-migration-parity-inventory.yaml: ACES SDL, ACES schema/profile gap, Shifter backend responsibility, validation gate, or archive/delete. Inventory rows cite canonical owners and must not become a second runtime schema, parser, status taxonomy, or exception envelope.",
+        "checks": []
+      },
+      {
+        "id": "ADR-024-R3",
+        "description": "Archive/delete is a post-cutover posture only. CyberScript, current CMS scenario templates, Polaris runtime material, CTF behavior, experiment execution, Mission Control, provisioner paths, artifact handling, status models, and validation gates remain current authority until replacement gates are implemented and green.",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": ["agent-policy"],
+    "evidence": [
+      "docs/architecture/aces-migration-adr.md",
+      "docs/architecture/aces-migration-parity-inventory.yaml",
+      "scenario-dev/polaris/design/aces-sdl-validation-path.md",
+      "scenario-dev/polaris/sdl/README.md",
+      "shifter/shifter_platform/cms/scenarios/schema.py",
+      "shifter/shifter_platform/cms/scenarios/registry.py",
+      "shifter/shifter_platform/cms/scenarios/hydrator.py",
+      "shifter/shifter_platform/shared/schemas",
+      "shifter/cyberscript",
+      "shifter/shifter_platform/ctf",
+      "shifter/shifter_platform/cms/experiments",
+      "shifter/shifter_platform/mission_control",
+      "shifter/shifter_platform/engine",
+      "shifter/engine/provisioner",
+      "scripts/adr_guard/adr_guard.py"
+    ]
   }
 ]

--- a/docs/architecture/aces-migration-adr.md
+++ b/docs/architecture/aces-migration-adr.md
@@ -1,0 +1,180 @@
+# ADR-024: ACES migration uses a parity-gated parallel cutover
+
+## Status
+
+Accepted.
+
+## Date
+
+2026-06-29
+
+## Context
+
+Shifter currently has several scenario, runtime, experiment, and backend
+contract surfaces that predate ACES:
+
+- CMS scenario templates and the scenario registry/hydrator under
+  `shifter/shifter_platform/cms/scenarios/`.
+- CyberScript contracts re-exported through `shared` and consumed by CMS,
+  engine, CTF, and experiment code.
+- Polaris scenario material under `scenario-dev/polaris/`, including ACES SDL
+  drafts, content packages, container realization files, CTFd sync manifests,
+  walkthroughs, and smoke tests.
+- CTF event, challenge, scoring, participant, and range services under
+  `shifter/shifter_platform/ctf/`.
+- Experiment execution planning under `cms.experiments`, with command
+  rendering guarded by `shared.script_context.ScriptExecutionContext`.
+- Mission Control views, range state, terminal access, Guacamole integration,
+  uploaded artifacts, and status/event consumers.
+- Engine and provisioner service boundaries that materialize hydrated specs
+  into database rows, Terraform, cloud tasks, and runtime state.
+
+ACES is the target scenario and experiment contract family, but Shifter cannot
+switch by declaration alone. Current Shifter behavior remains authoritative
+until an ACES path proves parity against the existing stack and passes explicit
+cutover gates.
+
+APTL provides the migration precedent. Its ACES adoption used a parallel path,
+a parity inventory as the audit surface, manifest/conformance gates, and
+archive-after-cutover cleanup. Shifter should reuse that pattern while keeping
+Shifter-specific backend responsibilities in Shifter instead of pushing them
+into ACES SDL.
+
+## Decision
+
+Shifter will migrate toward ACES through a parity-gated parallel cutover.
+
+ACES may become the canonical scenario, runtime, experiment, and backend
+contract surface only after Shifter proves that the ACES path covers the
+legacy surfaces identified in
+`docs/architecture/aces-migration-parity-inventory.yaml`.
+
+The migration has three boundaries:
+
+1. **Authoring and contract boundary.** ACES owns authored scenario and
+   experiment meaning, published schemas, backend manifests, profiles, and
+   conformance vocabulary.
+2. **Shifter backend boundary.** Shifter owns portal behavior, CMS/CTF service
+   semantics, Mission Control, user authorization, range lifecycle, cloud
+   provisioning, artifacts, logs, status, audit, and operator runbooks.
+3. **Validation boundary.** A cutover can happen only when parity inventory
+   rows are reconciled, ACES manifest/conformance gates pass, and Shifter's
+   portal/engine/provisioner validation passes without weakening current
+   guards.
+
+The extension boundary is an explicit ACES contract/profile discriminator at
+the scenario registry and hydrator boundary, not implicit YAML shape detection
+and not Polaris-specific branches in Shifter core.
+
+## Goals
+
+- Preserve current Shifter runtime behavior until parity and cutover readiness
+  are proven.
+- Make the migration reviewable by mapping every legacy surface to exactly one
+  owner category in the parity inventory.
+- Keep ACES semantic ownership separate from Shifter backend realization.
+- Reuse existing Shifter service boundaries, shared contracts, persisted-spec
+  envelopes, authorization helpers, redaction helpers, status models, and
+  provisioner orchestration.
+- Let implementation issues cite stable inventory row ids instead of
+  re-litigating broad migration scope in every PR.
+
+## Non-Goals
+
+- This ADR does not cut over Shifter to ACES.
+- This ADR does not remove CyberScript, current scenario templates, Polaris
+  runtime material, CTF behavior, experiment execution, Mission Control,
+  provisioner code, artifacts, status models, or validation gates.
+- This ADR does not add an ACES parser, ACES runtime target, ACES backend
+  manifest, new API endpoint, data migration, or cloud workflow.
+- This ADR does not make Polaris the public type system for the ACES adapter.
+  Polaris is the primary parity proving case, not the adapter contract.
+
+## Migration Constraints
+
+- ACES integration must enter through `shared`, `cms.scenarios.*`,
+  `cms.services`, and `engine.services` boundaries. Direct ACES or CyberScript
+  imports outside `shared` remain disallowed unless a later ADR changes the
+  import contract.
+- Current CMS scenario id validation, path containment, YAML `safe_load`,
+  Pydantic validation, persisted-spec wrapping, and model validation remain in
+  force until replaced by an equal or stronger ACES-backed gate.
+- CTF scoring, participant access, challenge release, flag validation, hint
+  behavior, event lifecycle, and organizer/admin authorization remain Shifter
+  service responsibilities unless ACES publishes a matching contract and
+  Shifter deliberately binds to it.
+- Experiment command rendering remains behind
+  `ScriptExecutionContext` until ACES participant/runtime contracts prove an
+  equal or stronger prompt, artifact, and command boundary.
+- Mission Control remains the operator/user runtime UI and status boundary.
+  ACES may supply contract payloads, but it does not own Shifter UI behavior.
+- Provisioning remains behind Shifter's engine/provisioner service boundary.
+  ACES backend work must adapt to that boundary rather than invoking cloud,
+  Terraform, Docker, or shell behavior directly from CMS/CTF/Mission Control.
+- No secrets, private keys, real flags, live cloud ids, rendered runtime
+  config, or backend credentials may be embedded in ADR examples or inventory
+  rows.
+
+## Parity Inventory Boundary
+
+The parity inventory is an audit manifest, not a runtime schema. It exists to
+route each legacy surface to one owner category and to identify the next issue
+kind needed for that row.
+
+Every row must use exactly one of these categories:
+
+- **ACES SDL**: the surface belongs in authored ACES scenario or experiment
+  content.
+- **ACES schema/profile gap**: the surface belongs in ACES, but ACES does not
+  yet publish the needed schema, profile, vocabulary, or conformance support.
+- **Shifter backend responsibility**: the surface is portal, service,
+  provisioner, runtime, artifact, status, audit, or operator behavior that
+  Shifter must keep owning.
+- **validation gate**: the surface is not authored directly, but parity must
+  be proven by tests, smoke checks, conformance, ADR guards, import guards,
+  static checks, or live validation.
+- **archive/delete**: the surface is eligible for archive or removal only after
+  the cutover gate proves that no current runtime path depends on it.
+
+Inventory rows cite canonical owners. They must not copy secret-bearing data,
+become a second scenario schema, duplicate ACES models, duplicate CyberScript
+models, duplicate status taxonomies, or replace existing runtime manifests.
+
+## Cutover Gates
+
+A future cutover PR must satisfy all of these gates:
+
+- Every inventory row is reconciled to one category and any candidate issue
+  named by the row is resolved or explicitly marked not needed by a reviewed
+  inventory update.
+- ACES SDL parsing, semantic validation, manifest/profile validation, and
+  backend conformance pass against the Shifter-supported profile.
+- The Shifter ACES path launches the relevant scenario through the normal
+  portal, CMS, engine, and provisioner path, not only through an external demo.
+- Polaris passes its existing infrastructure and content validation in the
+  Shifter path that operators actually use.
+- Existing CTF, experiment, Mission Control, artifact, status, audit, and
+  provisioner tests remain green.
+- `python3 scripts/adr_guard/adr_guard.py --all --level ci` and the
+  stack-native checks required by changed paths remain green.
+- Archive/delete rows are moved only after imports, runtime loaders, docs, and
+  tests no longer treat the legacy surface as current authority.
+
+## Rollback Posture
+
+During the parallel phase, rollback is simple: keep the current Shifter path as
+the default and disable or remove the ACES path if validation fails.
+
+At cutover, rollback requires a preserved legacy reference surface and a
+reversible runtime selector until one release has proven the ACES path. The
+cutover PR must identify the selector or operational rollback path it uses.
+Archive/delete cleanup happens only after that rollback posture is explicit.
+
+## Consequences
+
+- Issue and PR discussions can cite inventory rows by stable id.
+- ACES expressivity gaps are routed to ACES or ACES-profile work instead of
+  being patched into Shifter as a private scenario language.
+- Shifter backend responsibilities remain visible and testable.
+- The migration can progress incrementally without breaking current operators
+  before parity is proven.

--- a/docs/architecture/aces-migration-parity-inventory.yaml
+++ b/docs/architecture/aces-migration-parity-inventory.yaml
@@ -1,0 +1,420 @@
+# Shifter ACES migration parity inventory.
+#
+# Audit surface for ADR-024. Every legacy Shifter scenario, CyberScript,
+# Polaris, CTF, experiment, Mission Control, provisioner, artifact, status, and
+# validation surface listed here maps to exactly one owner category. This file
+# is not a runtime schema, not a parser input, and not an implementation plan.
+
+schema_version: 1
+generated_for: "issue-1230"
+related_adr: docs/architecture/aces-migration-adr.md
+
+categories:
+  - ACES SDL
+  - ACES schema/profile gap
+  - Shifter backend responsibility
+  - validation gate
+  - archive/delete
+
+surfaces:
+  - scenario
+  - CyberScript
+  - Polaris
+  - CTF
+  - experiment
+  - Mission Control
+  - provisioner
+  - artifact
+  - status
+  - validation
+
+row_schema:
+  required_fields:
+    - id
+    - surface
+    - legacy_source
+    - legacy_field
+    - category
+    - aces_target
+    - shifter_owner
+    - validation_evidence
+    - next_issue_kind
+    - candidate_issue_title
+    - notes
+  next_issue_kinds:
+    - none
+    - design-only
+    - implementation-candidate
+
+rows:
+  - id: scenario.yaml-defaults
+    surface: scenario
+    legacy_source: shifter/shifter_platform/cms/scenarios/templates/*.yaml
+    legacy_field: built-in scenario template files
+    category: Shifter backend responsibility
+    aces_target: ACES authored scenario input after registry profile support exists
+    shifter_owner: cms.scenarios.loader, cms.scenarios.registry
+    validation_evidence: shifter/shifter_platform/tests/scenario_editor/test_registry.py
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Add a parallel ACES scenario registry path
+    notes: Current YAML templates remain authoritative until an ACES-backed registry path validates equal behavior.
+
+  - id: scenario.any-template-union
+    surface: scenario
+    legacy_source: shifter/shifter_platform/cms/scenarios/schema.py
+    legacy_field: AnyScenarioTemplate, ScenarioTemplate, CTFScenarioTemplate
+    category: Shifter backend responsibility
+    aces_target: ACES profile discriminator at the scenario registry boundary
+    shifter_owner: cms.scenarios.schema
+    validation_evidence: shifter/shifter_platform/tests/scenario_editor/test_services.py
+    next_issue_kind: design-only
+    candidate_issue_title: Define the Shifter ACES scenario profile discriminator
+    notes: The discriminator boundary belongs at registry/hydrator boundaries, not by inspecting raw YAML shape.
+
+  - id: scenario.hydration-range-spec
+    surface: scenario
+    legacy_source: shifter/shifter_platform/cms/scenarios/hydrator.py
+    legacy_field: hydrate_scenario, hydrate_ctf
+    category: Shifter backend responsibility
+    aces_target: ACES RuntimeModel to Shifter RangeSpec adapter
+    shifter_owner: cms.scenarios.hydrator
+    validation_evidence: shifter/shifter_platform/tests/cms/test_ctf_hydrator.py
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Build an ACES RuntimeModel to Shifter range adapter
+    notes: Hydration owns Shifter request semantics and must not be bypassed by future ACES entrypoints.
+
+  - id: cyberscript.shared-reexports
+    surface: CyberScript
+    legacy_source: shifter/shifter_platform/shared/__init__.py
+    legacy_field: CyberScript enum and exception re-exports
+    category: archive/delete
+    aces_target: shared-native contracts and ACES contract wrappers
+    shifter_owner: shared package
+    validation_evidence: cd shifter/shifter_platform && uv run lint-imports --config ../../.importlinter
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Retire CyberScript shared re-exports after ACES parity
+    notes: Archive/delete is post-cutover only; current imports remain valid until a reviewed replacement lands.
+
+  - id: cyberscript.schema-shims
+    surface: CyberScript
+    legacy_source: shifter/shifter_platform/shared/schemas/
+    legacy_field: request, range, subnet, app, credentials, behaviour, persistence shims
+    category: ACES schema/profile gap
+    aces_target: ACES SDL and runtime contract models with Shifter compatibility wrappers
+    shifter_owner: shared.schemas
+    validation_evidence: shifter/cyberscript/tests/test_schemas.py; shifter/shifter_platform/tests/shared/
+    next_issue_kind: design-only
+    candidate_issue_title: Map CyberScript schema shims to ACES contract/profile coverage
+    notes: The map must distinguish ACES-owned semantics from Shifter-only compatibility wrappers.
+
+  - id: cyberscript.script-context
+    surface: CyberScript
+    legacy_source: shifter/cyberscript/script_context.py
+    legacy_field: ScriptExecutionContext
+    category: Shifter backend responsibility
+    aces_target: ACES participant/runtime contracts only after equal prompt and artifact boundaries exist
+    shifter_owner: shared.script_context, cms.experiments.orchestrator.execution_plan
+    validation_evidence: shifter/shifter_platform/tests/cms/experiments/test_orchestrator_command_safety.py
+    next_issue_kind: design-only
+    candidate_issue_title: Define ACES participant-runtime parity for experiment command execution
+    notes: This is a security boundary for shell, prompt, S3 key, transcript, and instance-id handling.
+
+  - id: polaris.full-sdl
+    surface: Polaris
+    legacy_source: scenario-dev/polaris/sdl/polaris-operation-northstorm.sdl.yaml
+    legacy_field: full Polaris ACES SDL scenario
+    category: ACES SDL
+    aces_target: authored ACES scenario content
+    shifter_owner: scenario-dev/polaris/sdl
+    validation_evidence: scenario-dev/polaris/sdl/README.md
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Validate full Polaris SDL through the Shifter ACES path
+    notes: The SDL is authoring evidence; it is not yet the Shifter runtime boot contract.
+
+  - id: polaris.demo-sdl
+    surface: Polaris
+    legacy_source: scenario-dev/polaris/sdl/polaris-demo-minimal.sdl.yaml
+    legacy_field: minimal ACES backend demo
+    category: validation gate
+    aces_target: ACES parser and backend mechanics smoke input
+    shifter_owner: scenario-dev/polaris/sdl
+    validation_evidence: scenario-dev/polaris/sdl/README.md
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Add Shifter CI coverage for minimal ACES scenario validation
+    notes: The demo should prove mechanics without becoming the full parity claim.
+
+  - id: polaris.image-realization
+    surface: Polaris
+    legacy_source: scenario-dev/polaris/containers/images.yaml
+    legacy_field: images map and content_mounts
+    category: Shifter backend responsibility
+    aces_target: backend realization manifest bound to ACES node source refs
+    shifter_owner: scenario-dev/polaris/containers
+    validation_evidence: scenario-dev/polaris/tests/run-all-smoketests.sh
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Bind Polaris image realization to the Shifter ACES backend adapter
+    notes: Image selection and local build strategy are backend realization, not SDL semantics.
+
+  - id: polaris.content-packages
+    surface: Polaris
+    legacy_source: scenario-dev/polaris/content-packages/polaris/*/package.yaml
+    legacy_field: scenario content package manifests
+    category: ACES SDL
+    aces_target: ACES content declarations plus provenance references
+    shifter_owner: scenario-dev/polaris/content-packages
+    validation_evidence: scenario-dev/polaris/tests/scenario_smoketest/README.md
+    next_issue_kind: design-only
+    candidate_issue_title: Classify Polaris content packages against ACES content/provenance contracts
+    notes: Package manifests carry scenario meaning, while generated runtime material stays out of the inventory.
+
+  - id: polaris.portal-template
+    surface: Polaris
+    legacy_source: shifter/shifter_platform/cms/scenarios/templates/polaris.yaml
+    legacy_field: portal-visible Polaris scenario template
+    category: Shifter backend responsibility
+    aces_target: Shifter ACES registry entry after parity
+    shifter_owner: cms.scenarios.templates
+    validation_evidence: scripts/polaris-aws-range/polaris_provision.py
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Add a portal/engine ACES launch path for Polaris
+    notes: The normal Shifter launch path remains the cutover gate for Polaris.
+
+  - id: polaris.smoketests
+    surface: Polaris
+    legacy_source: scenario-dev/polaris/tests/
+    legacy_field: run-all-smoketests, scenario_smoketest, asset smoketests
+    category: validation gate
+    aces_target: ACES/Shifter parity validation evidence
+    shifter_owner: scenario-dev/polaris/tests
+    validation_evidence: scenario-dev/polaris/tests/run-all-smoketests.sh
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Promote Polaris ACES parity smoke checks into the cutover gate
+    notes: Existing smoke tests are required evidence for any ACES cutover claim.
+
+  - id: ctf.event-lifecycle
+    surface: CTF
+    legacy_source: shifter/shifter_platform/ctf/models/event.py
+    legacy_field: CTFEvent lifecycle and range config
+    category: Shifter backend responsibility
+    aces_target: ACES experiment/run references where applicable
+    shifter_owner: ctf.models, ctf.services.event
+    validation_evidence: shifter/shifter_platform/tests/ctf/test_events.py
+    next_issue_kind: design-only
+    candidate_issue_title: Define the boundary between ACES experiment runs and Shifter CTF events
+    notes: Event lifecycle and organizer authorization stay Shifter-owned.
+
+  - id: ctf.challenge-scoring
+    surface: CTF
+    legacy_source: shifter/shifter_platform/ctf/models/challenge.py
+    legacy_field: challenge metadata, points, release, visibility, target refs
+    category: ACES schema/profile gap
+    aces_target: ACES objective/evaluation/scoring or participant-facing challenge contract
+    shifter_owner: ctf.models, ctf.services.challenge, ctf.services.scoring
+    validation_evidence: shifter/shifter_platform/tests/ctf/test_challenge_services.py
+    next_issue_kind: design-only
+    candidate_issue_title: Specify ACES coverage for CTF challenge and scoring semantics
+    notes: Shifter should not encode CTF scoring as private ACES extensions without an ACES profile decision.
+
+  - id: ctf.flag-validation
+    surface: CTF
+    legacy_source: shifter/shifter_platform/ctf/services/submission.py
+    legacy_field: flag submission and correctness checks
+    category: Shifter backend responsibility
+    aces_target: ACES evaluation result evidence only after a matching contract exists
+    shifter_owner: ctf.services.submission
+    validation_evidence: shifter/shifter_platform/tests/ctf/test_submit_flag_rate_limit_api.py
+    next_issue_kind: design-only
+    candidate_issue_title: Decide whether ACES consumes Shifter CTF submission evidence
+    notes: Shifter owns answer validation and abuse controls.
+
+  - id: ctf.ctfd-sync
+    surface: CTF
+    legacy_source: scripts/ctfd-workshop/polaris_manifest.py
+    legacy_field: validate_manifest, verify_challenge_rows, ordered challenge names
+    category: validation gate
+    aces_target: CTFd parity and challenge-row evidence for Polaris
+    shifter_owner: scripts/ctfd-workshop
+    validation_evidence: scripts/ctfd-workshop/test_sync_polaris_ctfd.py
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Connect CTFd manifest validation to ACES parity evidence
+    notes: Sync validation proves live board integrity; it is not authored ACES scenario meaning by itself.
+
+  - id: experiment.lifecycle
+    surface: experiment
+    legacy_source: shifter/shifter_platform/cms/experiments/schemas.py
+    legacy_field: ExperimentStatus, RunStatus, transitions
+    category: ACES schema/profile gap
+    aces_target: ACES experiment-core and runtime status contracts
+    shifter_owner: cms.experiments.schemas
+    validation_evidence: shifter/shifter_platform/tests/cms/experiments/test_services.py
+    next_issue_kind: design-only
+    candidate_issue_title: Map Shifter experiment lifecycle to ACES experiment-core contracts
+    notes: Status parity must distinguish Shifter operational state from ACES archival experiment records.
+
+  - id: experiment.execution-plan
+    surface: experiment
+    legacy_source: shifter/shifter_platform/cms/experiments/orchestrator/execution_plan.py
+    legacy_field: build_execution_plan, ScriptCommand, RunExecutionPlan
+    category: Shifter backend responsibility
+    aces_target: ACES participant runtime adapter after profile support exists
+    shifter_owner: cms.experiments.orchestrator
+    validation_evidence: shifter/shifter_platform/tests/cms/experiments/test_orchestrator_command_safety.py
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Adapt ACES participant runtime contracts to Shifter experiment execution
+    notes: The current AWS-only SSM execution boundary remains explicit.
+
+  - id: experiment.artifacts
+    surface: artifact
+    legacy_source: shifter/shifter_platform/cms/experiments/models.py
+    legacy_field: experiment run artifacts and Claude transcript artifacts
+    category: ACES schema/profile gap
+    aces_target: ACES evidence/provenance and experiment-run artifact contracts
+    shifter_owner: cms.experiments
+    validation_evidence: shifter/shifter_platform/tests/cms/experiments/
+    next_issue_kind: design-only
+    candidate_issue_title: Define ACES evidence mapping for Shifter experiment artifacts
+    notes: Artifact identity and redaction rules need a contract map before implementation.
+
+  - id: mission-control.range-ui
+    surface: Mission Control
+    legacy_source: shifter/shifter_platform/mission_control/views/_ranges.py
+    legacy_field: range dashboard and action surfaces
+    category: Shifter backend responsibility
+    aces_target: ACES status payloads consumed by Shifter UI after adapter support
+    shifter_owner: mission_control.views, engine.services
+    validation_evidence: shifter/shifter_platform/tests/mission_control/test_range_api.py
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Expose ACES-backed range status through existing Mission Control views
+    notes: Mission Control remains the product UI even if ACES supplies backend state.
+
+  - id: mission-control.terminal-guacamole
+    surface: Mission Control
+    legacy_source: shifter/shifter_platform/mission_control/views/_guacamole.py
+    legacy_field: Guacamole and terminal access flows
+    category: Shifter backend responsibility
+    aces_target: n/a
+    shifter_owner: mission_control.views, engine.ssh
+    validation_evidence: shifter/shifter_platform/tests/mission_control/test_views_guacamole.py
+    next_issue_kind: none
+    candidate_issue_title: n/a
+    notes: Terminal and Guacamole access are Shifter runtime/user-access behavior, not ACES SDL semantics.
+
+  - id: provisioner.persisted-specs
+    surface: provisioner
+    legacy_source: shifter/shifter_platform/engine/interpreter.py
+    legacy_field: interpret, wrap_persisted_spec
+    category: Shifter backend responsibility
+    aces_target: ACES runtime model payload wrapped as a Shifter persisted spec when supported
+    shifter_owner: engine.interpreter, shared.schemas.persistence
+    validation_evidence: shifter/shifter_platform/tests/engine/
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Persist ACES-derived specs through the existing Shifter envelope
+    notes: Raw unwrapped ACES payloads must not bypass persisted-spec validation.
+
+  - id: provisioner.range-services
+    surface: provisioner
+    legacy_source: shifter/shifter_platform/engine/services/
+    legacy_field: create, lifecycle, queries, terminal, NGFW range services
+    category: Shifter backend responsibility
+    aces_target: ACES backend target adapter into Shifter engine services
+    shifter_owner: engine.services
+    validation_evidence: shifter/shifter_platform/tests/engine/
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Implement a Shifter ACES backend target through engine services
+    notes: ACES backend work must adapt to services instead of reaching around them.
+
+  - id: provisioner.polaris-aws-path
+    surface: provisioner
+    legacy_source: scripts/polaris-aws-range/
+    legacy_field: standalone Polaris provisioning and golden AMI validation
+    category: validation gate
+    aces_target: Shifter portal/engine cutover validation evidence
+    shifter_owner: scripts/polaris-aws-range, shifter/engine/provisioner
+    validation_evidence: scripts/polaris-aws-range/README.md
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Reconcile Polaris standalone validation with ACES cutover readiness
+    notes: The normal portal/engine launch path must pass before ACES replaces current behavior.
+
+  - id: artifact.cms-assets
+    surface: artifact
+    legacy_source: shifter/shifter_platform/cms/models/assets.py
+    legacy_field: uploaded assets and S3-backed file metadata
+    category: Shifter backend responsibility
+    aces_target: ACES evidence refs only where a later contract binds them
+    shifter_owner: cms.assets, shared.s3
+    validation_evidence: shifter/shifter_platform/tests/cms/test_assets.py
+    next_issue_kind: design-only
+    candidate_issue_title: Decide which Shifter uploaded artifacts become ACES evidence references
+    notes: Shifter owns storage, inspection, permissions, and secret handling for uploaded artifacts.
+
+  - id: artifact.polaris-content
+    surface: artifact
+    legacy_source: scenario-dev/polaris/content-packages/polaris/
+    legacy_field: generated scenario content inputs
+    category: ACES SDL
+    aces_target: ACES content/provenance declarations
+    shifter_owner: scenario-dev/polaris/content-packages
+    validation_evidence: scenario-dev/polaris/tests/scenario_smoketest/README.md
+    next_issue_kind: design-only
+    candidate_issue_title: Bind Polaris content packages to ACES provenance terms
+    notes: Content inputs are scenario meaning; generated outputs remain runtime evidence.
+
+  - id: status.engine-range
+    surface: status
+    legacy_source: shifter/shifter_platform/engine/models.py
+    legacy_field: Range.Status and Instantiation.status
+    category: Shifter backend responsibility
+    aces_target: ACES operation-status-v1 adapter view
+    shifter_owner: engine.models, engine.services
+    validation_evidence: shifter/shifter_platform/tests/engine/
+    next_issue_kind: design-only
+    candidate_issue_title: Map Shifter lifecycle states to ACES operation status
+    notes: Shifter keeps operator-facing lifecycle states; ACES status should be an adapter view.
+
+  - id: status.ctf-range
+    surface: status
+    legacy_source: shifter/shifter_platform/ctf/services/range/status.py
+    legacy_field: participant CTF range status
+    category: Shifter backend responsibility
+    aces_target: ACES participant/runtime observation only after a matching contract exists
+    shifter_owner: ctf.services.range
+    validation_evidence: shifter/shifter_platform/tests/ctf/test_services/test_range.py
+    next_issue_kind: design-only
+    candidate_issue_title: Decide whether CTF participant range status is exported to ACES
+    notes: Participant access state stays tied to Shifter CTF authorization.
+
+  - id: validation.adr-guard
+    surface: validation
+    legacy_source: scripts/adr_guard/adr_guard.py
+    legacy_field: ADR and repository policy checks
+    category: validation gate
+    aces_target: cutover policy gate
+    shifter_owner: scripts/adr_guard
+    validation_evidence: python3 scripts/adr_guard/adr_guard.py --all --level ci
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Add ACES cutover checks to adr_guard when implementation starts
+    notes: This issue does not add a new executable gate; cutover implementation should.
+
+  - id: validation.import-boundaries
+    surface: validation
+    legacy_source: .importlinter; scripts/check_layer_imports/layer_imports.yaml
+    legacy_field: shared-only CyberScript import rule and layer import contracts
+    category: validation gate
+    aces_target: ACES/shared import boundary check
+    shifter_owner: import-linter and layer import checks
+    validation_evidence: cd shifter/shifter_platform && uv run lint-imports --config ../../.importlinter
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Extend import boundary checks for ACES adoption
+    notes: Future ACES imports need the same discipline as current CyberScript imports.
+
+  - id: validation.aces-manifest-conformance
+    surface: validation
+    legacy_source: aces-sdl/contracts/profiles/backend/
+    legacy_field: backend profile and conformance contract corpus
+    category: validation gate
+    aces_target: ACES backend manifest and conformance CLI
+    shifter_owner: future Shifter ACES backend adapter
+    validation_evidence: aces conformance backend --profile <shifter-profile>
+    next_issue_kind: implementation-candidate
+    candidate_issue_title: Publish and validate a Shifter ACES backend manifest
+    notes: Cutover requires a published profile claim validated by ACES conformance, not prose.


### PR DESCRIPTION
## Summary

Adds ADR-024 and a row-based parity inventory that define Shifter's ACES migration as a parallel, parity-gated cutover while preserving current Shifter behavior until explicit readiness gates pass.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1230

## ADR Impact

- ADR-024
- ADR-021

## Changes

- Add ADR-024 describing the ACES migration decision, goals, non-goals, constraints, cutover gates, and rollback posture.
- Add a reviewable ACES parity inventory mapping Shifter scenario, CyberScript, Polaris, CTF, experiment, Mission Control, provisioner, artifact, status, and validation surfaces to the approved owner categories.
- Register ADR-024 in the machine-readable ADR index with evidence links and agent-policy rules.

## Test Plan

- [x] `python3 scripts/adr_guard/adr_guard.py --files docs/adr/index.yaml docs/architecture/aces-migration-adr.md docs/architecture/aces-migration-parity-inventory.yaml --level fast`
- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- [x] `pre-commit run --all-files` passed before the final `origin/dev` merge
- [x] Merged-branch hook retry: `pre-commit run pytest-shifter --all-files`
- Unit tests / integration tests: N/A — docs-only change

Note: after the final `origin/dev` merge, the full all-files hook run reached one Guacamole async timing failure in `pytest-shifter`; rerunning that failing pre-commit hook passed.

## Ground Control Checks

- [x] `gc_assert_quality_gates` passed for this no-requirements docs run
- [x] Codex pre-push review cycle passed clean
- [x] GRC screening was recorded for issue #1230

## Traceability

- IMPLEMENTS: ADR-024 <- docs/architecture/aces-migration-adr.md, ADR-024 <- docs/architecture/aces-migration-parity-inventory.yaml, ADR-024 <- docs/adr/index.yaml
- TESTS: ADR-024 <- python3 scripts/adr_guard/adr_guard.py --all --level ci, ADR-024 <- pre-commit run --all-files, ADR-024 <- pre-commit run pytest-shifter --all-files

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed