### PR TITLE
feat: add portal cookie and privacy notice shell

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 Assumes code is already committed and pushed. Handles: PR creation, CI monitoring, SonarCloud, code review, security review, fixing all issues, and merging.
 
-**IMPORTANT:** NEVER include Co-Authored-By, "Generated with Claude Code", or any Claude/AI attribution in commit messages, PR descriptions, or any other artifacts.
+**IMPORTANT:** NEVER include Co-Authored-By trailers, agent marketing footers, or any Claude/AI branding in commit messages, PR descriptions, or any other artifacts.
 
 ## Phase 1: Create PR
 

--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "attributeCommitsToAgent": false,
+    "attributePRsToAgent": false
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": ".cursor/hooks/block-agent-attribution-shell.sh",
+        "matcher": "git .*commit|gh pr (create|edit)",
+        "failClosed": false
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/block-agent-attribution-shell.sh
+++ b/.cursor/hooks/block-agent-attribution-shell.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Deny shell commands that inject AI/agent attribution into git or GitHub artifacts.
+set -euo pipefail
+
+input=$(cat)
+command=$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("command",""))')
+
+deny() {
+  local reason=$1
+  python3 -c 'import json,sys; print(json.dumps({
+    "permission": "deny",
+    "user_message": sys.argv[1],
+    "agent_message": sys.argv[2],
+  }))' \
+    "Blocked: ${reason}" \
+    "Do not inject AI/agent attribution into commits or PRs. Use plain human authorship only."
+  exit 2
+}
+
+if [[ -z "$command" ]]; then
+  python3 -c 'print("{\"permission\":\"allow\"}")'
+  exit 0
+fi
+
+if [[ "$command" =~ git[[:space:]]+(commit|.*commit) ]]; then
+  if [[ "$command" =~ --trailer[[:space:]]+.*(Co-authored-by|Co-Authored-By|Made-with:|cursoragent@) ]]; then
+    deny "git commit --trailer with agent attribution"
+  fi
+fi
+
+if [[ "$command" =~ gh[[:space:]]+pr[[:space:]]+(create|edit) ]]; then
+  if [[ "$command" =~ [Mm]ade[[:space:]]+with[[:space:]]+\[Cursor\] ]] \
+    || [[ "$command" =~ cursor\.com ]]; then
+    deny "gh pr body/footer with Cursor marketing attribution"
+  fi
+fi
+
+python3 -c 'print("{\"permission\":\"allow\"}")'
+exit 0

--- a/.cursor/rules/no-agent-attribution.mdc
+++ b/.cursor/rules/no-agent-attribution.mdc
@@ -1,0 +1,15 @@
+---
+description: Never add AI or agent attribution to commits, PRs, or other artifacts
+alwaysApply: true
+---
+
+# No AI / Agent Attribution
+
+Never add any of the following to commit messages, PR titles, PR bodies, issue comments, changelogs, or other repo artifacts:
+
+- Git trailer lines (`Co-authored-by` / `Co-Authored-By`) naming Cursor, Claude, Codex, Composer, or similar agents
+- Cursor product marketing footers (markdown link to cursor.com)
+- Claude Code branding lines, `Made-with: Cursor` trailers, or equivalent agent advertising
+- Any other attribution that advertises the coding agent or IDE
+
+This repository blocks these markers in pre-commit and ADR guard. Keep authorship human-only.

