### PR TITLE
removed: drop dead risk_register APIKey reference from access.py

### DIFF
--- a/changelog.d/1244.changed.md
+++ b/changelog.d/1244.changed.md
@@ -1,0 +1,1 @@
+Removed an unreachable dead `APIKey` branch from the `risk_register` access policy, left over after the legacy `rr_live_` API key was retired in #1124. Internal cleanup with no user-facing or behavioral change; the archival `APIKey` model and table are unaffected.

--- a/docs/architecture/risk-register-apikey-retirement-preflight-1124.md
+++ b/docs/architecture/risk-register-apikey-retirement-preflight-1124.md
@@ -56,6 +56,10 @@ minting path is not.
   programmatic caller to the endpoint class; `risk_register.access` still proves
   the token owner belongs to an allowed Cognito group, and session callers still
   need staff/superuser permission where the current API requires it.
+- Keep `risk_register.access` on runtime principals only. After #1124, that
+  means `shared.api_tokens.ApiToken` plus authenticated sessions; the archival
+  `risk_register.models.APIKey` model must not be imported into access-policy
+  branches or accepted as a `request.auth` shape.
 - Treat `AuditLog.ActorType.APIKEY` and `AuditLog.EntityType.APIKEY` as durable
   historical enum values unless a separate audit-taxonomy migration updates the
   model, serializers, admin, docs, and tests together. Do not partially rename
@@ -74,7 +78,7 @@ minting path is not.
 | Platform DRF auth | `config/_drf_settings.py`, `ApiTokenAuthentication`, DRF `SessionAuthentication` | Risk-register endpoints should use the shared session/bearer-token path. No legacy app-local authenticator should remain as an accepting credential path. |
 | Scope admission | `shared.api_tokens.scopes`, `shared.api_tokens.permissions.require_scope` | Use `RISK_READ` and `RISK_WRITE`; do not add app-local booleans, wildcard scopes, or APIKey-specific scopes. |
 | Token lifecycle | `shared/api_tokens/{models,admin,audit,scopes,permissions}.py` | Replacement tokens use the one-time raw-token, bounded-TTL, revocation, and audit behavior already implemented there. |
-| Risk authorization | `risk_register.access.principal_has_risk_register_access`, `HasRiskRegisterCognitoGroup`, `IsStaffSessionOrToken` | Keep Cognito-group and staff/session semantics. Remove only the legacy key principal, not the second-stage domain gates. |
+| Risk authorization | `risk_register.access.principal_has_risk_register_access`, `HasRiskRegisterCognitoGroup`, `IsStaffSessionOrToken` | Keep Cognito-group and staff/session semantics. Runtime token branches accept `ApiToken` only; the archival `APIKey` model must not remain in access-policy imports or `request.auth` type checks. Remove only the legacy key principal, not the second-stage domain gates. |
 | Legacy key surfaces | `risk_register.models.APIKey`, `risk_register.api.authentication`, `risk_register.api.views.APIKeyViewSet`, `risk_register.api.serializers`, `risk_register.views.apikey_*`, `APIKeyAdmin` | Disable or remove runtime mint/auth surfaces deliberately. Preserve archival data only when needed for comments or audit history. |
 | Audit | `risk_register.services.AuditEvent`, `audit_log`, `audit_log_from_request`, `get_client_ip`, `get_request_id`, `shared.api_tokens.audit` | Use existing audit helpers and trusted client-IP resolution. Do not add a parallel credential-retirement audit table. |
 | Error envelopes | `shared.api.errors.api_exception_handler`, `api_error_response` | API retirement errors use the platform envelope and fixed messages. Do not echo raw header values, hashes, prefixes, or provider traces. |

--- a/shifter/shifter_platform/risk_register/access.py
+++ b/shifter/shifter_platform/risk_register/access.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 
-from risk_register.models import APIKey
 from shared.api_tokens.models import ApiToken
 
 if TYPE_CHECKING:
@@ -35,8 +34,8 @@ def _groups_intersect_allowed(groups: list[str]) -> bool:
     return bool(set(groups) & allowed)
 
 
-def _token_owner_has_access(auth: ApiToken | APIKey) -> bool:
-    """Return True when the token or API key owner belongs to an allowed group."""
+def _token_owner_has_access(auth: ApiToken) -> bool:
+    """Return True when the token owner belongs to an allowed group."""
     owner = getattr(auth, "created_by", None)
     if owner is None:
         return False
@@ -57,7 +56,7 @@ def principal_has_risk_register_access(request: HttpRequest) -> bool:
     user = getattr(request, "user", None)
 
     result = False
-    if allowed and isinstance(auth, (ApiToken, APIKey)):
+    if allowed and isinstance(auth, ApiToken):
         result = _token_owner_has_access(auth)
     elif allowed and user and user.is_authenticated:
         result = _session_user_has_access(request, user)


### PR DESCRIPTION
## Summary

Pure behavior-preserving cleanup, follow-up to #1124. After the legacy risk-register `rr_live_` API key was retired, `request.auth` on the risk-register surface is only ever a platform `ApiToken`, leaving an unreachable dead `APIKey` arm in the `risk_register.access` Cognito-group authorization helper. This removes that dead reference; the `APIKey` model and table stay archival for `Comment.author_apikey` and audit history.

## Requirement UIDs

- `PLAT-106`

## Related Issues

Closes #1244

## ADR Impact

- No ADR required

## Changes

- risk_register/access.py: drop the `from risk_register.models import APIKey` import, narrow `_token_owner_has_access(auth: ApiToken | APIKey)` to `auth: ApiToken`, and narrow `isinstance(auth, (ApiToken, APIKey))` to `isinstance(auth, ApiToken)`
- docs/architecture/risk-register-apikey-retirement-preflight-1124.md: preflight note updated (Step 2.5) with the #1244 guardrail that `risk_register.access` must not reference the archival APIKey type

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

No behavior change. Existing `risk_register` access + Cognito-group + token-access suites pass (`test_cognito_group_access.py`, `test_api_token_access.py`); ruff, mypy, lint-imports, and adr_guard clean.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: PLAT-106 ← shifter/shifter_platform/risk_register/access.py
- TESTS: PLAT-106 ← shifter/shifter_platform/tests/risk_register/test_cognito_group_access.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/1244.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
