### PR TITLE
docs: rescope cyberscript around aces

### DIFF
--- a/changelog.d/1231.changed.md
+++ b/changelog.d/1231.changed.md
@@ -1,0 +1,1 @@
+Documented the ACES migration triage for CyberScript and scenario backlog items, making CyberScript extension requests route to current-stack maintenance, ACES migration, superseded, or close buckets instead of extending the legacy DSL indefinitely.

--- a/docs/architecture/aces-cyberscript-issue-triage.md
+++ b/docs/architecture/aces-cyberscript-issue-triage.md
@@ -1,0 +1,48 @@
+# ACES CyberScript issue triage
+
+Issue #1231 re-scopes scenario and CyberScript work around ADR-024:
+ACES is the target scenario, runtime, experiment, and backend contract
+surface, while current Shifter behavior remains authoritative until parity
+and cutover gates pass.
+
+## Triage rules
+
+- **Maintain** means the issue protects current production behavior, legacy
+  documentation, or mechanical cleanup that is still useful while CyberScript
+  remains the live path.
+- **Migrate** means the need may still be valid, but the implementation target
+  is ACES SDL, an ACES Shifter profile, a Shifter backend adapter, or a later
+  ADR-backed contract. Do not implement it as a new CyberScript semantic.
+- **Supersede** means ADR-024, the parity inventory, or the ACES migration
+  issue series has replaced the investigation or design question.
+- **Close** means the issue describes a CyberScript expansion that is no
+  longer aligned unless a later ADR deliberately reopens that surface.
+
+## Requirement posture
+
+- PLAT-007 tracks scenario expressiveness gaps as ACES migration/profile gaps,
+  not as private provisioner behavior or new CyberScript semantics.
+- PLAT-209 tracks the parity-gated convergence path toward ACES as the
+  canonical scenario definition surface. CyberScript compatibility is
+  transition support, not a co-equal new authoring target.
+- PLAT-210 tracks the Shifter ACES compatibility profile and legacy diagnostic
+  posture. Additional non-ACES profiles require a future ADR or requirement.
+
+## Issue disposition
+
+| Issues | Disposition | Follow-up |
+| --- | --- | --- |
+| #620 | Supersede, then close after #1231 lands. The investigation goal is covered by ADR-024, the parity inventory, and this triage. | Point readers to #1231 and the ACES migration issue series. |
+| #676 | Migrate into the ACES Migration Architecture milestone as the PLAT-007 tracking issue. | Update the issue body after the Ground Control requirement text is updated. |
+| #776 | Maintain as current-stack platform work. | Future ACES adapter work must preserve the behavior if it becomes part of the supported Shifter profile. |
+| #433 | Maintain as legacy/current documentation while CyberScript remains the live path. | Archive or replace only after the cutover gate. |
+| #349 | Maintain as a current production correctness bug. | Fix against the current Shifter path; do not wait for ACES. |
+| #313 | Maintain as low-risk legacy cleanup. | Keep scoped to shared schema cleanup; do not broaden into new DSL design. |
+| #314, #330 | Close after #1231 lands as no longer aligned unless recast as ACES migration tooling. | A future tool should validate ACES profiles or migration parity, not create a new standalone CyberScript product surface. |
+| #328, #368 | Migrate. These are terminal/UI and participant-runtime capabilities that should be represented through the ACES profile or Shifter backend adapter. | Reopen only as ACES profile/backend-adapter work if needed by #1232-#1237. |
+| #355, #376, #383, #401 | Migrate. These ask for adversary behavior, goals, tools, or agentic options; those belong in ACES semantics or Shifter adapter responsibilities. | Convert only when an ACES issue identifies a concrete profile gap. |
+| #374 | Supersede. ADR-024 makes `InstanceConfig` a Shifter backend boundary, not a CyberScript architecture-conformance target. | Reference the parity inventory rows `scenario.any-template-union` and `scenario.hydration-range-spec`. |
+| #427, #428, #429, #430, #431, #432 | Migrate as future ACES-authored scenario content. | Do not implement as CyberScript-only scenario expansion; bind to ACES catalog/back-end work after #1232 and #1233. |
+
+No current production behavior is removed by this triage. It changes backlog
+intent and requirement wording only.

--- a/docs/architecture/aces-migration-adr.md
+++ b/docs/architecture/aces-migration-adr.md
@@ -92,6 +92,12 @@ and not Polaris-specific branches in Shifter core.
 
 ## Migration Constraints
 