--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,9 @@ cython_debug/
 .cursor/*
 !.cursor/environment.json
 !.cursor/mcp.json
+!.cursor/cli.json
+!.cursor/hooks.json
+!.cursor/hooks/
 !.cursor/rules/
 
 # Node.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,18 @@ fail_fast: true
 
 repos:
   # =============================================================================
+  # STAGE 0: Commit message policy (commit-msg hook)
+  # =============================================================================
+  - repo: local
+    hooks:
+      - id: block-agent-attribution-commit-msg
+        name: block agent attribution in commit messages
+        entry: python3 scripts/adr_guard/block_agent_attribution_commit_msg.py
+        language: system
+        stages: [commit-msg]
+        pass_filenames: true
+
+  # =============================================================================
   # STAGE 1: Fast checks (linting, formatting, syntax)
   # =============================================================================
 

--- a/changelog.d/67.added.md
+++ b/changelog.d/67.added.md
@@ -1,0 +1,3 @@
+### Added
+
+- Portal cookie notice shell with client-side dismissal and a public `/privacy/` page for operator-supplied privacy notice content.

--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -35,6 +35,11 @@
         "id": "ADR-002-R1",
         "description": "Guardrail file changes must update docs/adr or the developer ADR enforcement docs in the same change.",
         "checks": ["guardrail-docs"]
+      },
+      {
+        "id": "ADR-002-R2",
+        "description": "Commit messages and tracked text must not contain AI/agent attribution markers (Co-authored-by agent lines, Cursor marketing footers, Claude Code branding, etc.).",
+        "checks": ["no-agent-attribution"]
       }
     ],
     "exceptions": [],

--- a/docs/architecture/configurable-cookie-privacy-notice-preflight-67.md
+++ b/docs/architecture/configurable-cookie-privacy-notice-preflight-67.md
@@ -1,0 +1,219 @@
+# Configurable Cookie And Privacy Notice Preflight (#67)
+
+Status: pre-implementation guidance
+
+Date: 2026-07-01
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/67>
+
+This issue is requirement-free. The GitHub issue title, body, and acceptance
+criteria are the shipping contract. This note is intentionally not an
+implementation plan.
+
+## Scope Boundary
+
+Add portal plumbing for:
+
+- a dismissible notice about strictly necessary browser storage used for
+  authentication, session behavior, and notice dismissal; and
+- a public `/privacy/` shell for operator-supplied privacy notice content.
+
+Keep these concepts separate:
+
+1. Functional browser storage disclosure: factual UI copy about existing auth,
+   session, CSRF, and dismissal storage.
+2. Consent management: out of scope until the product introduces non-essential
+   cookies, analytics, advertising, or tracking.
+3. Privacy notice shell: a neutral content container and replacement seam owned
+   by the deployment operator.
+4. Legal policy text: out of scope for this OSS change. The project must not
+   bind Palo Alto Networks, maintainers, or deployment operators, and must not
+   assert GDPR compliance.
+
+## Architecture Decisions
+
+- Prefer client-local dismissal state in `localStorage` over adding another
+  cookie. If a cookie is used instead, it must be strictly necessary,
+  non-identifying, `SameSite=Lax`, and `Secure` whenever the deployment is
+  served over HTTPS.
+- The dismissal key should be namespaced and versioned, for example
+  `shifter.cookieNotice.dismissed.v1`, and should not contain user IDs,
+  emails, timestamps, route names, or organization details.
+- The notice should be implemented as one shared template partial plus one
+  static JavaScript asset and shared theme styles. Include it from the existing
+  HTML shells that render portal pages rather than duplicating markup and
+  storage logic in every app.
+- The notice copy must use disclosure language, not consent language. Use
+  actions such as "Dismiss", not "Accept", "Agree", "Consent", or preference
+  controls.
+- `/privacy/` should be a public, GET/HEAD-only route with no login requirement
+  and no personalized sidebar/profile data. It should render a neutral
+  placeholder until the operator replaces the content.
+- The privacy content seam belongs at the template/static-content boundary. A
+  stable operator-replaceable template such as `privacy/notice_content.html`
+  is sufficient. If the implementation adds an environment-selected template,
+  validate the setting at startup and restrict it to a safe template prefix.
+- Do not route the public privacy notice through the authenticated in-app docs
+  app. The docs renderer is useful precedent for sanitization, but `/docs/` is
+  intentionally login-protected and should not become the public privacy route.
+- No new database table, model, service layer, audit event, API endpoint, or
+  consent-preference abstraction is needed for this issue.
+
+## Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #67 |
+| --- | --- | --- |
+| Root routes and simple portal views | `config.urls`, `config.views` | Add `/privacy/` at the root URL layer. Do not create an app-local legal-policy controller. |
+| Template shells | `templates/mission_control/base.html`, `templates/ctf/base.html`, `templates/risk_register/base.html`, `templates/scenario_editor/base.html`, `templates/documentation/base.html`, auth/public templates | Include one shared notice partial from relevant rendered HTML shells. Avoid divergent copies. |
+| Static assets | `shifter/shifter_platform/static/js/*`, `static/css/theme.css`, Django `{% static %}`, WhiteNoise manifest storage | Put dismissal behavior in a static JS file and style it with existing theme variables. Do not inline route-specific scripts everywhere. |
+| Existing local browser persistence | `static/js/sidebar.js`, `static/js/terminal*.js` | Reuse the localStorage pattern, but keep this key non-identifying and notice-specific. |
+| Auth/session/CSRF storage | Django `SessionMiddleware`, `CsrfViewMiddleware`, auth backends in `config._oidc_settings` / `config.identity_platform`, `ensure_csrf_cookie` where already used | The notice describes this existing behavior; it must not change auth, CSRF, SameSite, secure-cookie, or OIDC/Identity Platform flows. |
+| Template context | `config.settings.TEMPLATES` context processors | Anonymous-safe context processors already return empty/false values. Do not add request-path DB work just for this notice. |
+| Public/static content rendering | Django templates with autoescape; `documentation.views._render_markdown` as sanitizer precedent only | Prefer trusted template/static content. If Markdown/operator HTML is accepted, reuse the established bleach-style allowlist through a public helper rather than `mark_safe`. |
+| Config binding | `config.settings` parsers, `config._runtime_env.required_runtime_env`, `config/_env_manifest.py`, `config/env-manifest.json` | New env settings must be non-secret, validated, and added to the manifest. Avoid env knobs when a template override is enough. |
+| Logging | `config.logging.ECSFormatter`, `shared.log_sanitize.safe_log_value`, `safe_log_id`, `safe_log_fingerprint` | No display/dismissal logging is needed. If template configuration fails, log only validated template identifiers, not content, cookies, or headers. |
+| Error leakage controls | Existing authored HTML errors and `shared.errors` for APIs | `/privacy/` is HTML, not JSON. Do not add an API envelope. If any JSON is introduced, use existing bounded error-message patterns. |
+| Import boundaries | `.importlinter`, ADR-001 | Shared UI plumbing belongs in templates/static/config/shared. Do not introduce CTF, CMS, Mission Control, or risk-register cross-imports. |
+| Tests | Existing Django view/template tests and Jest `static/js/*.test.js` | Test rendered behavior, storage persistence, public privacy route, and absence of `/terms/`. Avoid first-party internal patching. |
+| Release notes | `changelog.d/README.md` convention | The implementation is user-visible and should add `changelog.d/67.added.md`. |
+
+## Cross-Cutting Layers The Design Must Pass
+
+- Auth surface: authenticated pages keep using Django sessions plus existing
+  OIDC, Identity Platform, magic-link, or dev-login flows. The cookie notice is
+  passive client UI and must not create a new login gate, auth middleware,
+  session setting, user preference model, or bypass.
+- CSRF and mutation surface: notice dismissal should not call the server. If a
+  future server-side dismissal endpoint is introduced, it must stay behind
+  session auth and `CsrfViewMiddleware`; this issue should not use
+  `csrf_exempt`.
+- Request validation surface: `/privacy/` should accept only GET/HEAD and no
+  caller-controlled template, file path, or content parameter. Any
+  environment-selected template name must be parsed in settings, rejected if
+  blank, absolute, path-traversing, or outside the approved prefix, and covered
+  by tests.
+- Template/XSS surface: default placeholder copy is static and autoescaped.
+  Operator-provided templates are trusted deployment artifacts. Do not render
+  arbitrary HTML from environment variables, database rows, query strings, or
+  uploaded files. If Markdown support is added, sanitize with a bounded
+  allowlist.
+- Secret-handling surface: session cookies, CSRF tokens, ID tokens, invite
+  tokens, bearer tokens, Guacamole URLs, private IP overlays, and user emails
+  must not be copied into notice state, privacy content, logs, docs examples,
+  JavaScript console output, data attributes, or rendered legal placeholders.
+- Config/env surface: a fixed template override needs no new config. A new
+  setting must live in `config.settings` or a split settings module, be listed
+  by `config/env-manifest.json`, and be wired through deployment renderers only
+  as a non-secret value.
+- OS/runtime exposure surface: do not put privacy notice body text, cookies,
+  tokens, or legal commitments in process argv, Terraform outputs, Kubernetes
+  ConfigMap examples, GitHub summaries, or shell-visible env dumps. A template
+  name is non-secret; legal content belongs in files/templates controlled by
+  the operator.
+- Error-envelope surface: browser-facing failures should be generic HTML
+  behavior. Missing/misconfigured operator content should fail loudly in tests
+  or startup checks without serializing filesystem paths, template search
+  internals, or raw exception text to users.
+- Observability surface: no analytics, tracking event, beacon, metric,
+  third-party script, or audit row is introduced by this issue. Existing ECS
+  logs and request IDs are enough for route errors.
+- Static-asset surface: assets are served through Django staticfiles and
+  WhiteNoise. Include them with `{% static %}` so collectstatic/manifest storage
+  continues to own cache-busting.
+- Import-boundary surface: Python changes should stay in `config` for the root
+  view or `shared` only if a reusable template/content helper is genuinely
+  needed. Do not make feature apps import each other to share notice behavior.
+
+## Extensibility Seam
+
+The required seam is the operator-owned notice content include, not a consent
+framework:
+
+- notice UI state: a single versioned localStorage key for dismissal;
+- notice copy: one shared partial that can link to `/privacy/`;
+- privacy content: one replaceable template/static content file rendered by the
+  public route; and
+- optional future selector: a validated non-secret template-name setting if
+  operators need deployment-time selection among packaged notice variants.
+
+The obvious future variation is adding non-essential cookies. That should be a
+separate consent-management decision with its own storage schema, preferences
+UI, legal text, and audit/retention review. Do not pre-build that framework for
+this issue.
+
+## Whole-Repo Scope
+
+Likely implementation touches some of:
+
+- `shifter/shifter_platform/config/urls.py` and `config/views.py` for
+  `/privacy/`.
+- `shifter/shifter_platform/templates/**` for the public privacy shell,
+  replaceable content template, and shared cookie notice partial.
+- `shifter/shifter_platform/static/js/` and `static/css/` for dismissal
+  behavior and styling.
+- `shifter/shifter_platform/tests/config`, template tests, and
+  `static/js/*.test.js` for route and localStorage behavior.
+- `shifter/shifter_platform/documentation/docs/**` or `docs/dev/**` for
+  operator replacement documentation.
+- `config/env-manifest.json` and env renderers only if a new env setting is
+  added.
+- `changelog.d/67.added.md` for the user-visible portal change.
+
+Usually out of scope:
+
+- Terraform, Kubernetes, workflows, ADR registry, or secret-delivery changes
+  unless a new deployment-facing setting or mounted content path is introduced.
+- DRF, API tokens, audit tables, database migrations, service facades, or
+  background jobs.
+
+## Gotchas And Anti-Patterns
+
+- Do not call the notice a consent banner. A dismissible disclosure for
+  strictly necessary storage is not a granular consent mechanism.
+- Do not add `/terms/`, terms-of-service copy, organization-specific policy
+  text, controller identity, processor list, retention period, lawful basis,
+  transfer statement, or rights workflow as OSS-authored commitments.
+- Do not claim the portal is GDPR-compliant because this route exists.
+- Do not add analytics, advertising tags, tracking pixels, telemetry beacons,
+  third-party consent SDKs, or new non-essential cookies.
+- Do not store dismissal in the Django session or user profile; that turns a
+  local UI affordance into persistence and retention surface area.
+- Do not put dismissal state, tokens, cookies, or user identifiers in query
+  strings, hidden form fields, server logs, audit rows, or template context.
+- Do not use `mark_safe`, raw HTML from env vars, or query-selected template
+  names for operator content.
+- Do not fork the notice markup across Mission Control, CTF, risk register,
+  docs, auth, and scenario editor templates.
+- Do not weaken `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`,
+  `SECURE_SSL_REDIRECT`, `ALLOWED_HOSTS`, CSRF trusted origins, or auth
+  middleware to make the notice appear.
+- Do not add a generic legal-policy service, repository, exception hierarchy,
+  schema package, or preference model before there is a real domain contract.
+
+## Non-Goals
+
+- No implementation, route, template, JavaScript, CSS, settings, migration, or
+  test change is made by this preflight note.
+- No legal advice, approved privacy policy, terms of service, GDPR compliance
+  determination, retention schedule, data-controller identity, processor list,
+  transfer statement, or rights workflow is authored here.
+- No non-essential cookies, analytics, advertising, tracking, preference center,
+  consent logs, or consent APIs.
+- No changes to authentication, session issuance, CSRF behavior, OIDC,
+  Identity Platform, CTF magic links, or dev-login.
+- No new Ground Control requirement or traceability link; issue #67 is the
+  authoritative contract.
+
+## Validation
+
+For this documentation-only architecture preflight, run:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+```
+
+Implementation follow-ups should also run the stack-native checks for changed
+surfaces, especially Django view/template tests, Jest tests for the static
+notice script, `uv run ruff check .`, `uv run ruff format --check .`, and
+`uv run lint-imports --config ../../.importlinter` from
+`shifter/shifter_platform` when Python code changes.

--- a/scripts/adr_guard/adr_guard.py
+++ b/scripts/adr_guard/adr_guard.py
@@ -66,6 +66,7 @@ GUARDRAIL_FILES = {
     # audit redaction, or prod-confirm policy without touching code, so
     # ADR enforcement watches the file.
     ".shifter.yaml",
+    ".cursor/cli.json",
 }
 DOC_PATHS = (
     "docs/adr/",
@@ -499,8 +500,51 @@ def check_guardrail_docs(repo_root: Path, files: list[str] | None) -> list[Viola
     ]
 
 
+def check_no_agent_attribution(repo_root: Path, files: list[str] | None) -> list[Violation]:
+    """Reject AI/agent marketing or co-author attribution in tracked text."""
+    from agent_attribution import find_agent_attribution_matches
+
+    candidates = files
+    if candidates is None:
+        candidates = [
+            rel
+            for rel in subprocess.check_output(["git", "ls-files"], cwd=repo_root, text=True).splitlines()
+            if rel
+        ]
+
+    violations: list[Violation] = []
+    for rel in candidates:
+        if rel in _AGENT_ATTRIBUTION_SCAN_SKIP:
+            continue
+        path = repo_root / rel
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        matches = find_agent_attribution_matches(text)
+        if not matches:
+            continue
+        first = matches[0]
+        violations.append(
+            Violation(
+                "no-agent-attribution",
+                "ADR-002-R2",
+                rel,
+                f"Prohibited AI/agent attribution ({first.rule}): {first.excerpt}",
+            )
+        )
+    return violations
+
+
 DOCS_COVERAGE_MANIFEST = "docs/adr/documentation-coverage.yaml"
 DOCS_COVERAGE_RULE_ID = "ADR-022-R1"
+_AGENT_ATTRIBUTION_SCAN_SKIP = {
+    "scripts/adr_guard/agent_attribution.py",
+    "scripts/adr_guard/block_agent_attribution_commit_msg.py",
+    "scripts/adr_guard/tests/test_agent_attribution.py",
+}
 _DOCS_EXCLUDED_PART = "_deprecated"
 _MARKDOWN_LINK_PATTERN = re.compile(r"\]\(([^)\s]+)")
 
@@ -5635,6 +5679,7 @@ CHECKS = {
     "no-terraform-operational-placeholders": check_no_terraform_operational_placeholders,
     "github-oidc-no-admin-access": check_github_oidc_no_admin_access,
     "documentation-coverage": check_documentation_coverage,
+    "no-agent-attribution": check_no_agent_attribution,
 }
 CHECK_LEVELS = {
     "fast": [
@@ -5660,6 +5705,7 @@ CHECK_LEVELS = {
         "no-terraform-operational-placeholders",
         "github-oidc-no-admin-access",
         "documentation-coverage",
+        "no-agent-attribution",
     ],
     "ci": [
         "adr-registry",
@@ -5685,6 +5731,7 @@ CHECK_LEVELS = {
         "no-terraform-operational-placeholders",
         "github-oidc-no-admin-access",
         "documentation-coverage",
+        "no-agent-attribution",
     ],
     "all": list(CHECKS),
 }

--- a/scripts/adr_guard/agent_attribution.py
+++ b/scripts/adr_guard/agent_attribution.py
@@ -1,0 +1,62 @@
+"""Detect prohibited AI/agent attribution in commit messages and tracked text."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Attribution markers only — not general mentions of cursor.com in docs or IAM names.
+_ATTRIBUTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "co-authored-by-cursor",
+        re.compile(r"(?im)^Co-authored-by:\s*Cursor\b"),
+    ),
+    (
+        "co-authored-by-cursoragent",
+        re.compile(r"(?im)^Co-authored-by:.*cursoragent@", re.IGNORECASE),
+    ),
+    (
+        "co-authored-by-claude",
+        re.compile(r"(?im)^Co-authored-by:\s*.*\bClaude\b"),
+    ),
+    (
+        "co-authored-by-codex",
+        re.compile(r"(?im)^Co-authored-by:\s*.*\bCodex\b"),
+    ),
+    (
+        "co-authored-by-composer",
+        re.compile(r"(?im)^Co-authored-by:\s*.*\bComposer\b"),
+    ),
+    (
+        "made-with-cursor-footer",
+        re.compile(r"Made with \[Cursor\]\(https://cursor\.com\)", re.IGNORECASE),
+    ),
+    (
+        "made-with-cursor-trailer",
+        re.compile(r"(?im)^Made-with:\s*Cursor\b"),
+    ),
+    (
+        "generated-with-claude-code",
+        re.compile(r"Generated with Claude Code", re.IGNORECASE),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class AgentAttributionMatch:
+    """One prohibited attribution marker."""
+
+    rule: str
+    excerpt: str
+
+
+def find_agent_attribution_matches(text: str) -> list[AgentAttributionMatch]:
+    """Return every prohibited attribution marker found in ``text``."""
+    matches: list[AgentAttributionMatch] = []
+    for rule, pattern in _ATTRIBUTION_PATTERNS:
+        for found in pattern.finditer(text):
+            excerpt = found.group(0).strip()
+            if len(excerpt) > 120:
+                excerpt = excerpt[:117] + "..."
+            matches.append(AgentAttributionMatch(rule=rule, excerpt=excerpt))
+    return matches

--- a/scripts/adr_guard/block_agent_attribution_commit_msg.py
+++ b/scripts/adr_guard/block_agent_attribution_commit_msg.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""pre-commit commit-msg hook: reject prohibited AI/agent attribution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from agent_attribution import find_agent_attribution_matches
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <commit-msg-file>", file=sys.stderr)
+        return 2
+
+    text = Path(sys.argv[1]).read_text(encoding="utf-8")
+    matches = find_agent_attribution_matches(text)
+    if not matches:
+        return 0
+
+    print(
+        "Commit message contains prohibited AI/agent attribution. Remove it and retry.",
+        file=sys.stderr,
+    )
+    for match in matches:
+        print(f"  - {match.rule}: {match.excerpt}", file=sys.stderr)
+    print(
+        "Disable Cursor commit/PR attribution in ~/.cursor/cli-config.json and .cursor/cli.json.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adr_guard/tests/test_agent_attribution.py
+++ b/scripts/adr_guard/tests/test_agent_attribution.py
@@ -1,0 +1,42 @@
+"""Tests for agent attribution detection."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parents[1]
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+
+from agent_attribution import find_agent_attribution_matches
+
+
+class AgentAttributionTests(unittest.TestCase):
+    def test_blocks_cursor_co_author_trailer(self):
+        text = "fix: thing\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\n"
+        matches = find_agent_attribution_matches(text)
+        self.assertGreaterEqual(len(matches), 1)
+        rules = {match.rule for match in matches}
+        self.assertIn("co-authored-by-cursor", rules)
+
+    def test_blocks_made_with_cursor_pr_footer(self):
+        text = "## Summary\n\nMade with [Cursor](https://cursor.com)\n"
+        matches = find_agent_attribution_matches(text)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].rule, "made-with-cursor-footer")
+
+    def test_blocks_generated_with_claude_code(self):
+        text = "Generated with Claude Code\n"
+        matches = find_agent_attribution_matches(text)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].rule, "generated-with-claude-code")
+
+    def test_allows_cursor_docs_reference(self):
+        text = "See https://cursor.com/docs/settings/aws-bedrock for setup.\n"
+        self.assertEqual(find_agent_attribution_matches(text), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/shifter/shifter_platform/config/urls.py
+++ b/shifter/shifter_platform/config/urls.py
@@ -14,10 +14,12 @@ from config.views import (
     legacy_oidc_authenticate,
     logout_view,
     platform_login,
+    privacy_notice,
 )
 
 urlpatterns = [
     path("", home, name="home"),
+    path("privacy/", privacy_notice, name="privacy_notice"),
     path("login/", platform_login, name="platform_login"),
     path("auth/identity/session/", identity_platform_session, name="identity_platform_session"),
     path("dashboard/", dashboard_router, name="dashboard_router"),

--- a/shifter/shifter_platform/config/views.py
+++ b/shifter/shifter_platform/config/views.py
@@ -6,7 +6,7 @@ import logging
 from django.conf import settings
 from django.contrib.auth import BACKEND_SESSION_KEY, login, logout
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseForbidden, HttpResponseRedirect, JsonResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseForbidden, HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 def home(request):
     """Landing page - coming soon."""
     return render(request, "coming_soon.html")
+
+
+@require_http_methods(["GET", "HEAD"])
+def privacy_notice(request: HttpRequest) -> HttpResponse:
+    """Public privacy notice shell for operator-supplied content."""
+    return render(request, "privacy/notice.html")
 
 
 def _render_identity_platform_login(request, *, status_code: int = 200):

--- a/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/adr-enforcement.md
@@ -69,6 +69,11 @@ The first slice intentionally stays small:
   This is a changeset-level check (needs to see multiple files) so it runs in
   pre-commit and `--level fast`, but NOT in the per-edit Claude hook.
 
+- `no-agent-attribution`
+  Rejects AI/agent attribution markers in tracked text (agent `Co-authored-by`
+  trailers, Cursor marketing footers, Claude Code branding strings, etc.).
+  A `commit-msg` pre-commit hook blocks the same markers in commit messages.
+
 - `cross-layer-model-imports`
   Fails on direct cross-layer model imports inside service layers. The current tree already satisfies this rule, so it is part of the default guard.
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/index.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/index.md
@@ -10,10 +10,11 @@ Getting started as a Shifter developer.
 4. [CI/CD](ci-cd) - How deployments work
 5. [Secrets](secrets) - What secrets exist, where they live
 6. [Platform API Development](api) - DRF endpoints, scopes, schema, and error envelopes
-7. [Terraform](terraform) - Infrastructure patterns
-8. [Cloud Adapters](cloud-adapters) - Cloud abstraction layer
-9. [Principles](principles) - Engineering philosophy
-10. [ADR Enforcement](adr-enforcement) - Architecture guardrails and policy checks
+7. [Privacy Notice Shell](privacy-notice) - Operator-owned `/privacy/` content and cookie disclosure
+8. [Terraform](terraform) - Infrastructure patterns
+9. [Cloud Adapters](cloud-adapters) - Cloud abstraction layer
+10. [Principles](principles) - Engineering philosophy
+11. [ADR Enforcement](adr-enforcement) - Architecture guardrails and policy checks
 
 ## Prerequisites
 

--- a/shifter/shifter_platform/documentation/docs/technical/dev/privacy-notice.md
+++ b/shifter/shifter_platform/documentation/docs/technical/dev/privacy-notice.md
@@ -1,0 +1,57 @@
+# Privacy Notice And Cookie Disclosure
+
+The Shifter portal ships a neutral privacy notice shell and a dismissible
+browser-storage disclosure. These are operator-facing mechanics only. They are
+not legal advice, not a binding privacy policy, and not a GDPR compliance claim.
+
+## What Shipped In OSS
+
+- A dismissible notice on portal HTML pages explaining that strictly necessary
+  browser storage is used for authentication, session behavior, and remembering
+  notice dismissal.
+- A public `/privacy/` route that renders placeholder content until the
+  deployment operator replaces it.
+- No analytics, advertising, tracking cookies, or non-essential consent flows.
+
+## Operator Replacement Steps
+
+1. Copy or edit `shifter/shifter_platform/templates/privacy/notice_content.html`
+   in your deployment overlay, fork, or image build step.
+2. Replace the placeholder with reviewed legal text for your deployment,
+   including at minimum:
+   - data controller identity and contact details
+   - categories of personal data processed
+   - retention periods
+   - subprocessors or processors, if any
+   - international transfers, if any
+   - lawful bases, if applicable
+   - data-subject rights mechanisms
+3. Rebuild and redeploy the portal image or static bundle so the updated
+   template is served at `/privacy/`.
+4. Verify `/privacy/` is reachable without authentication and that the cookie
+   notice links to it.
+
+If you maintain environment-specific template directories, point Django's
+template loader at your operator-owned template path instead of editing the
+upstream file in place.
+
+## Cookie Notice Behavior
+
+- Dismissal is stored locally in the browser under the versioned key
+  `shifter.cookieNotice.dismissed.v1`.
+- The notice uses disclosure language and a **Dismiss** action. It is not a
+  consent banner and does not manage non-essential cookie preferences.
+- The notice does not call the server when dismissed.
+
+## Out Of Scope
+
+- `/terms/` or terms-of-service content
+- Organization-specific legal commitments authored by the OSS project
+- Analytics, advertising, or granular consent management
+
+## Related Files
+
+- `templates/partials/cookie_notice.html`
+- `templates/privacy/notice.html`
+- `templates/privacy/notice_content.html`
+- `static/js/cookie-notice.js`

--- a/shifter/shifter_platform/static/css/cookie-notice.css
+++ b/shifter/shifter_platform/static/css/cookie-notice.css
@@ -1,0 +1,56 @@
+.cookie-notice {
+    position: fixed;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem 1rem;
+    max-width: min(42rem, calc(100vw - 2rem));
+    padding: 0.875rem 1rem;
+    background: var(--theme-surface, #151515);
+    border: 1px solid var(--theme-border, #484848);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgb(0, 0, 0, 0.35);
+    color: var(--theme-text, #eaebeb);
+    font-size: 0.875rem;
+    line-height: 1.45;
+}
+
+.cookie-notice[hidden] {
+    display: none !important;
+}
+
+.cookie-notice__text {
+    flex: 1 1 16rem;
+    margin: 0;
+}
+
+.cookie-notice__actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+}
+
+.cookie-notice__link {
+    color: var(--theme-accent, #94a3b8);
+    text-decoration: underline;
+}
+
+.cookie-notice__dismiss {
+    border: 1px solid var(--theme-border, #484848);
+    border-radius: 4px;
+    background: var(--theme-surface-elevated, #1f1f1f);
+    color: var(--theme-text, #eaebeb);
+    font: inherit;
+    font-size: 0.8125rem;
+    padding: 0.375rem 0.75rem;
+    cursor: pointer;
+}
+
+.cookie-notice__dismiss:hover {
+    border-color: var(--theme-accent, #94a3b8);
+}

--- a/shifter/shifter_platform/static/js/cookie-notice.js
+++ b/shifter/shifter_platform/static/js/cookie-notice.js
@@ -1,0 +1,35 @@
+/**
+ * Dismissible strictly-necessary storage notice (client-local persistence only).
+ */
+
+const STORAGE_KEY = 'shifter.cookieNotice.dismissed.v1';
+
+function initCookieNotice() {
+    const notice = document.getElementById('cookie-notice');
+    if (!notice) {
+        return;
+    }
+
+    if (localStorage.getItem(STORAGE_KEY) === '1') {
+        notice.hidden = true;
+        return;
+    }
+
+    notice.hidden = false;
+
+    const dismissButton = document.getElementById('cookie-notice-dismiss');
+    if (!dismissButton) {
+        return;
+    }
+
+    dismissButton.addEventListener('click', () => {
+        localStorage.setItem(STORAGE_KEY, '1');
+        notice.hidden = true;
+    });
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initCookieNotice);
+} else {
+    initCookieNotice();
+}

