### PR TITLE
added: gdc polaris-dc AD image packer build

### DIFF
--- a/.github/workflows/packer-gcp.yml
+++ b/.github/workflows/packer-gcp.yml
@@ -24,6 +24,7 @@ on:
           - windows
           - dc
           - polaris-vm
+          - polaris-dc
       environment:
         description: 'GCP environment to build in'
         required: true
@@ -128,7 +129,7 @@ jobs:
           # (no imported base image, so no source-image secret is required).
 
       - name: Generate WinRM bootstrap secret (Windows/DC only)
-        if: inputs.image_type == 'windows' || inputs.image_type == 'dc'
+        if: inputs.image_type == 'windows' || inputs.image_type == 'dc' || inputs.image_type == 'polaris-dc'
         run: |
           # Throwaway local-admin password for the build VM only; the VM is
           # sysprepped and discarded so it never reaches the published image.

--- a/changelog.d/+gdc-polaris-dc-image.added.md
+++ b/changelog.d/+gdc-polaris-dc-image.added.md
@@ -1,0 +1,1 @@
+Added a GCP Packer build for the `polaris-dc` (BOREAS.LOCAL) domain-controller image, salvaged from the GDC effort when Polaris moved to the GCE range-cell backend, so a GDC AD image can still be baked if needed in future.

--- a/shifter/packer/gcp/locals.pkr.hcl
+++ b/shifter/packer/gcp/locals.pkr.hcl
@@ -30,4 +30,31 @@ locals {
     netsh advfirewall firewall add rule name="WinRM-HTTPS-5986" protocol=TCP dir=in localport=5986 action=allow
     netsh advfirewall firewall delete rule name="WinRM-5985" protocol=TCP localport=5985
   EOT
+
+  # Variant for the polaris-dc (BOREAS.LOCAL) GDC image bake. Uses the built-in
+  # Administrator so the identity survives the AD promotion reboot as the domain
+  # Administrator; the polaris-dc builder disables the GCE account manager so it
+  # does not reset the password out from under packer's WinRM connection. This
+  # image is captured un-sysprepped on purpose (a promoted DC cannot be
+  # generalized), so the bootstrap identity is retained by design.
+  winrm_https_bootstrap_dc_ps1 = <<-EOT
+    $ErrorActionPreference = 'Stop'
+    # Use the built-in Administrator (net user is bulletproof vs Set-LocalUser on
+    # a possibly-disabled account) so the identity survives the promotion reboot
+    # as the domain Administrator.
+    net user Administrator '${var.winrm_bootstrap_password}' /active:yes
+
+    winrm quickconfig -quiet
+    winrm set winrm/config/service '@{AllowUnencrypted="false"}'
+    winrm set winrm/config/service/auth '@{Basic="false"}'
+
+    $cert = New-SelfSignedCertificate -DnsName ([System.Net.Dns]::GetHostName()) -CertStoreLocation Cert:\LocalMachine\My
+    $thumb = $cert.Thumbprint
+    Remove-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTPS"} -ErrorAction SilentlyContinue
+    New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTPS"} -ValueSet @{Hostname=([System.Net.Dns]::GetHostName());CertificateThumbprint=$thumb}
+    Remove-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address="*";Transport="HTTP"} -ErrorAction SilentlyContinue
+
+    netsh advfirewall firewall add rule name="WinRM-HTTPS-5986" protocol=TCP dir=in localport=5986 action=allow
+    netsh advfirewall firewall delete rule name="WinRM-5985" protocol=TCP localport=5985
+  EOT
 }

