### PR TITLE
Fix MCP tool schema dialect for Vertex

### DIFF
--- a/changelog.d/1306.fixed.md
+++ b/changelog.d/1306.fixed.md
@@ -1,0 +1,1 @@
+Fixed the in-repo MCP servers' advertised JSON Schema dialect so Vertex-backed tool registration accepts their tool schemas without changing runtime validation.

--- a/mcp/ngfw/index.js
+++ b/mcp/ngfw/index.js
@@ -7,6 +7,7 @@ import {
   getProfile as _getProfile,
   awsJson,
 } from "./lib.js";
+import { installToolSchemaDialectNormalizer } from "../shared/tool-schema-dialect.js";
 
 const PROFILES = {
   dev: process.env.PANW_SHIFTER_DEV_PROFILE,
@@ -47,6 +48,7 @@ const server = new McpServer({
   name: "shifter-ngfw",
   version: "1.0.0",
 });
+installToolSchemaDialectNormalizer(server);
 
 const EnvSchema = z
   .enum(["dev", "prod"])

--- a/mcp/ops/index.js
+++ b/mcp/ops/index.js
@@ -38,6 +38,7 @@ import {
   ghExec,
   resolveGitRef,
 } from "./lib.js";
+import { installToolSchemaDialectNormalizer } from "../shared/tool-schema-dialect.js";
 import {
   loadPolicy,
   profileFromEnv,
@@ -3248,6 +3249,7 @@ registerTool(ctx, {
 async function main() {
   installLiveProcessHandlers();
   const server = new McpServer({ name: "shifter-ops", version: "1.0.0" });
+  installToolSchemaDialectNormalizer(server);
   const policy = loadPolicy({
     path: path.join(_REPO_ROOT, ".shifter.yaml"),
     profile: profileFromEnv(process.env),

--- a/mcp/planner/index.js
+++ b/mcp/planner/index.js
@@ -3,6 +3,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
+import { installToolSchemaDialectNormalizer } from "../shared/tool-schema-dialect.js";
 import {
   PLAN_ID_PATTERN,
   createPlan,
@@ -41,6 +42,7 @@ const PLAN_ID_SCHEMA = z
   .regex(PLAN_ID_PATTERN, "Plan ID must be 8 lowercase hex characters");
 
 const server = new McpServer({ name: "shifter-planner", version: "1.0.0" });
+installToolSchemaDialectNormalizer(server);
 
 // ==========================================================================
 // Plan tools

--- a/mcp/shared/tool-schema-dialect.js
+++ b/mcp/shared/tool-schema-dialect.js
@@ -1,0 +1,85 @@
+const TOOLS_LIST_METHOD = "tools/list";
+const JSON_SCHEMA_DRAFT_2020_12 =
+  "https://json-schema.org/draft/2020-12/schema";
+
+const LEGACY_JSON_SCHEMA_DIALECTS = new Set([
+  "http://json-schema.org/draft-07/schema#",
+  "https://json-schema.org/draft-07/schema#",
+]);
+
+function schemaShape(schema) {
+  const shape = schema?.shape ?? schema?._def?.shape ?? schema?._zod?.def?.shape;
+  return typeof shape === "function" ? shape() : shape;
+}
+
+function literalValue(schema) {
+  return (
+    schema?.value ??
+    schema?._def?.value ??
+    schema?._def?.values?.[0] ??
+    schema?._zod?.def?.value ??
+    schema?._zod?.def?.values?.[0]
+  );
+}
+
+function requestMethod(requestSchema) {
+  return literalValue(schemaShape(requestSchema)?.method);
+}
+
+export function normalizeJsonSchemaDialect(schema) {
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+
+  if (Array.isArray(schema)) {
+    for (const item of schema) {
+      normalizeJsonSchemaDialect(item);
+    }
+    return schema;
+  }
+
+  if (LEGACY_JSON_SCHEMA_DIALECTS.has(schema.$schema)) {
+    schema.$schema = JSON_SCHEMA_DRAFT_2020_12;
+  }
+
+  for (const value of Object.values(schema)) {
+    normalizeJsonSchemaDialect(value);
+  }
+  return schema;
+}
+
+export function normalizeToolSchemaDialects(listToolsResult) {
+  for (const tool of listToolsResult?.tools ?? []) {
+    normalizeJsonSchemaDialect(tool.inputSchema);
+    normalizeJsonSchemaDialect(tool.outputSchema);
+  }
+  return listToolsResult;
+}
+
+export function installToolSchemaDialectNormalizer(mcpServer) {
+  const protocolServer = mcpServer?.server;
+  if (
+    !protocolServer ||
+    protocolServer.__shifterToolSchemaDialectNormalizerInstalled
+  ) {
+    return;
+  }
+
+  const setRequestHandler = protocolServer.setRequestHandler.bind(protocolServer);
+  protocolServer.setRequestHandler = (requestSchema, handler) => {
+    if (requestMethod(requestSchema) !== TOOLS_LIST_METHOD) {
+      return setRequestHandler(requestSchema, handler);
+    }
+    return setRequestHandler(requestSchema, async (request, extra) =>
+      normalizeToolSchemaDialects(await handler(request, extra))
+    );
+  };
+
+  Object.defineProperty(
+    protocolServer,
+    "__shifterToolSchemaDialectNormalizerInstalled",
+    {
+      value: true,
+    }
+  );
+}

--- a/mcp/shared/tool-schema-dialect.test.js
+++ b/mcp/shared/tool-schema-dialect.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  installToolSchemaDialectNormalizer,
+  normalizeJsonSchemaDialect,
+} from "./tool-schema-dialect.js";
+
+const LEGACY_DRAFT_07 = "http://json-schema.org/draft-07/schema#";
+const DRAFT_2020_12 = "https://json-schema.org/draft/2020-12/schema";
+
+describe("tool schema dialect normalization", () => {
+  it("rewrites legacy draft-07 schema declarations recursively", () => {
+    const schema = {
+      $schema: LEGACY_DRAFT_07,
+      type: "object",
+      properties: {
+        nested: {
+          $schema: LEGACY_DRAFT_07,
+          type: "string",
+        },
+      },
+    };
+
+    normalizeJsonSchemaDialect(schema);
+
+    assert.equal(schema.$schema, DRAFT_2020_12);
+    assert.equal(schema.properties.nested.$schema, DRAFT_2020_12);
+  });
+
+  it("normalizes only tools/list handler results", async () => {
+    const protocolServer = {
+      setRequestHandler(requestSchema, handler) {
+        this.requestSchema = requestSchema;
+        this.handler = handler;
+      },
+    };
+
+    installToolSchemaDialectNormalizer({ server: protocolServer });
+    protocolServer.setRequestHandler(
+      { shape: { method: { value: "tools/list" } } },
+      async () => ({
+        tools: [
+          {
+            name: "example",
+            inputSchema: { $schema: LEGACY_DRAFT_07, type: "object" },
+            outputSchema: { $schema: LEGACY_DRAFT_07, type: "object" },
+          },
+        ],
+      })
+    );
+
+    const result = await protocolServer.handler({}, {});
+    assert.equal(result.tools[0].inputSchema.$schema, DRAFT_2020_12);
+    assert.equal(result.tools[0].outputSchema.$schema, DRAFT_2020_12);
+
+    protocolServer.setRequestHandler(
+      { shape: { method: { value: "tools/call" } } },
+      async () => ({ $schema: LEGACY_DRAFT_07 })
+    );
+
+    const nonListResult = await protocolServer.handler({}, {});
+    assert.equal(nonListResult.$schema, LEGACY_DRAFT_07);
+  });
+});


### PR DESCRIPTION
Closes #1306

## Summary
- Normalize advertised MCP tool input/output schemas from Draft-07 to JSON Schema Draft 2020-12 for the in-repo MCP servers.
- Apply the normalization at `tools/list` registration for `shifter-ops`, `shifter-ngfw`, and `shifter-planner` without changing runtime tool validation.
- Add focused coverage for recursive schema-dialect normalization and `tools/list`-only wrapping.

## RCA
Vertex validates registered tool schemas as JSON Schema Draft 2020-12. The in-repo MCP servers were advertising schemas with Draft-07 `$schema` declarations emitted by the MCP SDK's Zod schema conversion. That made Vertex reject tool registration before any tool invocation ran. Local reproduction mapped the failing tool index to `mcp__shifter-ops__describe_log_streams`, with `mcp__shifter-ops__get_log_events` next in the same bad dialect sequence.

## Verification
- `node --test mcp/shared/tool-schema-dialect.test.js`
- `cd mcp/ops && npm test`
- `cd mcp/ngfw && npm test`
- `cd mcp/planner && npm test`
- `cd mcp/shared && npm run lint`
- `cd mcp/ops && npm run lint`
- `cd mcp/ngfw && npm run lint`
- `cd mcp/planner && npm run lint`
- `python3 scripts/adr_guard/adr_guard.py --files mcp/shared/tool-schema-dialect.js mcp/shared/tool-schema-dialect.test.js mcp/ops/index.js mcp/ngfw/index.js mcp/planner/index.js changelog.d/1306.fixed.md --level fast`
- Strict MCP config and full default Vertex-backed startup both completed successfully after the schema-dialect fix.