### PR TITLE
fix(scripts): symlink all local.auto.tfvars overlays in setup-worktree

### DIFF
--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -92,19 +92,19 @@ ensure_symlink \
     "shifter/engine/provisioner/.venv"
 
 # Gitignored Terraform deployment overlays. Keep per-account values in the
-# main checkout and symlink them into worktrees so local plans remain usable
-# without committing deployment-specific tfvars.
-for tfvars_overlay in \
-    "platform/terraform/environments/dev/portal/local.auto.tfvars" \
-    "platform/terraform/environments/dev/range/local.auto.tfvars" \
-    "platform/terraform/environments/prod/portal/local.auto.tfvars" \
-    "platform/terraform/environments/prod/range/local.auto.tfvars"
-do
-    ensure_symlink \
-        "$MAIN_REPO/$tfvars_overlay" \
-        "$WORKTREE_ROOT/$tfvars_overlay" \
-        "$tfvars_overlay"
-done
+# main checkout and symlink every local.auto.tfvars it has into this worktree
+# at the same relative path, so local plans remain usable without committing
+# deployment-specific tfvars. Discovered rather than hardcoded so new envs/
+# stacks (e.g. core, proof, gcp) are picked up automatically.
+if [[ -d "$MAIN_REPO/platform/terraform" ]]; then
+    while IFS= read -r -d '' tfvars_overlay; do
+        rel="${tfvars_overlay#"$MAIN_REPO/"}"
+        ensure_symlink \
+            "$tfvars_overlay" \
+            "$WORKTREE_ROOT/$rel" \
+            "$rel"
+    done < <(find "$MAIN_REPO/platform/terraform" -type f -name 'local.auto.tfvars' -print0)
+fi
 
 # Node modules (for stylelint, prettier, etc.)
 if [[ -f "$WORKTREE_ROOT/package.json" ]]; then


### PR DESCRIPTION
## Problem

`scripts/setup-worktree.sh` symlinked only a hardcoded set of four Terraform overlays (dev/prod × portal/range) from the main checkout into a worktree. Any other `local.auto.tfvars` — notably the core-root overlay (`environments/<env>/local.auto.tfvars`, which carries `budget_alert_email` for the `_core` stack), plus proof and gcp overlays — was silently missed, so `terraform plan` in a worktree fell back to the fail-loud committed baseline.

## Change

Discover every `local.auto.tfvars` under the main checkout's `platform/terraform` tree and symlink each at its relative path, instead of maintaining a hardcoded list. New envs/stacks are picked up automatically. Still idempotent via the existing `ensure_symlink` helper (valid/broken/wrong-target/real-file all handled).

## Verification

- `bash -n` clean; pre-commit `shellcheck` **Passed**.
- Dry-run of the discovery loop against the main checkout lists all overlays including the newly-covered `environments/dev/local.auto.tfvars` (core).

Follows the same pattern as the `.env` / venv symlinks already in the script.