--- a/shifter/packer/gcp/polaris-dc.pkr.hcl
+++ b/shifter/packer/gcp/polaris-dc.pkr.hcl
@@ -1,0 +1,112 @@
+// POLARIS polaris-dc GDC image: a PRE-PROMOTED Windows Server 2022 BOREAS.LOCAL
+// domain controller with the polaris AD content baked in. Every range boots an
+// already-promoted DC (fast spin-up, no per-range promotion).
+//
+// This is captured UN-SYSPREPPED on purpose: GCESysprep cannot generalize a
+// promoted DC, and on GDC (no GCE metadata server) a sysprepped image hangs at
+// OOBE with no network. Un-sysprepped, the specialized image boots straight to
+// the DC. WinRM is bootstrapped on the built-in Administrator (locals.pkr.hcl
+// winrm_https_bootstrap_dc_ps1) so the connection survives the promotion reboot
+// (the built-in Administrator becomes the domain Administrator, same password).
+// virtio-win drivers are staged so the guest binds GDC's virtio NIC (the GCE
+// image ships gVNIC, not virtio-net — the cause of the DC having no network).
+source "googlecompute" "polaris-dc" {
+  project_id              = var.project_id
+  zone                    = var.zone
+  machine_type            = var.machine_type
+  source_image_family     = "windows-2022"
+  source_image_project_id = ["windows-cloud"]
+  disk_size               = 100
+
+  communicator   = "winrm"
+  winrm_username = "Administrator"
+  winrm_password = var.winrm_bootstrap_password
+  winrm_insecure = true
+  winrm_use_ssl  = true
+  winrm_use_ntlm = true
+  winrm_timeout  = "30m"
+
+  network               = var.network
+  subnetwork            = var.subnetwork
+  service_account_email = var.service_account_email
+  scopes                = ["https://www.googleapis.com/auth/cloud-platform"]
+
+  use_internal_ip  = var.use_internal_ip
+  omit_external_ip = var.use_internal_ip
+  use_iap          = var.use_internal_ip
+
+  metadata = {
+    windows-startup-script-ps1 = local.winrm_https_bootstrap_dc_ps1
+    // Stop the GCE guest agent from resetting the built-in Administrator
+    // password that the bootstrap sets (and that packer reconnects with after
+    // the promotion reboot). Without this the agent races the bootstrap and
+    // WinRM auth fails.
+    disable-account-manager = "true"
+  }
+
+  image_name        = "${var.image_prefix}-polaris-dc-{{timestamp}}"
+  image_family      = "${var.image_prefix}-polaris-dc"
+  image_description = "POLARIS polaris-dc: pre-promoted BOREAS.LOCAL DC with polaris AD content (GCE, un-sysprepped)"
+  image_labels = {
+    project    = "shifter"
+    managed-by = "packer"
+    image-type = "polaris-dc"
+  }
+}
+
+build {
+  sources = ["source.googlecompute.polaris-dc"]
+
+  // Base system configuration (RDP, firewall, WinRM) in the dc role.
+  provisioner "powershell" {
+    environment_vars = ["PACKER_ROLE=dc"]
+    script           = "../scripts/windows/base.ps1"
+  }
+
+  // OpenSSH (harmless; useful for operator access to the DC).
+  provisioner "powershell" {
+    elevated_user     = "Administrator"
+    elevated_password = var.winrm_bootstrap_password
+    environment_vars  = ["PACKER_ROLE=dc"]
+    script            = "../scripts/windows/services.ps1"
+  }
+
+  // Stage upstream virtio-win drivers so the guest binds GDC's virtio NIC.
+  provisioner "powershell" {
+    script = "scripts/polaris-dc/install-virtio.ps1"
+  }
+
+  // Stage the AD content seed for finalize.ps1 to run post-promotion.
+  provisioner "powershell" {
+    inline = ["New-Item -ItemType Directory -Force -Path C:\\polaris | Out-Null"]
+  }
+  provisioner "file" {
+    source      = "../../../scripts/polaris-aws-range/a2_setup.ps1"
+    destination = "C:\\polaris\\a2_setup.ps1"
+  }
+
+  // Install AD DS/DNS, set forwarder + firewall-off, rename to dc01, and
+  // Install-ADDSForest with the reboot deferred to the windows-restart below.
+  provisioner "powershell" {
+    script = "scripts/polaris-dc/promote-bake.ps1"
+  }
+
+  // Apply the deferred promotion reboot; packer reconnects over WinRM as the
+  // domain Administrator once the DC is back up.
+  provisioner "windows-restart" {
+    restart_timeout = "20m"
+  }
+
+  // Post-reboot: wait for AD DS, seed the polaris AD content (a2_setup.ps1).
+  // MUST BE LAST — a2_setup sets the CTF Administrator password.
+  provisioner "powershell" {
+    elevated_user     = "Administrator"
+    elevated_password = var.winrm_bootstrap_password
+    script            = "scripts/polaris-dc/finalize.ps1"
+  }
+
+  post-processor "manifest" {
+    output     = "polaris-dc-manifest.json"
+    strip_path = true
+  }
+}

