### PR TITLE
feat: GDC-native polaris-dc Windows DC build tooling

### DIFF
--- a/shifter/engine/provisioner/_gdc_vm_disks.py
+++ b/shifter/engine/provisioner/_gdc_vm_disks.py
@@ -87,6 +87,48 @@ def _build_vm_manifest(
 ) -> dict[str, Any]:
     """Build the ``VirtualMachine`` custom resource manifest."""
     prefix_length = network.subnet_cidr.split("/", 1)[1]
+    spec: dict[str, Any] = {
+        "osType": compute.os_label,
+        "compute": {
+            "cpu": {"vcpus": compute.vcpus},
+            "memory": {"capacity": compute.memory},
+        },
+        "interfaces": [
+            {
+                "name": "eth0",
+                "networkName": network.network_name,
+                "ipAddresses": [f"{network.static_ip}/{prefix_length}"],
+                "default": True,
+            }
+        ],
+        "disks": [
+            {
+                "boot": True,
+                "autoDelete": False,
+                "virtualMachineDiskName": disk_name,
+            }
+        ],
+    }
+    # GDC's VM webhook forbids cloudInit on Windows VMs ("CloudInit is only
+    # supported for Linux VMs"). The NoCloud seed carries the Linux host-key /
+    # authorized_keys / first-boot script; Windows guests self-configure from
+    # the baked image (e.g. the polaris-dc first-boot promotion task) and take
+    # their static IP from the interface spec above, so no seed is attached.
+    if compute.os_label == "Linux":
+        spec["cloudInit"] = {
+            "noCloud": {
+                "secretRef": {"name": user_data_secret_name},
+            }
+        }
+    else:
+        # Windows guests need UEFI. The firmware bootloader defaults to legacy
+        # BIOS (SeaBIOS), which cannot boot the GCE Windows Server 2022 image
+        # (UEFI/GPT, no MBR boot code) -> "No bootable device". The Linux guest
+        # images support legacy BIOS, so only Windows opts into UEFI.
+        # Secure Boot is disabled: GDC's OVMF has no Microsoft UEFI CA keys
+        # enrolled, so with it on the firmware rejects the (MS-signed) Windows
+        # bootloader with "Access Denied" -> "No bootable option or device".
+        spec["firmware"] = {"bootloader": {"type": "uefi", "enableSecureBoot": False}}
     return {
         "apiVersion": f"{_VM_GROUP}/{_VM_VERSION}",
         "kind": "VirtualMachine",
@@ -95,31 +137,5 @@ def _build_vm_manifest(
             "namespace": namespace,
             "labels": labels,
         },
-        "spec": {
-            "osType": compute.os_label,
-            "compute": {
-                "cpu": {"vcpus": compute.vcpus},
-                "memory": {"capacity": compute.memory},
-            },
-            "interfaces": [
-                {
-                    "name": "eth0",
-                    "networkName": network.network_name,
-                    "ipAddresses": [f"{network.static_ip}/{prefix_length}"],
-                    "default": True,
-                }
-            ],
-            "disks": [
-                {
-                    "boot": True,
-                    "autoDelete": False,
-                    "virtualMachineDiskName": disk_name,
-                }
-            ],
-            "cloudInit": {
-                "noCloud": {
-                    "secretRef": {"name": user_data_secret_name},
-                }
-            },
-        },
+        "spec": spec,
     }

--- a/shifter/engine/provisioner/tests/test_gdc_vmruntime_assets.py
+++ b/shifter/engine/provisioner/tests/test_gdc_vmruntime_assets.py
@@ -258,12 +258,11 @@ class TestApplyRangeAssets:
         assert disk_body["spec"]["source"]["gcs"]["secretRef"] == "gdc-vm-image-gcs"
         assert vm_body["kind"] == "VirtualMachine"
         assert vm_body["spec"]["interfaces"][0]["ipAddresses"] == ["10.200.0.104/28"]