--- a/shifter/shifter_platform/static/js/cookie-notice.test.js
+++ b/shifter/shifter_platform/static/js/cookie-notice.test.js
@@ -1,0 +1,49 @@
+/**
+ * Cookie notice dismissal tests.
+ */
+
+const STORAGE_KEY = 'shifter.cookieNotice.dismissed.v1';
+
+const buildNoticeMarkup = () => `
+    <section id="cookie-notice" class="cookie-notice" hidden>
+        <p>Strictly necessary browser storage is used for authentication and session behavior.</p>
+        <a id="cookie-notice-privacy-link" href="/privacy/">Privacy notice</a>
+        <button type="button" id="cookie-notice-dismiss">Dismiss</button>
+    </section>
+`;
+
+function loadCookieNoticeModule() {
+    jest.resetModules();
+    document.body.innerHTML = buildNoticeMarkup();
+    require('./cookie-notice.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+}
+
+describe('cookie-notice', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    test('shows notice when dismissal key is absent', () => {
+        loadCookieNoticeModule();
+        const notice = document.getElementById('cookie-notice');
+        expect(notice.hidden).toBe(false);
+    });
+
+    test('hides notice when dismissal key is set', () => {
+        localStorage.setItem(STORAGE_KEY, '1');
+        loadCookieNoticeModule();
+        const notice = document.getElementById('cookie-notice');
+        expect(notice.hidden).toBe(true);
+    });
+
+    test('dismiss persists storage key and hides notice', () => {
+        loadCookieNoticeModule();
+        const privacyLink = document.getElementById('cookie-notice-privacy-link');
+        expect(privacyLink.getAttribute('href')).toBe('/privacy/');
+        document.getElementById('cookie-notice-dismiss').click();
+        expect(localStorage.getItem(STORAGE_KEY)).toBe('1');
+        expect(document.getElementById('cookie-notice').hidden).toBe(true);
+        expect(privacyLink.getAttribute('href')).toBe('/privacy/');
+    });
+});

--- a/shifter/shifter_platform/templates/coming_soon.html
+++ b/shifter/shifter_platform/templates/coming_soon.html
@@ -37,5 +37,6 @@
         <footer class="footer">
             {% trans "&copy; 2025 Brad Edwards" %}
         </footer>
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/ctf/base.html
+++ b/shifter/shifter_platform/templates/ctf/base.html
@@ -45,5 +45,6 @@
         <script src="{% static 'js/dropdown.js' %}"></script>
         {% block extra_js %}
         {% endblock %}
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/dev_login.html
+++ b/shifter/shifter_platform/templates/dev_login.html
@@ -48,5 +48,6 @@
                 </button>
             </form>
         </div>
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/documentation/base.html
+++ b/shifter/shifter_platform/templates/documentation/base.html
@@ -106,5 +106,6 @@
         </script>
         {% block extra_js %}
         {% endblock %}
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/identity_platform_login.html
+++ b/shifter/shifter_platform/templates/identity_platform_login.html
@@ -143,5 +143,6 @@
         {# The auth module imports the Firebase modular SDK (version-pinned) from #}
         {# gstatic; TOTP MFA is only available through the modular API, not compat. #}
         <script type="module" src="{% static 'js/identity_platform_auth.js' %}"></script>
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/identity_platform_logout.html
+++ b/shifter/shifter_platform/templates/identity_platform_logout.html
@@ -19,5 +19,6 @@
         {{ identity_platform_logout_config_json|json_script:"identity-platform-logout-config" }}
         <script type="module"
                 src="{% static 'js/identity_platform_logout.js' %}"></script>
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/mission_control/base.html
+++ b/shifter/shifter_platform/templates/mission_control/base.html
@@ -33,5 +33,6 @@
         <script src="{% static 'js/dropdown.js' %}"></script>
         {% block extra_js %}
         {% endblock %}
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/partials/cookie_notice.html
+++ b/shifter/shifter_platform/templates/partials/cookie_notice.html
@@ -1,0 +1,26 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
+{% load static i18n %}
+<section id="cookie-notice"
+         class="cookie-notice"
+         aria-label="{% trans 'Browser storage notice' %}"
+         hidden>
+    <p class="cookie-notice__text">
+        {% blocktrans trimmed %}
+        This portal uses strictly necessary browser storage for authentication, session behavior, and remembering that you dismissed this notice.
+        {% endblocktrans %}
+        {% blocktrans trimmed %}
+        It does not use analytics, advertising, or non-essential tracking cookies.
+        {% endblocktrans %}
+        <a id="cookie-notice-privacy-link"
+           class="cookie-notice__link"
+           href="{% url 'privacy_notice' %}">{% trans "Privacy notice" %}</a>
+    </p>
+    <div class="cookie-notice__actions">
+        <button type="button"
+                id="cookie-notice-dismiss"
+                class="cookie-notice__dismiss">{% trans "Dismiss" %}</button>
+    </div>
+</section>
+<link rel="stylesheet" href="{% static 'css/cookie-notice.css' %}">
+<script src="{% static 'js/cookie-notice.js' %}"></script>

--- a/shifter/shifter_platform/templates/privacy/notice.html
+++ b/shifter/shifter_platform/templates/privacy/notice.html
@@ -1,0 +1,51 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
+{% load static i18n %}
+<!DOCTYPE html>
+<html lang="en" class="theme-dark">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport"
+              content="width=device-width, initial-scale=1.0">
+        <title>{% trans "Privacy Notice" %} {% trans "- Shifter" %}</title>
+        <link rel="stylesheet" href="{% static 'css/theme.css' %}">
+        <link rel="icon"
+              type="image/svg+xml"
+              href="{% static 'images/favicon.svg' %}">
+        <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: var(--theme-bg, #1f1f1f);
+            color: var(--theme-text, #eaebeb);
+            font-family: Lato, "Assistant", sans-serif;
+        }
+
+        .privacy-page {
+            max-width: 48rem;
+            margin: 0 auto;
+            padding: 2.5rem 1.5rem 6rem;
+        }
+
+        .privacy-page h1 {
+            font-size: 1.75rem;
+            margin: 0 0 1rem;
+        }
+
+        .privacy-page p {
+            line-height: 1.6;
+            color: var(--theme-text-secondary, #b8b8b8);
+        }
+
+        .privacy-page p + p {
+            margin-top: 1rem;
+        }
+        </style>
+    </head>
+    <body class="theme-dark">
+        <main class="privacy-page">
+            {% include "privacy/notice_content.html" %}
+        </main>
+        {% include "partials/cookie_notice.html" %}
+    </body>
+</html>

--- a/shifter/shifter_platform/templates/privacy/notice_content.html
+++ b/shifter/shifter_platform/templates/privacy/notice_content.html
@@ -1,0 +1,29 @@
+{# SPDX-FileCopyrightText: 2026 Palo Alto Networks, Inc. #}
+{# SPDX-License-Identifier: MIT #}
+{% load i18n %}
+{# Operator-owned privacy notice body. Replace this template before production use. #}
+<section class="privacy-notice-content">
+    <h1>{% trans "Privacy Notice Placeholder" %}</h1>
+    <p>
+        {% blocktrans trimmed %}
+        This page is a neutral shell shipped with the Shifter portal.
+        It is not a binding privacy policy and does not assert GDPR compliance.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans trimmed %}
+        Before production use, the deployment operator must replace this content with reviewed legal text
+        that identifies the data controller, contact details, categories of personal data processed,
+        retention periods, subprocessors or processors, international transfers (if any),
+        lawful bases (if applicable), and data-subject rights mechanisms relevant to that deployment.
+        {% endblocktrans %}
+    </p>
+    <p>
+        {% blocktrans trimmed %}
+        This OSS project does not add analytics, advertising, tracking cookies,
+        or non-essential cookie consent flows.
+        The portal only discloses strictly necessary browser storage used for authentication,
+        session behavior, and notice dismissal.
+        {% endblocktrans %}
+    </p>
+</section>

--- a/shifter/shifter_platform/templates/risk_register/base.html
+++ b/shifter/shifter_platform/templates/risk_register/base.html
@@ -31,5 +31,6 @@
         <script src="{% static 'js/sidebar.js' %}"></script>
         {% block extra_js %}
         {% endblock %}
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/templates/scenario_editor/base.html
+++ b/shifter/shifter_platform/templates/scenario_editor/base.html
@@ -47,5 +47,6 @@
         <script src="{% static 'js/sidebar.js' %}"></script>
         {% block extra_js %}
         {% endblock %}
+        {% include "partials/cookie_notice.html" %}
     </body>
 </html>

--- a/shifter/shifter_platform/tests/config/test_privacy_notice.py
+++ b/shifter/shifter_platform/tests/config/test_privacy_notice.py
@@ -1,0 +1,39 @@
+"""Behavior tests for the public privacy notice route and cookie notice shell."""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+class TestPrivacyNoticeView:
+    URL = reverse("privacy_notice")
+
+    def test_public_get_renders_placeholder(self):
+        response = Client().get(self.URL)
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "deployment operator" in content.lower()
+        assert "/terms/" not in content
+
+    def test_public_head_allowed(self):
+        assert Client().head(self.URL).status_code == 200
+
+    def test_post_not_allowed(self):
+        assert Client().post(self.URL).status_code == 405
+
+    def test_includes_cookie_notice_partial(self):
+        response = Client().get(self.URL)
+        content = response.content.decode()
+        assert 'id="cookie-notice"' in content
+        assert "cookie-notice.js" in content
+
+
+class TestCookieNoticeOnPortalShell:
+    def test_home_includes_cookie_notice(self):
+        response = Client().get(reverse("home"))
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert 'id="cookie-notice"' in content
+        assert reverse("privacy_notice") in content


### PR DESCRIPTION
## Summary

Adds portal plumbing for a dismissible strictly-necessary browser storage notice and a public `/privacy/` shell with neutral placeholder content. Operators replace the template before production; no consent framework, `/terms/`, or legal commitments are introduced.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #67

## ADR Impact

- ADR-021
- ADR-029

## Changes

- Add public `/privacy/` route with operator-replaceable placeholder template content
- Add shared cookie notice partial, CSS, and client-side dismissal via versioned localStorage key
- Include notice on portal HTML shells (mission control, CTF, docs, auth pages, etc.)
- Add Django and Jest tests plus operator documentation
- Block AI/agent attribution in commits and tracked text (ADR-002-R2)

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

pytest tests/config/test_privacy_notice.py and jest static/js/cookie-notice.test.js cover the privacy route and dismissal behavior.

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/67.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed

## Documentation

Updated: see diff.