--- a/shifter/packer/gcp/scripts/polaris-dc/finalize.ps1
+++ b/shifter/packer/gcp/scripts/polaris-dc/finalize.ps1
@@ -32,7 +32,7 @@ if (-not (Test-Path "C:\polaris\a2_setup.ps1")) {
 }
 Write-Host "Running a2_setup.ps1 (DNS forwarder $fwd)..."
 & powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\polaris\a2_setup.ps1" -DnsForwarder $fwd
-if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) {
+if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
     throw "a2_setup.ps1 failed with exit code $LASTEXITCODE"
 }
 

--- a/shifter/packer/gcp/scripts/polaris-dc/finalize.ps1
+++ b/shifter/packer/gcp/scripts/polaris-dc/finalize.ps1
@@ -1,0 +1,62 @@
+# POLARIS polaris-dc bake-time finalize (runs after the promotion reboot).
+#
+# The builder has rebooted as the BOREAS.LOCAL domain controller and packer has
+# reconnected over WinRM as the domain Administrator. Wait for AD DS to serve,
+# then run the AD content seed (a2_setup.ps1, staged at C:\polaris\a2_setup.ps1)
+# which creates the OUs/users/groups/SPNs/DCSync ACL/flags/shares and sets the
+# CTF Administrator password. This is the last provisioner before capture, so
+# a2_setup's Administrator-password change does not break any later WinRM step.
+$ErrorActionPreference = "Stop"
+Start-Transcript -Path "C:\polaris-finalize.log" -Append -Force
+Write-Host "=== polaris-dc finalize $(Get-Date -Format o) ==="
+
+# Firewall stays off on the DC (assert again post-reboot).
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+
+# Wait until AD Web Services / NTDS answer.
+$ok = $false
+for ($i = 0; $i -lt 60; $i++) {
+    try { Get-ADDomain -ErrorAction Stop | Out-Null; $ok = $true; break }
+    catch { Write-Host "waiting for AD DS ($i)..."; Start-Sleep -Seconds 10 }
+}
+if (-not $ok) { throw "AD DS did not become available after promotion" }
+Write-Host "AD DS is serving."
+
+$fwd = "8.8.8.8"
+if (Test-Path "C:\polaris-dns-forwarder.txt") {
+    $fwd = (Get-Content "C:\polaris-dns-forwarder.txt" -Raw).Trim()
+}
+
+if (-not (Test-Path "C:\polaris\a2_setup.ps1")) {
+    throw "C:\polaris\a2_setup.ps1 missing (file provisioner did not run)"
+}
+Write-Host "Running a2_setup.ps1 (DNS forwarder $fwd)..."
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File "C:\polaris\a2_setup.ps1" -DnsForwarder $fwd
+if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) {
+    throw "a2_setup.ps1 failed with exit code $LASTEXITCODE"
+}
+
+# GDC's OVMF boots with empty NVRAM (the exported image loses its UEFI boot
+# variables), so it does not know the "Windows Boot Manager" entry and falls
+# back to the removable-media path \EFI\Boot\bootx64.efi. GCE Windows only ships
+# \EFI\Microsoft\Boot\bootmgfw.efi, so OVMF loops on a boot entry that never
+# chains into Windows. Copy the Windows Boot Manager to the fallback path so the
+# firmware boots it. (bootmgfw.efi reads \EFI\Microsoft\Boot\BCD regardless of
+# where it is launched from, so no BCD change is needed.)
+Write-Host "Staging Windows bootloader at the UEFI fallback path..."
+mountvol S: /S
+try {
+    if (-not (Test-Path "S:\EFI\Microsoft\Boot\bootmgfw.efi")) {
+        throw "bootmgfw.efi not found on the ESP; cannot stage UEFI fallback"
+    }
+    New-Item -ItemType Directory -Path "S:\EFI\Boot" -Force | Out-Null
+    Copy-Item "S:\EFI\Microsoft\Boot\bootmgfw.efi" "S:\EFI\Boot\bootx64.efi" -Force
+    Write-Host "  copied bootmgfw.efi -> S:\EFI\Boot\bootx64.efi"
+    Get-ChildItem "S:\EFI\Boot" | ForEach-Object { Write-Host "   ESP fallback: $($_.Name) $($_.Length)" }
+}
+finally {
+    mountvol S: /D
+}
+
+Write-Host "=== polaris-dc finalize complete ==="
+Stop-Transcript