+- CyberScript work during the parallel phase is limited to current-stack
+  compatibility, production bug fixes, documentation, and migration/archive
+  support. New scenario meaning, scenario DSL semantics, participant-runtime
+  semantics, or backend contract semantics belong in ACES SDL, an ACES
+  Shifter profile, or a later accepted ADR that explicitly widens the legacy
+  surface.
 - ACES integration must enter through `shared`, `cms.scenarios.*`,
   `cms.services`, and `engine.services` boundaries. Direct ACES or CyberScript
   imports outside `shared` remain disallowed unless a later ADR changes the
@@ -175,6 +181,9 @@ Archive/delete cleanup happens only after that rollback posture is explicit.
 - Issue and PR discussions can cite inventory rows by stable id.
 - ACES expressivity gaps are routed to ACES or ACES-profile work instead of
   being patched into Shifter as a private scenario language.
+- Existing CyberScript and scenario backlog items are triaged in
+  `docs/architecture/aces-cyberscript-issue-triage.md` so implementation work
+  can distinguish current-stack maintenance from ACES migration candidates.
 - Shifter backend responsibilities remain visible and testable.
 - The migration can progress incrementally without breaking current operators
   before parity is proven.

--- a/docs/architecture/aces-migration-parity-inventory.yaml
+++ b/docs/architecture/aces-migration-parity-inventory.yaml
@@ -6,8 +6,9 @@
 # is not a runtime schema, not a parser input, and not an implementation plan.
 
 schema_version: 1
-generated_for: "issue-1230"
+generated_for: "issues-1230-1231"
 related_adr: docs/architecture/aces-migration-adr.md
+related_triage: docs/architecture/aces-cyberscript-issue-triage.md
 
 categories:
   - ACES SDL

