### PR TITLE
fix: NTLM auth for the GCE Windows/DC packer builds

### DIFF
--- a/shifter/packer/gcp/dc.pkr.hcl
+++ b/shifter/packer/gcp/dc.pkr.hcl
@@ -17,6 +17,11 @@ source "googlecompute" "dc" {
   winrm_password = var.winrm_bootstrap_password
   winrm_insecure = true
   winrm_use_ssl  = true
+  // NTLM (via Negotiate) instead of packer's default Basic auth: the bootstrap
+  // disables Basic on the WinRM service (and GCE's built-in listener defaults to
+  // Basic=false too), so Basic auth is rejected and packer otherwise hangs until
+  // winrm_timeout. NTLM authenticates the local packer_user over the TLS channel.
+  winrm_use_ntlm = true
   winrm_timeout  = "30m"
 
   network               = var.network

--- a/shifter/packer/gcp/windows.pkr.hcl
+++ b/shifter/packer/gcp/windows.pkr.hcl
@@ -23,6 +23,11 @@ source "googlecompute" "windows" {
   winrm_password = var.winrm_bootstrap_password
   winrm_insecure = true
   winrm_use_ssl  = true
+  // NTLM (via Negotiate) instead of packer's default Basic auth: the bootstrap
+  // disables Basic on the WinRM service (and GCE's built-in listener defaults to
+  // Basic=false too), so Basic auth is rejected and packer otherwise hangs until
+  // winrm_timeout. NTLM authenticates the local packer_user over the TLS channel.
+  winrm_use_ntlm = true
   winrm_timeout  = "30m"
 
   network               = var.network


### PR DESCRIPTION
## Summary
The `windows` and `dc` GCE image builds (`packer-gcp.yml`) hung until the 30-minute `winrm_timeout` and failed. This path had never been exercised — the GDC range smoketest only used the Linux guests (ubuntu, kali).

## Root cause
Diagnosed live with a throwaway Windows-2022 VM running the real `locals.pkr.hcl` WinRM bootstrap:
- The bootstrap script completes cleanly and the HTTPS WinRM listener comes up on 5986.
- The bootstrap disables Basic auth (`Basic=false`), and GCE's built-in listener defaults to `Basic=false` too.
- Packer defaults to **Basic** auth for WinRM, so every auth attempt was rejected → 30-minute timeout.

## Fix
Set `winrm_use_ntlm = true` on the `windows` and `dc` sources so packer authenticates the local `packer_user` via NTLM/Negotiate over the existing TLS channel.

## Verification (dev)
Re-dispatched both builds on this branch — both completed and exported their qcow2 to the GDC VM image bucket:
- `windows.qcow2` (21.3 GB)
- `dc.qcow2` (20.4 GB)

The full guest image set (ubuntu, kali, brokenbk, windows, dc) is now present in `gs://shifter-gcp-dev-gdc-vm-images/`.

Part of #615 (D26a).