--- a/shifter/packer/gcp/scripts/polaris-dc/install-virtio.ps1
+++ b/shifter/packer/gcp/scripts/polaris-dc/install-virtio.ps1
@@ -1,0 +1,50 @@
+# Install the virtio-win paravirtualized drivers into the Windows driver store.
+#
+# GDC VM Runtime (KubeVirt/QEMU) presents the guest a virtio NIC (macvtap
+# binding) and virtio block devices. GCE Windows images ship Google's own
+# network stack (gVNIC), not the upstream virtio-net (NetKVM) driver, so on GDC
+# the guest comes up with no usable NIC and never gets a DHCP lease -- the root
+# cause of the polaris-dc having no network. Stage the upstream virtio-win
+# drivers so Windows binds them when the virtio devices appear on GDC.
+#
+# pnputil /add-driver /install adds the packages to the driver store now (on the
+# GCE builder the virtio devices are absent, so nothing is displaced); Windows
+# loads them when the matching device enumerates on the GDC host.
+$ErrorActionPreference = "Stop"
+Start-Transcript -Path "C:\install-virtio.log" -Append -Force
+Write-Host "=== install-virtio $(Get-Date -Format o) ==="
+
+$isoUrl = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso"
+$isoPath = "C:\virtio-win.iso"
+
+Write-Host "Downloading virtio-win.iso..."
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri $isoUrl -OutFile $isoPath -UseBasicParsing
+
+Write-Host "Mounting ISO..."
+$mount = Mount-DiskImage -ImagePath $isoPath -PassThru
+$drive = ($mount | Get-Volume).DriveLetter + ":"
+Write-Host "Mounted at $drive"
+
+# 2k22 = Windows Server 2022 driver subdir; amd64 architecture. Install the
+# network (NetKVM), block (viostor/vioscsi), balloon and serial (vioserial, used
+# by the guest agent) drivers.
+$os = "2k22"
+$arch = "amd64"
+$drivers = @("NetKVM", "viostor", "vioscsi", "Balloon", "vioserial", "qemupciserial")
+foreach ($drv in $drivers) {
+    $dir = "$drive\$drv\$os\$arch"
+    $inf = Get-ChildItem -Path $dir -Filter "*.inf" -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($null -ne $inf) {
+        Write-Host ("  pnputil add-driver " + $inf.FullName)
+        pnputil /add-driver $inf.FullName /install | Out-Null
+    }
+    else {
+        Write-Host ("  no inf for " + $drv + " under " + $dir + "; skipping")
+    }
+}
+
+Dismount-DiskImage -ImagePath $isoPath -ErrorAction SilentlyContinue
+Remove-Item $isoPath -Force -ErrorAction SilentlyContinue
+Write-Host "=== install-virtio complete ==="
+Stop-Transcript

--- a/shifter/packer/gcp/scripts/polaris-dc/promote-bake.ps1
+++ b/shifter/packer/gcp/scripts/polaris-dc/promote-bake.ps1
@@ -1,0 +1,64 @@
+# POLARIS polaris-dc bake-time promotion (GDC pre-promoted DC).
+#
+# Runs on the packer builder over WinRM. Installs AD DS + DNS, disables the
+# firewall (the CTF DC serves LDAP/Kerberos/SMB/GC to the range), sets the
+# BOREAS.LOCAL DNS forwarder, renames to dc01, and promotes a fresh forest with
+# -NoRebootOnCompletion so packer controls the reboot (a `windows-restart`
+# provisioner follows). After the reboot the builder comes back as the domain
+# controller; the WinRM reconnect authenticates as the domain Administrator
+# (same password as the built-in Administrator set in the DC WinRM bootstrap),
+# and finalize.ps1 seeds the AD content.
+#
+# Promotion is done at bake time (not first boot) so every range boots an
+# already-promoted DC - fast spin-up, no per-range 20-minute promotion. The
+# image is captured un-sysprepped because GCESysprep cannot generalize a
+# promoted domain controller (and on GDC there is no metadata server to answer
+# a sysprepped image's OOBE, which is why the earlier sysprepped build hung with
+# no network).
+[CmdletBinding()]
+param(
+    [string]$DsrmPassword = "DsrmR3store!2026",
+    [string]$DnsForwarder = "8.8.8.8"
+)
+$ErrorActionPreference = "Stop"
+Start-Transcript -Path "C:\polaris-promote-bake.log" -Append -Force
+Write-Host "=== polaris-dc promote-bake $(Get-Date -Format o) ==="
+
+# The DC serves AD to the whole range; the CTF design runs it firewall-off
+# (a2_setup assumes reachable LDAP/SMB/etc.).
+Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+
+foreach ($feat in @("AD-Domain-Services", "DNS")) {
+    if (-not (Get-WindowsFeature -Name $feat).Installed) {
+        Write-Host "  installing feature $feat"
+        Install-WindowsFeature -Name $feat -IncludeManagementTools
+    }
+}
+
+# Note: the Windows hostname is intentionally NOT renamed to dc01. Renaming
+# leaves a pending-rename that Install-ADDSForest refuses to run over (it needs
+# its own reboot first), and the hostname is cosmetic here: the range DNS
+# container (172.20.0.2) is authoritative for dc01.boreas.local -> the DC IP, so
+# participants resolve dc01 regardless of the DC's Windows computer name, and
+# Kerberos/LDAP key off the domain (boreas.local), not the host name.
+Import-Module ADDSDeployment
+$secureDsrm = ConvertTo-SecureString $DsrmPassword -AsPlainText -Force
+Write-Host "  Install-ADDSForest BOREAS.LOCAL (reboot deferred to packer)..."
+Install-ADDSForest `
+    -DomainName "boreas.local" `
+    -DomainNetbiosName "BOREAS" `
+    -ForestMode "WinThreshold" `
+    -DomainMode "WinThreshold" `
+    -InstallDns `
+    -DatabasePath "C:\Windows\NTDS" `
+    -LogPath "C:\Windows\NTDS" `
+    -SysvolPath "C:\Windows\SYSVOL" `
+    -SafeModeAdministratorPassword $secureDsrm `
+    -CreateDnsDelegation:$false `
+    -NoRebootOnCompletion:$true `
+    -Force:$true
+
+# Stash the forwarder for finalize.ps1 (runs post-reboot, once DNS is serving).
+Set-Content -Path "C:\polaris-dns-forwarder.txt" -Value $DnsForwarder -Encoding ascii
+Write-Host "=== promote-bake complete (packer will reboot next) ==="
+Stop-Transcript

