### PR TITLE
refactor: make .tgz extension explicit in get_file_extension

### DIFF
--- a/changelog.d/97.changed.md
+++ b/changelog.d/97.changed.md
@@ -1,0 +1,1 @@
+Internal: make `.tgz` compound extension explicit in shared upload inspection helper (no user-visible behavior change).

--- a/shifter/shifter_platform/shared/uploads/inspection.py
+++ b/shifter/shifter_platform/shared/uploads/inspection.py
@@ -189,12 +189,14 @@ def get_file_extension(filename: str) -> str:
     """
     lower = filename.lower()
     if lower.endswith(".tar.gz"):
-        return ".tar.gz"
-    if lower.endswith(".tgz"):
-        return ".tgz"
-    if "." in filename:
-        return "." + lower.rsplit(".", 1)[-1]
-    return ""
+        extension = ".tar.gz"
+    elif lower.endswith(".tgz"):
+        extension = ".tgz"
+    elif "." in filename:
+        extension = "." + lower.rsplit(".", 1)[-1]
+    else:
+        extension = ""
+    return extension
 
 
 def validate_magic_bytes(header: bytes, fmt: FileFormat) -> None:

--- a/shifter/shifter_platform/shared/uploads/inspection.py
+++ b/shifter/shifter_platform/shared/uploads/inspection.py
@@ -185,11 +185,13 @@ _UTF8_BOM = b"\xef\xbb\xbf"
 def get_file_extension(filename: str) -> str:
     """Return the file extension including the leading dot, lowercased.
 
-    Recognizes the compound extension ``.tar.gz`` as a single unit.
+    Recognizes compound extensions ``.tar.gz`` and ``.tgz`` as single units.
     """
     lower = filename.lower()
     if lower.endswith(".tar.gz"):
         return ".tar.gz"
+    if lower.endswith(".tgz"):
+        return ".tgz"
     if "." in filename:
         return "." + lower.rsplit(".", 1)[-1]
     return ""

--- a/shifter/shifter_platform/tests/shared/uploads/test_inspection.py
+++ b/shifter/shifter_platform/tests/shared/uploads/test_inspection.py
@@ -86,6 +86,9 @@ class TestGetFileExtension:
     def test_compound_tar_gz(self):
         assert get_file_extension("agent.tar.gz") == ".tar.gz"
 
+    def test_compound_tgz(self):
+        assert get_file_extension("agent.tgz") == ".tgz"
+
     def test_case_insensitive(self):
         assert get_file_extension("FILE.MSI") == ".msi"
 


### PR DESCRIPTION
## Summary

Makes `.tgz` handling explicit in the canonical upload extension helper for clarity and maintainability. Behavior is unchanged — `.tgz` already resolved via the simple suffix fallback and remains an alias for the existing `tar_gz` format registry entry.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #97

## ADR Impact

- ADR-021

## Changes

- Add explicit `.tgz` compound-extension check in `shared/uploads/inspection.get_file_extension`
- Add shared inspection unit test for `.tgz` alongside existing `.tar.gz` coverage

## Test Plan

- [x] Unit tests pass (`make test`)
- [x] Integration tests pass if applicable (`make integration`)
- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] No coverage regression

Focused: `uv run pytest shifter/shifter_platform/tests/shared/uploads/test_inspection.py::TestGetFileExtension`

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: issue #97 ← shifter/shifter_platform/shared/uploads/inspection.py
- TESTS: issue #97 ← shifter/shifter_platform/tests/shared/uploads/test_inspection.py

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- [x] Changelog fragment added at `changelog.d/97.changed.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed