### PR TITLE
fix(cms): scope reconciler row lock to self (Postgres outer-join FOR UPDATE)

### DIFF
--- a/changelog.d/1395.fixed.md
+++ b/changelog.d/1395.fixed.md
@@ -1,0 +1,1 @@
+Fix `reconcile_range_events` crash-looping on PostgreSQL with `NotSupportedError: FOR UPDATE cannot be applied to the nullable side of an outer join`. The stale-instance query `select_related("request")`-joins a nullable FK and then locks rows; scope the lock to the base table with `select_for_update(of=("self",))` so range-event reconciliation stays running.

--- a/shifter/shifter_platform/cms/management/commands/reconcile_range_events.py
+++ b/shifter/shifter_platform/cms/management/commands/reconcile_range_events.py
@@ -24,12 +24,13 @@ import logging
 import tempfile
 import time
 from argparse import ArgumentParser
-from datetime import timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import transaction
+from django.db.models import QuerySet
 from django.utils import timezone
 
 from cms.handlers.range_events import apply_range_status
@@ -195,6 +196,25 @@ def _apply_locked_range_instance(
     return outcome
 
 
+def stale_range_instances_queryset(cutoff: datetime, batch_size: int) -> QuerySet[RangeInstance]:
+    """Locked queryset of stale, non-terminal, live RangeInstance rows.
+
+    ``of=("self",)`` scopes ``FOR UPDATE`` to the ``RangeInstance`` base table:
+    ``select_related("request")`` LEFT-joins a nullable FK, and Postgres rejects
+    ``FOR UPDATE`` on the nullable side of an outer join (#1395). SQLite drops
+    row locking entirely, which is why this only surfaced against Postgres.
+    """
+    return (
+        RangeInstance.all_objects.filter(
+            deleted_at__isnull=True,
+            status__in=[s.value for s in ResourceStatus if s.value not in _TERMINAL_STATUS_VALUES],
+            updated_at__lt=cutoff,
+        )
+        .select_related("request")
+        .select_for_update(skip_locked=True, of=("self",))[:batch_size]
+    )
+
+
 def reconcile_range_instances(
     stale_seconds: int,
     batch_size: int,
@@ -220,15 +240,7 @@ def reconcile_range_instances(
     }
 
     with transaction.atomic():
-        stale_instances = list(
-            RangeInstance.all_objects.filter(
-                deleted_at__isnull=True,
-                status__in=[s.value for s in ResourceStatus if s.value not in _TERMINAL_STATUS_VALUES],
-                updated_at__lt=cutoff,
-            )
-            .select_related("request")
-            .select_for_update(skip_locked=True)[:batch_size]
-        )
+        stale_instances = list(stale_range_instances_queryset(cutoff, batch_size))
 
     for instance in stale_instances:
         request_id = instance.request.request_id if instance.request else None

--- a/shifter/shifter_platform/tests/cms/test_reconcile_range_events.py
+++ b/shifter/shifter_platform/tests/cms/test_reconcile_range_events.py
@@ -22,6 +22,7 @@ from django.utils import timezone
 from cms.handlers.range_events import apply_range_status, process_range_event
 from cms.management.commands.reconcile_range_events import (
     reconcile_range_instances,
+    stale_range_instances_queryset,
 )
 from cms.models import RangeInstance
 from cms.models import Request as CMSRequest
@@ -534,3 +535,18 @@ class TestReconcileHeartbeat:
 
         assert heartbeat_file.exists(), "heartbeat file must be written during loop iteration"
         assert call_count == 1
+
+
+class TestStaleRangeInstancesQueryset:
+    """#1395: the reconciler's locked query must scope FOR UPDATE to the base row."""
+
+    def test_locks_only_self_not_the_joined_nullable_request(self, db):
+        # select_related("request") LEFT-joins a nullable FK; a bare
+        # select_for_update raised NotSupportedError on Postgres ("FOR UPDATE
+        # cannot be applied to the nullable side of an outer join"). of=("self",)
+        # scopes the lock to cms_range so only the base row is locked.
+        qs = stale_range_instances_queryset(timezone.now(), 10)
+
+        assert qs.query.select_for_update is True
+        assert qs.query.select_for_update_skip_locked is True
+        assert qs.query.select_for_update_of == ("self",)


### PR DESCRIPTION
Closes #1395.

## Problem
`reconcile_range_events` built its stale-instance batch as `select_related("request").select_for_update(skip_locked=True)`. `RangeInstance.request` is a nullable FK, so `select_related` emits a LEFT OUTER JOIN and PostgreSQL rejects `FOR UPDATE` on the nullable side:

```
django.db.utils.NotSupportedError: FOR UPDATE cannot be applied to the nullable side of an outer join
```

That crash-looped `worker-reconciler`, so range-event reconciliation was down. SQLite silently drops row locking, which is why the existing (SQLite) tests never caught it.

## Fix
Scope the lock to the base table with `select_for_update(skip_locked=True, of=("self",))` — only `RangeInstance` rows are locked; the joined (nullable) `request` is not. Extracted the query into `stale_range_instances_queryset` for testability.

## Test
Added an ORM-level regression test asserting the query locks only `self` (`select_for_update_of == ("self",)`), which runs in the normal (SQLite) suite. A behavioral Postgres reproduction would require hoisting the dir-scoped `django_db_setup` postgres override to a shared conftest (the redirect currently only covers `tests/ctf/test_services/`); left out of scope.

## Verification
`pytest tests/cms/test_reconcile_range_events.py` → 20 passed.