--- a/docs/architecture/aces-scenario-cyberscript-rescope-preflight-1231.md
+++ b/docs/architecture/aces-scenario-cyberscript-rescope-preflight-1231.md
@@ -1,0 +1,194 @@
+# ACES Scenario And CyberScript Rescope Preflight
+
+Issue: GitHub #1231, "02 - ACES migration: re-scope scenario and
+CyberScript requirements".
+
+This note records the architecture guardrails for the rescope. It is
+intentionally not an implementation plan and does not change current runtime
+behavior.
+
+## Boundary
+
+ADR-024 is the controlling architecture decision:
+`docs/architecture/aces-migration-adr.md` makes ACES the target contract family,
+but current Shifter behavior remains authoritative until a parallel ACES path
+passes the parity gates in
+`docs/architecture/aces-migration-parity-inventory.yaml`.
+
+The rescope should make requirement text and GitHub issue disposition reflect
+that boundary:
+
+- ACES owns authored scenario and experiment meaning, published schemas,
+  profiles, backend manifests, and conformance vocabulary.
+- Shifter owns portal behavior, CMS/CTF services, Mission Control, user
+  authorization, range lifecycle, cloud provisioning, artifacts, logs, audit,
+  status, and operator runbooks.
+- CyberScript compatibility is migration/archive work unless a later ADR
+  explicitly grants it new canonical scope.
+- No current production behavior is removed as part of this issue. Archive or
+  delete language is valid only as a post-cutover disposition.
+
+Ground Control requirement reads and GitHub issue reads were unavailable in
+this sandbox during preflight. The implementation must review the live
+PLAT-007, PLAT-209, PLAT-210, #620, #676, and related issue text before making
+edits or dispositions. Do not infer their current wording from this note.
+
+## Disposition Buckets
+
+Every existing scenario, ACES, Polaris, and CyberScript issue considered by
+#1231 should land in exactly one bucket:
+
+| Bucket | Use When | Guardrail |
+| --- | --- | --- |
+| maintain | It protects current production Shifter behavior before ACES parity. | Keep it scoped to compatibility, bug fixes, validation, or documentation; do not extend CyberScript semantics as the long-term model. |
+| migrate | It is still needed but should move to the ACES target path. | Tie it to an inventory row or ACES profile/schema gap; keep Shifter backend responsibilities separate from authored ACES semantics. |
+| supersede | ADR-024 or the parity inventory already replaces the issue's direction. | Point to the controlling ADR/inventory row and create a narrower follow-up only when a concrete implementation need remains. |
+| close | It is no longer aligned, duplicates current guidance, or asks for post-cutover removal before parity. | Close without removing runtime behavior; if evidence is uncertain, leave it maintain/migrate until the live issue text is reviewed. |
+
+#620 is referenced locally as the long-term scenario-expressiveness path for
+declarative composition. Treat that as migration-oriented unless the live issue
+body proves it is obsolete or already superseded. #676 was not available
+locally; its bucket must come from the live issue text.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail |
+| --- | --- | --- |
+| ACES migration decision | `docs/architecture/aces-migration-adr.md` / ADR-024 in `docs/adr/index.yaml` | Do not create a second migration doctrine in requirement prose or issue comments. |
+| Legacy surface inventory | `docs/architecture/aces-migration-parity-inventory.yaml` | Use row ids for follow-up issue scope; the inventory is not a runtime schema or parser input. |
+| Scenario loading | `cms.scenarios.loader` | Preserve scenario-id slug validation, template path containment, `yaml.safe_load`, and Pydantic `TypeAdapter(AnyScenarioTemplate)` validation. |
+| Scenario registry | `cms.scenarios.registry` | Keep YAML defaults, DB customs, metadata overlays, access filtering, and collision handling in the registry boundary. |
+| Scenario authoring | `cms.scenario_editor.services` facade plus `_validation`, `_persistence`, `_metadata`, `_yaml` | Do not add a second YAML parser, custom-scenario table workflow, or metadata overlay path. |
+| Scenario models | `cms.models.scenarios.Scenario` and `ScenarioMetadata` | DB custom scenarios remain validated by `Scenario.to_template()` on save and use soft-delete semantics. |
+| Hydration | `cms.scenarios.hydrator` | New ACES input must adapt into Shifter `RangeSpec`/`CTFRangeSpec` semantics here or at an adjacent registry/hydrator adapter boundary. |
+| CMS launch | `cms.services.create_range` and scenario service facade | Keep user/agent validation, active-range checks, persisted CMS request state, audit logging, failure status, and engine dispatch. |
+| Shared contracts | `shifter/shifter_platform/shared/schemas/**`, `shared.script_context`, `shared.template_vars` | Only `shared` may import CyberScript directly today. New non-DSL contracts belong in `shared` natively. |
+| Persistence envelope | `shared.schemas.persistence.wrap_persisted_spec` / `unwrap_persisted_spec` and `engine.interpreter` | Do not persist raw ACES payloads or unwrapped runtime specs in CMS/engine rows. |
+| Engine boundary | `engine.services` and `engine.interpreter` | ACES backend work adapts to engine services; CMS/CTF/Mission Control must not invoke cloud, Terraform, Docker, or shell provisioning directly. |
+| CTF integration | `ctf.bridges` and `ctf.services.*` | CTF continues to cross into CMS through bridge/service calls, not direct scenario or engine internals. |
+| Experiment execution | `cms.experiments.schemas`, `cms.experiments.orchestrator.execution_plan`, `shared.script_context.ScriptExecutionContext` | Prompt, command, S3 key, provider, and instance-id handling stays behind the existing execution-context gate. |
+| API auth and scopes | `shared.api_tokens.authentication`, `shared.api_tokens.permissions.require_scope`, `shared.api_tokens.scopes` | If any DRF surface changes, use exact registered scopes; no wildcard or locally invented scope checks. |
+| User auth | `shared.auth.validate_cms_authoring_user`, `threat_research_required`, CTF role helpers | Keep service-layer authorization canonical; template hiding or view-only checks are not sufficient. |
+| Errors | `shared.errors`, `shared.api.errors`, `shared.exceptions.CMSError`, experiment exceptions, CTF exceptions | Translate at domain boundaries; do not add a parallel scenario/ACES exception hierarchy. |
+| Logging | `shared.log_sanitize.safe_log_value`, `safe_log_id`, `safe_log_fingerprint` | User-controlled ids use `safe_log_value`; sensitive identifiers use fingerprints or masks, not raw logs. |
+| Import enforcement | `.importlinter`, `scripts/check_layer_imports/layer_imports.yaml`, `scripts/adr_guard/adr_guard.py` | Future ACES imports need the same discipline as current CyberScript imports. |
+| Polaris evidence | `scenario-dev/polaris/sdl/README.md`, `design/aces-sdl-validation-path.md`, `containers/images.yaml`, smoke tests | SDL is authoring evidence; image realization is backend evidence; `cms/scenarios/templates/polaris.yaml` is still the live portal template. |
+
+## Cross-Cutting Layers
+
+Security layers the future design must satisfy:
+
+- Auth surface: requirement/issue rescope is documentation and tracker work.
+  Any later browser authoring change must stay behind
+  `threat_research_required` and `validate_cms_authoring_user`. Any later DRF
+  endpoint must use `IsAuthenticatedSessionOrApiToken` plus exact
+  `require_scope` gates from `shared.api_tokens.scopes`.
+- Scenario input shape: scenario ids must pass the loader/editor slug
+  validators; file-backed YAML must stay contained under
+  `cms/scenarios/templates/`; YAML parsing uses `yaml.safe_load`; parsed
+  payloads validate through the existing Pydantic scenario adapters or a
+  future ACES adapter at the registry/hydrator boundary.
+- ACES conformance shape: ACES SDL/profile/backend-manifest claims must pass
+  ACES conformance before becoming cutover evidence. Requirement prose must
+  not serve as a substitute for a parser, manifest, or conformance gate.
+- Persistence shape: CMS custom scenarios use `Scenario.definition` plus
+  `Scenario.to_template()` validation; range runtime specs use
+  `wrap_persisted_spec`; engine rows are created by `engine.interpreter` in a
+  transaction. Do not introduce unwrapped JSON blobs or duplicate spec
+  discriminators.
+- Command and OS exposure: experiment commands, prompts, S3 keys, provider
+  assumptions, and instance ids remain mediated by `ScriptExecutionContext`.
+  Tokens, credentials, flags, prompt bodies, shell text, private keys, or
+  backend secrets must not be placed in process argv, issue bodies, ADR
+  examples, logs, or generated reports.
+- Secret and artifact handling: uploaded assets, experiment artifacts, CTF
+  flags, NGFW credentials, cloud ids, and runtime config remain Shifter-owned
+  storage/audit concerns. ACES rows may reference evidence classes but must
+  not copy secret-bearing material.
+- Error envelopes: DRF responses use `shared.api.errors`; function views and
+  JSON helpers should classify/sanitize user-facing messages rather than
+  returning raw `str(exc)`. Logs may include sanitized ids and row names, not
+  full exception payloads that carry generated scripts, credentials, prompts,
+  or flags.
+- Repository validators: doc/architecture changes must pass
+  `python3 scripts/adr_guard/adr_guard.py --all --level ci`. Runtime Python in
+  `shifter/shifter_platform` also needs Ruff and import-linter; workflow,
+  Terraform, and Kubernetes paths need the stack-native checks listed in
+  `.gc/plan-rules.md`.
+
+Maintainability incumbents the implementation must build on are the table
+above. The highest-risk mistake is creating parallel schemas, parser flows,
+status taxonomies, or exception/logging policies around ACES instead of adding
+a deliberate adapter at the existing registry/hydrator/shared-contract seams.
+
+Extensibility seam: the one required parameter is an explicit scenario contract
+or profile discriminator at the registry/hydrator boundary, e.g. legacy demo,
+legacy CTF, and ACES Shifter profile. That discriminator must be explicit
+metadata, not implicit YAML shape detection and not a Polaris-specific branch
+inside Shifter core. Future variations should add profile/adapter entries
+behind that seam rather than editing CMS, CTF, Mission Control, and engine
+surfaces separately.
+
+Whole-repo surfaces in scope for the future implementation:
+
+- Ground Control requirement text for PLAT-007, PLAT-209, PLAT-210, and
+  related requirement records.
+- GitHub issues #620, #676, and related open scenario/CyberScript issues.
+- `docs/architecture/aces-migration-adr.md`
+- `docs/architecture/aces-migration-parity-inventory.yaml`
+- `docs/adr/index.yaml` and `docs/adr/exceptions.yaml` if guardrails change.
+- `.ground-control.yaml`, `.gc/plan-rules.md`, `.importlinter`, and
+  `scripts/check_layer_imports/layer_imports.yaml` if workflow or import
+  policy changes.
+- `shifter/shifter_platform/cms/scenarios/**`
+- `shifter/shifter_platform/cms/scenario_editor/**`
+- `shifter/shifter_platform/cms/services/**`
+- `shifter/shifter_platform/shared/**`
+- `shifter/shifter_platform/engine/**`
+- `shifter/shifter_platform/ctf/**`
+- `shifter/shifter_platform/cms/experiments/**`
+- `shifter/shifter_platform/mission_control/**`
+- `shifter/engine/provisioner/**`
+- `scenario-dev/polaris/**`
+- `scripts/adr_guard/**`
+
+## Gotchas And Anti-Patterns
+
+- Do not remove CyberScript, current CMS scenario templates, Polaris runtime
+  material, CTF behavior, experiment execution, Mission Control behavior,
+  provisioner paths, artifacts, status models, or validation gates in #1231.
+- Do not describe CyberScript as the future canonical extension surface.
+  Compatibility is maintain/migrate/archive work unless a later ADR says
+  otherwise.
+- Do not encode ACES-owned semantics as private Shifter YAML fields just to
+  close a requirement quickly. If ACES lacks a vocabulary, classify it as an
+  ACES schema/profile gap.
+- Do not make Polaris the public adapter contract. Polaris is the primary
+  parity proving case, not the type system.
+- Do not replace registry/hydrator validation with ad hoc shape checks,
+  filename conventions, or raw dict handling.
+- Do not create duplicate DTOs for range specs, scenario specs, artifacts,
+  statuses, CTF scoring, or experiment lifecycle. Use `shared` contracts or
+  add shared-native contracts with explicit migration notes.
+- Do not add cross-layer imports around service facades. CTF and Mission
+  Control must not reach into engine internals; CMS must not import CTF or
+  Mission Control; engine must not import CMS.
+- Do not use issue labels or milestones as the only disposition evidence.
+  The issue body/comment disposition should state maintain, migrate,
+  supersede, or close and cite the ADR/inventory row when applicable.
+- Do not create follow-up implementation issues from broad migration anxiety.
+  Create them only when the rescope identifies a concrete ACES profile gap,
+  adapter, validation gate, or Shifter backend responsibility.
+
+## Non-Goals
+
+- Implementing ACES parsing, registry support, hydration adapters,
+  conformance CLIs, backend manifests, data migrations, or runtime selectors.
+- Editing live production behavior, deleting legacy code, rebaking images,
+  changing CTF scoring/flags/hints, or mutating ranges.
+- Replacing CyberScript during this issue.
+- Creating new requirement UIDs for this requirement-free run.
+- Creating or closing GitHub issues without first reviewing their live content
+  and recording the bucket rationale.
+- Writing a file-local implementation plan; the next implementation should use
+  this note and ADR-024 as repo-wide design constraints.


