### PR TITLE
docs(deploy): point the dev-overlay note at sync-deploy-secrets.sh

### DIFF
--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -451,9 +451,10 @@ guacamole_autoscaling_cpu_target   = 60
 > **Keep the dev overlay minimal unless an event needs it.**
 > `TF_VARS_DEV_PORTAL` is the *only* place the running dev fleet size is set:
 > the committed `terraform.tfvars` is a fail-loud baseline that this secret
-> always overrides, and no script derives or reconciles these values; edit the
-> secret by hand (`gh secret set TF_VARS_DEV_PORTAL < payload.tfvars`). The
-> overlay above is *event-sized*. Left in place between events it makes every
+> always overrides. Nothing reconciles it automatically; edit your local
+> overlay and push it with `scripts/sync-deploy-secrets.sh` (see [Populating
+> and syncing the secrets](#populating-and-syncing-the-secrets)). The overlay
+> above is *event-sized*. Left in place between events it makes every
 > deploy run a full multi-instance ASG instance refresh (desired + warm pool ≈
 > a dozen instances, roughly an hour) and holds prod-class RDS/Redis/Guacamole
 > capacity. For ordinary dev, keep the ASG at a single instance with a minimal


### PR DESCRIPTION
Coherence fix. #1367 added a note stating "no script ... edit the secret by hand (`gh secret set ...`)"; #1380 then added `scripts/sync-deploy-secrets.sh` and a *Populating and syncing the secrets* section. Merged together on `dev` they contradict. Update the note to point at the script and that section. Doc-only; Vale clean.