--- a/shifter/packer/tests/test_packer_gcp.py
+++ b/shifter/packer/tests/test_packer_gcp.py
@@ -21,7 +21,7 @@ GCP_DIR = PACKER_DIR / "gcp"
 GCP_SCRIPTS_DIR = GCP_DIR / "scripts"
 
 # Image types that ship a GCE builder in this iteration.
-GCE_IMAGE_TYPES = ["ubuntu", "brokenbk", "kali", "windows", "dc", "polaris-vm"]
+GCE_IMAGE_TYPES = ["ubuntu", "brokenbk", "kali", "windows", "dc", "polaris-vm", "polaris-dc"]
 
 
 class TestGcpTemplateStructure:


### PR DESCRIPTION
## Summary

Salvages the one piece worth keeping from the GDC Polaris effort after Polaris moved to the GCE Compute Engine range-cell backend (#1342): the ability to bake the BOREAS.LOCAL Windows domain-controller (AD) image, in case a GDC AD image is needed in future. Adds the polaris-dc GCP Packer build (pre-promoted, un-sysprepped BOREAS.LOCAL DC) plus its bake scripts, the WinRM bootstrap local it uses, and the workflow/test wiring. The GDC range runtime is deliberately NOT carried over — the GCE range-cell path from #1342 remains the Polaris runtime; this is only the image-build capability.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Follow-up to #1342 (merged). Preserves the GDC AD image-build capability.

## ADR Impact

- ADR-021

## Changes

- Add shifter/packer/gcp/polaris-dc.pkr.hcl (pre-promoted, un-sysprepped BOREAS.LOCAL DC image) and scripts/polaris-dc/ bake helpers (finalize, install-virtio, promote-bake)
- Add the winrm_https_bootstrap_dc_ps1 local the polaris-dc build consumes
- Wire the polaris-dc image_type choice and its WinRM bootstrap secret into packer-gcp.yml
- Add polaris-dc to the GCE packer test matrix

## Test Plan

- [x] Packer structure tests pass (55) including polaris-dc
- [x] `packer validate` runs in CI
- [x] No application source touched; the GCE Polaris runtime is unchanged

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: #1342 <- shifter/packer/gcp/polaris-dc.pkr.hcl (GDC AD-image build capability salvaged from the GCE pivot)
- TESTS: #1342 <- shifter/packer/tests/test_packer_gcp.py (polaris-dc template structure + validate)

## Checklist

- [x] Code follows project coding standards
- [x] Changelog fragment added at `changelog.d/+gdc-polaris-dc-image.added.md`
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