-        # GDC's admission webhook forbids inline cloudInit userData over 2048
-        # bytes, so the VM references a per-VM Secret via secretRef instead.
-        assert vm_body["spec"]["cloudInit"]["noCloud"] == {
-            "secretRef": {"name": "range-42-victims-victim-1234-cloudinit"}
-        }
-        assert "userData" not in vm_body["spec"]["cloudInit"]["noCloud"]
+        # This is a Windows VM: GDC's VM webhook forbids cloudInit on Windows
+        # guests, so no NoCloud seed is attached (the guest self-configures from
+        # the baked image and takes its static IP from the interface spec).
+        assert vm_body["spec"]["osType"] == "Windows"
+        assert "cloudInit" not in vm_body["spec"]
 
         assert result == [
             {
@@ -597,3 +596,38 @@ def test_run_power_operation_stops_vm_and_waits_for_stopped(mock_access, mock_cl
         "range-42-victims-victim-1234",
         fake_api_exception,
     )
+
+
+def test_build_vm_manifest_attaches_cloudinit_only_for_linux():
+    """GDC forbids cloudInit on Windows VMs; Linux gets the NoCloud seed."""
+    from _gdc_vm_disks import _build_vm_manifest, _VMComputeSpec, _VMNetworkSpec
+
+    network = _VMNetworkSpec(network_name="range-9-core", static_ip="10.200.0.10", subnet_cidr="10.200.0.0/28")
+
+    linux = _build_vm_manifest(
+        namespace="range-9",
+        vm_name="range-9-core-attacker",
+        disk_name="range-9-core-attacker-boot",
+        user_data_secret_name="range-9-core-attacker-cloudinit",
+        labels={},
+        network=network,
+        compute=_VMComputeSpec(os_label="Linux", vcpus=2, memory="4Gi"),
+    )
+    assert linux["spec"]["cloudInit"]["noCloud"] == {"secretRef": {"name": "range-9-core-attacker-cloudinit"}}
+
+    windows = _build_vm_manifest(
+        namespace="range-9",
+        vm_name="range-9-core-dc",
+        disk_name="range-9-core-dc-boot",
+        user_data_secret_name="range-9-core-dc-cloudinit",
+        labels={},
+        network=network,
+        compute=_VMComputeSpec(os_label="Windows", vcpus=2, memory="8Gi"),
+    )
+    assert "cloudInit" not in windows["spec"]
+    assert windows["spec"]["osType"] == "Windows"
+    # Windows must boot UEFI (GCE Windows Server 2022 is UEFI/GPT; SeaBIOS can't
+    # boot it -> "No bootable device"). Linux stays on the default legacy BIOS.
+    assert windows["spec"]["firmware"]["bootloader"]["type"] == "uefi"
+    assert windows["spec"]["firmware"]["bootloader"]["enableSecureBoot"] is False
+    assert "firmware" not in linux["spec"]

--- a/shifter/gdc-vm-images/polaris-dc/autounattend.xml
+++ b/shifter/gdc-vm-images/polaris-dc/autounattend.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Unattended install answer file for the GDC-native polaris-dc image.
+
+  This drives an automated Windows Server 2022 install on GDC VM Runtime
+  (KubeVirt/QEMU) the *supported* way (per the GDC bare-metal windows-vm doc):
+  install fresh from the Windows ISO with the virtio-container-disk attached, so
+  the installer writes a correct UEFI/GPT/ESP layout and binds the virtio disk +
+  net drivers by construction (no GCE-export firmware hacks).
+
+  Media layout at install time (attached to the install VM):
+    - boot disk         : empty 100Gi VirtualMachineDisk (install target)
+    - windows-iso       : cdrom, Windows Server 2022 eval ISO
+    - virtio-driver     : cdrom, quay.io/kubevirt/virtio-container-disk
+    - polaris-answer    : cdrom, this autounattend.xml + the AD content scripts
+
+  Windows Setup auto-reads autounattend.xml from the root of any attached
+  removable drive. The virtio drivers are loaded in the windowsPE pass via
+  DriverPaths that list the candidate cdrom letters for the virtio disk (its
+  drive letter is assigned at runtime, so several are listed; non-existent paths
+  are ignored). FirstLogonCommands runs the AD promotion + a2_setup post-install.
+-->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+
+  <settings pass="windowsPE">
+    <!-- WinPE language/locale. REQUIRED for an unattended install: it is what
+         the interactive "Language to install / Time / Keyboard" screen collects.
+         Without it Setup cannot resolve the (language-specific) license terms and
+         fails with "Windows cannot find the Microsoft Software License Terms". -->
+    <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <SetupUILanguage><UILanguage>en-US</UILanguage></SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UILanguageFallback>en-US</UILanguageFallback>
+      <UserLocale>en-US</UserLocale>
+    </component>
+
+    <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <!-- Load the virtio storage (viostor/vioscsi) + network (NetKVM) drivers
+           from the virtio-container-disk cdrom. Its drive letter is assigned at
+           runtime, so list the common candidates; Setup skips paths that do not
+           exist. 2k22 = Windows Server 2022 driver subdir. -->
+      <DriverPaths>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="1"><Path>D:\viostor\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="2"><Path>E:\viostor\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="3"><Path>F:\viostor\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="4"><Path>D:\vioscsi\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="5"><Path>E:\vioscsi\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="6"><Path>F:\vioscsi\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="7"><Path>D:\NetKVM\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="8"><Path>E:\NetKVM\2k22\amd64</Path></PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="9"><Path>F:\NetKVM\2k22\amd64</Path></PathAndCredentials>
+      </DriverPaths>
+    </component>
+
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <DiskConfiguration>
+        <Disk wcm:action="add">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <!-- UEFI/GPT layout: EFI System Partition + MSR + Windows. -->
+          <CreatePartitions>
+            <CreatePartition wcm:action="add"><Order>1</Order><Type>EFI</Type><Size>260</Size></CreatePartition>
+            <CreatePartition wcm:action="add"><Order>2</Order><Type>MSR</Type><Size>16</Size></CreatePartition>
+            <CreatePartition wcm:action="add"><Order>3</Order><Type>Primary</Type><Extend>true</Extend></CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add"><Order>1</Order><PartitionID>1</PartitionID><Format>FAT32</Format><Label>System</Label></ModifyPartition>
+            <ModifyPartition wcm:action="add"><Order>2</Order><PartitionID>2</PartitionID></ModifyPartition>
+            <ModifyPartition wcm:action="add"><Order>3</Order><PartitionID>3</PartitionID><Format>NTFS</Format><Label>Windows</Label><Letter>C</Letter></ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <!-- Windows Server 2022 Standard, Desktop Experience = image index 2
+               in the eval install.wim (1=Standard Core, 2=Standard Desktop,
+               3=Datacenter Core, 4=Datacenter Desktop). Select by INDEX rather
+               than NAME: an unresolved InstallFrom is what Setup reports as
+               "Windows cannot find the Microsoft Software License Terms". -->
+          <InstallFrom>
+            <MetaData wcm:action="add"><Key>/IMAGE/INDEX</Key><Value>2</Value></MetaData>
+          </InstallFrom>
+          <InstallTo><DiskID>0</DiskID><PartitionID>3</PartitionID></InstallTo>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <!-- NO <ProductKey>: the edition is chosen by ImageInstall/InstallFrom
+             (index 2 = Standard Desktop Eval). An empty <ProductKey><Key></Key>
+             makes Setup fail edition/license resolution and abort with "Windows
+             cannot find the Microsoft Software License Terms" (bisected via the
+             GDC vnc/screenshot endpoint: license page renders fine without
+             UserData; adding an empty ProductKey is what breaks it). -->
+        <AcceptEula>true</AcceptEula>
+        <FullName>Boreas</FullName>
+        <Organization>Boreas Systems</Organization>
+      </UserData>
+    </component>
+  </settings>
+
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <ComputerName>dc01</ComputerName>
+    </component>
+  </settings>
+
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS"
+               xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <UserAccounts>
+        <AdministratorPassword>
+          <!-- The build/admin password. a2_setup.ps1 sets the final CTF
+               Administrator password (CortexSavesTheDay!) during the bake. -->
+          <Value>CortexSavesTheDay!</Value>
+          <PlainText>true</PlainText>
+        </AdministratorPassword>
+      </UserAccounts>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>Administrator</Username>
+        <Password><Value>CortexSavesTheDay!</Value><PlainText>true</PlainText></Password>
+        <LogonCount>3</LogonCount>
+      </AutoLogon>
+      <FirstLogonCommands>
+        <!-- Kick off the polaris DC bake. The answer cdrom's drive letter is
+             resolved by the bootstrap script itself (it searches removable
+             drives for polaris\bake.ps1). -->
+        <SynchronousCommand wcm:action="add">
+          <Order>1</Order>
+          <CommandLine>powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "foreach($d in (Get-Volume | ? {$_.DriveLetter}).DriveLetter){ $p = $d + ':\polaris\bake.ps1'; if(Test-Path $p){ Start-Process powershell -ArgumentList ('-NoProfile -ExecutionPolicy Bypass -File ' + $p) -Wait; break } }"</CommandLine>
+          <Description>Run polaris DC bake (AD promotion + a2_setup)</Description>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+
+</unattend>

--- a/shifter/gdc-vm-images/polaris-dc/bake.ps1
+++ b/shifter/gdc-vm-images/polaris-dc/bake.ps1
@@ -1,0 +1,104 @@
+# polaris-dc bake (runs on the natively-installed GDC Windows guest).
+#
+# Invoked by the autounattend FirstLogonCommand after a clean Windows Server
+# 2022 install (native on GDC VM Runtime, so UEFI/ESP/virtio are correct by
+# construction). Promotes a BOREAS.LOCAL forest and seeds the polaris AD content
+# via a2_setup.ps1 (staged next to this script on the answer cdrom). The
+# promotion reboots, so the post-reboot phase (a2_setup) is registered as a
+# RunOnce so it fires automatically after the reboot under the auto-logon admin.
+#
+# Writes C:\polaris\BAKE_DONE when finished so the build harness knows to stop
+# the VM and export the golden boot disk.
+$ErrorActionPreference = "Stop"
+New-Item -ItemType Directory -Force -Path C:\polaris | Out-Null
+Start-Transcript -Path "C:\polaris\bake.log" -Append -Force
+Write-Host "=== polaris-dc bake $(Get-Date -Format o) ==="
+
+# Resolve this script's own directory (the answer cdrom) so we can copy the
+# post-reboot script + a2_setup.ps1 to local disk (the cdrom letter can change
+# across the reboot; local C: is stable).
+$src = Split-Path -Parent $MyInvocation.MyCommand.Path
+Copy-Item (Join-Path $src "a2_setup.ps1") "C:\polaris\a2_setup.ps1" -Force
+
+$phase = "C:\polaris\phase.txt"
+$stage = if (Test-Path $phase) { Get-Content $phase -Raw } else { "promote" }
+
+if ($stage.Trim() -eq "promote") {
+    Set-Content -Path $phase -Value "seed" -Encoding ascii
+
+    # Install ALL virtio drivers into the (SATA-installed) OS so the exported
+    # golden image boots on the virtio bus that real ranges use (viostor for the
+    # boot disk, NetKVM for the NIC, etc.). Setup ran off a SATA disk to avoid
+    # needing viostor in WinPE (GDC headless VMs give no console to load it
+    # interactively); here, with Windows fully up, we bake the drivers in. Find
+    # the virtio-container-disk cdrom by a signature file rather than a drive
+    # letter (GDC attaches several agent cdroms, so letters are not stable).
+    $virtio = $null
+    foreach ($v in (Get-Volume | Where-Object { $_.DriveLetter })) {
+        $probe = ($v.DriveLetter + ":\viostor")
+        if (Test-Path $probe) { $virtio = ($v.DriveLetter + ":"); break }
+    }
+    if ($virtio) {
+        Write-Host "Installing virtio drivers from $virtio ..."
+        # pnputil adds every matching .inf to the driver store so the OS can bind
+        # them at boot regardless of bus. 2k22 subdir = Windows Server 2022.
+        Get-ChildItem -Path "$virtio\" -Recurse -Filter *.inf |
+            Where-Object { $_.FullName -match '2k22' -and $_.FullName -match 'amd64' } |
+            ForEach-Object {
+                Write-Host "  pnputil add-driver $($_.FullName)"
+                & pnputil.exe /add-driver $_.FullName /install 2>&1 | Out-Null
+            }
+    } else {
+        Write-Host "WARNING: virtio cdrom not found; golden image may not boot on virtio"
+    }
+
+    # Install OpenSSH server for operator access to the DC (optional but handy).
+    Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0 -ErrorAction SilentlyContinue | Out-Null
+    Set-Service -Name sshd -StartupType Automatic -ErrorAction SilentlyContinue
+
+    Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+
+    foreach ($feat in @("AD-Domain-Services", "DNS")) {
+        if (-not (Get-WindowsFeature -Name $feat).Installed) {
+            Install-WindowsFeature -Name $feat -IncludeManagementTools
+        }
+    }
+
+    # Register the post-reboot seed phase (this same script re-runs; phase=seed).
+    $runonce = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce"
+    Set-ItemProperty -Path $runonce -Name "PolarisBakeSeed" `
+        -Value ('powershell.exe -NoProfile -ExecutionPolicy Bypass -File "' + $MyInvocation.MyCommand.Path.Replace($src, "C:\polaris") + '"')
+    # Copy this script to C: so RunOnce can find it post-reboot.
+    Copy-Item $MyInvocation.MyCommand.Path "C:\polaris\bake.ps1" -Force
+    Set-ItemProperty -Path $runonce -Name "PolarisBakeSeed" `
+        -Value 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\polaris\bake.ps1"'
+
+    Import-Module ADDSDeployment
+    $dsrm = ConvertTo-SecureString "DsrmR3store!2026" -AsPlainText -Force
+    Write-Host "Install-ADDSForest BOREAS.LOCAL (reboots)..."
+    Install-ADDSForest `
+        -DomainName "boreas.local" -DomainNetbiosName "BOREAS" `
+        -ForestMode "WinThreshold" -DomainMode "WinThreshold" -InstallDns `
+        -DatabasePath "C:\Windows\NTDS" -LogPath "C:\Windows\NTDS" -SysvolPath "C:\Windows\SYSVOL" `
+        -SafeModeAdministratorPassword $dsrm -CreateDnsDelegation:$false `
+        -NoRebootOnCompletion:$false -Force:$true
+    Stop-Transcript
+    return
+}
+
+# phase == seed: AD DS is up after the promotion reboot; seed the content.
+Write-Host "=== polaris-dc bake seed phase $(Get-Date -Format o) ==="
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+$ok = $false
+for ($i = 0; $i -lt 60; $i++) {
+    try { Get-ADDomain -ErrorAction Stop | Out-Null; $ok = $true; break }
+    catch { Write-Host "waiting for AD DS ($i)..."; Start-Sleep -Seconds 10 }
+}
+if (-not $ok) { throw "AD DS did not come up after promotion" }
+
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\polaris\a2_setup.ps1" -DnsForwarder "8.8.8.8"
+if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) { throw "a2_setup failed: $LASTEXITCODE" }
+
+Set-Content -Path "C:\polaris\BAKE_DONE" -Value (Get-Date -Format o) -Encoding ascii
+Write-Host "=== polaris-dc bake complete; BAKE_DONE written ==="
+Stop-Transcript


### PR DESCRIPTION
## Summary

Enables building a Windows Server 2022 domain controller (BOREAS.LOCAL) that boots and installs **natively on GDC VM Runtime**, via the documented ISO-install path instead of exporting a GCE-tuned image (which cannot boot on GDC's KubeVirt/QEMU — different firmware and drivers).

This is the install/bake foundation for a fast, not-sysprepped golden qcow2 that ranges import and boot straight into a ready DC.

## Changes

**`engine/provisioner/_gdc_vm_disks.py` (+ tests)** — GDC-Windows VM enablement:
- Omit `cloudInit` for Windows guests (the GDC VM webhook forbids it).
- Boot Windows guests with **UEFI** firmware (GDC defaults to legacy SeaBIOS, which can't boot the UEFI/GPT Windows image → "No bootable device").
- **Disable Secure Boot** for Windows (GDC's OVMF has no Microsoft UEFI CA keys enrolled → the signed Windows bootloader is rejected with "Access Denied").
- Linux guests keep legacy BIOS + cloudInit unchanged.

**`gdc-vm-images/polaris-dc/`** — new build assets:
- `autounattend.xml`: fully-unattended WS2022 answer file, debugged against GDC's **headless** VMs — `International-Core-WinPE` for license/locale, install onto a **SATA** boot disk (so WinPE sees it without viostor), image-by-index, and **no empty `ProductKey`** (which otherwise aborts Setup with "cannot find the Microsoft Software License Terms").
- `bake.ps1`: post-install FirstLogon bake — installs virtio drivers (so the golden image boots on the virtio bus ranges use), enables OpenSSH, installs AD DS/DNS, promotes BOREAS.LOCAL, then (RunOnce) runs `a2_setup` to seed the polaris AD content and writes `BAKE_DONE`.

## Verified
Windows Server 2022 installs end-to-end on GDC (confirmed via the KubeVirt vnc/screenshot subresource): unattended install → OOBE auto-skip → auto-logon → AD DS install → BOREAS.LOCAL promotion.

## Not in this PR (follow-ups)
- Build orchestration (ISO repack, install-VM driver, golden-disk → qcow2 export) and **domain parameterization** so per-event DCs can use different domains (#1170 task).
- **Windows guest-agent install** — required for the DC's NIC to get its range-assigned IP on GDC (Windows has no cloud-init; the GDC guest agent applies `ipAddresses`). This is the remaining piece for a networked runtime DC.

Part of #1170.