### PR TITLE
fix: wait deterministically for the Guacamole bootstrap worker in its flaky test

### DIFF
--- a/shifter/shifter_platform/tests/mission_control/test_views_guacamole.py
+++ b/shifter/shifter_platform/tests/mission_control/test_views_guacamole.py
@@ -15,7 +15,6 @@ first-party patching) and unchanged.
 from __future__ import annotations
 
 import json
-import time
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -432,6 +431,7 @@ class TestGuacamoleSSHURL:
         ``/health`` on the same worker are unaffected).
         """
         import threading
+        from concurrent.futures import ThreadPoolExecutor
 
         from mission_control.views import guacamole_ssh_url
 
@@ -444,34 +444,50 @@ class TestGuacamoleSSHURL:
 
         def stalled_fetch(**_kwargs):
             reached_secrets.set()
-            release.wait(timeout=5)
+            release.wait(timeout=10)
             return {"SecretString": "TEST-SSH-PRIVATE-KEY-MATERIAL"}
+
+        # Capture the worker Future the bootstrap pool returns so the test can
+        # block on its completion deterministically, rather than polling the DB
+        # against a fixed wall-clock deadline (the poll flaked when the pool
+        # thread was CPU-starved under parallel test load). Patching the stdlib
+        # executor's submit is a concurrency-boundary mock, not a first-party seam.
+        submitted_futures: list = []
+        real_submit = ThreadPoolExecutor.submit
+
+        def _capturing_submit(self, fn, /, *args, **kwargs):
+            future = real_submit(self, fn, *args, **kwargs)
+            submitted_futures.append(future)
+            return future
 
         client = MagicMock()
         client.get_secret_value.side_effect = stalled_fetch
 
         try:
-            with patch("boto3.client", return_value=client), guac_exchange():
+            with (
+                patch("boto3.client", return_value=client),
+                patch.object(ThreadPoolExecutor, "submit", _capturing_submit),
+                guac_exchange(),
+            ):
                 response = guacamole_ssh_url(request)
 
                 # Request returned promptly without waiting on the stalled fetch.
                 assert response.status_code == 202
                 # The worker independently reached the Secrets Manager boundary
                 # and is blocked there — i.e. the fetch is off the request path.
-                assert reached_secrets.wait(timeout=5)
+                assert reached_secrets.wait(timeout=10)
                 release.set()
 
                 from mission_control.models import GuacamoleBootstrapRequest
 
+                # Deterministic wait: block until the worker actually finishes,
+                # then assert the persisted outcome. The timeout is only a
+                # deadlock guard, never the success-path timing.
+                assert submitted_futures, "expected a bootstrap worker to be submitted"
+                for future in submitted_futures:
+                    future.result(timeout=30)
+
                 bootstrap = GuacamoleBootstrapRequest.objects.get(pk=_json(response)["request_id"])
-                deadline = time.time() + 5
-                active_statuses = (
-                    GuacamoleBootstrapRequest.Status.PENDING,
-                    GuacamoleBootstrapRequest.Status.RUNNING,
-                )
-                while bootstrap.status in active_statuses and time.time() < deadline:
-                    time.sleep(0.05)
-                    bootstrap.refresh_from_db()
                 assert bootstrap.status == GuacamoleBootstrapRequest.Status.SUCCEEDED
         finally:
             release.set()


### PR DESCRIPTION
## Summary

Fixes the flaky `tests/mission_control/test_views_guacamole.py::TestGuacamoleSSHURL::test_request_returns_while_secrets_manager_is_stalled`, which intermittently red-lit the `Quality / Tests (shifter_platform)` CI job (seen on PR #1242, previously around #1124).

## Root cause

After releasing the stalled Secrets Manager fetch, the test polled the DB for the bootstrap status to reach `SUCCEEDED` against a fixed 5-second wall-clock deadline. Under `pytest -n auto` CPU starvation the background bootstrap pool thread is not scheduled within that window, leaving the row `RUNNING` at the deadline → `assert 'running' == ...SUCCEEDED`.

## Fix

Wait **deterministically** on the worker's completion instead of a timer: capture the `Future` returned by the stdlib `ThreadPoolExecutor.submit` and block on `future.result()`. The remaining timeout is now only a deadlock guard, never the success-path timing. The production code path is unchanged and runs for real; the test only observes when the worker returns.

ADR-019 boundary-mock policy: the patch target is the stdlib concurrency boundary (`concurrent.futures.ThreadPoolExecutor.submit`), not a first-party seam.

## Verification

- Target test: 18 consecutive passes (10 normal + 8 under full 16-CPU saturation).
- Whole `test_views_guacamole.py` file: passes 8× under `-n auto` with all CPUs saturated (the condition that triggered the flake).
- `ruff`, `adr_guard --all --level ci` (incl. boundary-mock-policy), and the full pre-commit suite pass.

## Related

Closes #1247

## Traceability

- TESTS: #1247 ← shifter/shifter_platform/tests/mission_control/test_views_guacamole.py