### PR DESCRIPTION
## Summary

- What changed: re-scoped the scenario/CyberScript backlog around ADR-024, added an ACES/CyberScript issue triage note, linked the parity inventory to that triage, recorded the preflight guardrails, and added a changelog fragment for the backlog posture change.
- Why: ACES is the target scenario contract path; CyberScript work should be current-stack compatibility, migration/archive support, or a later ADR-backed exception, not indefinite legacy DSL expansion.

## ADR Impact

- [ ] No ADR impact
- [x] Existing ADRs updated
- [ ] New ADR added
- [ ] Temporary exception added to `docs/adr/exceptions.yaml`

ADRs touched:

- ADR-024
- ADR-021

Exceptions added or renewed: none

## Guardrail Changes

- [x] No guardrail files changed
- [ ] Guardrail files changed and matching docs were updated

Guardrail files changed: none

## Verification

- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- [x] Relevant stack-native checks passed (`lint-imports`, `actionlint`, `tflint`, `gitleaks`) where applicable
- [x] Relevant tests
- [x] Docs updated where behavior or enforcement changed

Verification detail:

- `pre-commit run --all-files` passed.
- `python3 scripts/adr_guard/adr_guard.py --all --level ci` passed.
- Ground Control quality gates passed with an empty formal requirement scope.
- Pre-push Codex review cycle passed clean.
- Pre-push test-quality review cycle passed clean.
- `make policy` / Vale was unavailable in this checkout: there is no `Makefile` or `tools/` directory.

## Ground Control Checks

- [x] GRC screening recorded for #1231: `no_baseline`.
- [x] Implementation plan posted to #1231.
- [x] Documentation-only TDD carve-out recorded on #1231.
- [x] PLAT-007, PLAT-209, and PLAT-210 requirement text updated in Ground Control.
- [x] #676 synced to the updated PLAT-007 text and moved to the ACES Migration Architecture milestone.
- [x] #620 moved to the ACES Migration Architecture milestone with a superseded disposition note.

## Traceability

- IMPLEMENTS: (none - #1231 has no formal `## Requirements` scope; this PR updates architecture docs and requirement/project metadata)
- TESTS: (none - documentation/project-metadata run; verification listed above)

Closes #1231