### PR TITLE
fix: GCE range destroy tolerates a subnet with no CIDR

### DIFF
--- a/changelog.d/+gce-range-destroy-empty-cidr.fixed.md
+++ b/changelog.d/+gce-range-destroy-empty-cidr.fixed.md
@@ -1,0 +1,1 @@
+Fixed GCE range auto-cleanup failing when a provision errored before subnet-CIDR allocation. The destroy plan (`require_images=False`) now tolerates a subnet with an empty CIDR (subnets are deleted by resource name), instead of raising and leaving auto-cleanup unable to run.

--- a/shifter/engine/provisioner/gcp_range_cell_plan.py
+++ b/shifter/engine/provisioner/gcp_range_cell_plan.py
@@ -230,8 +230,16 @@ def _build_subnet_plans(
     config: GCERangeCellConfig,
     network_name: str,
     network_link: str,
+    require_images: bool,
 ) -> list[SubnetPlan]:
-    """Render deterministic subnetwork plans from range variables."""
+    """Render deterministic subnetwork plans from range variables.
+
+    Provision (``require_images=True``) needs a CIDR to create the subnet and
+    assign instance IPs. Destroy (``require_images=False``) deletes subnets by
+    resource name, so a subnet whose CIDR was never allocated (e.g. auto-cleanup
+    after a provision that failed before CIDR allocation) is tolerated with an
+    empty CIDR rather than raising.
+    """
     range_id = int(str(variables["range_id"]))
     subnets = _resource_dicts(variables.get("subnets"))
     subnet_by_name = {str(subnet.get("name", "")): subnet for subnet in subnets}
@@ -240,8 +248,10 @@ def _build_subnet_plans(
         subnet_name = str(subnet.get("name", "")).strip()
         subnet_uuid = str(subnet.get("uuid", "")).strip()
         subnet_cidr = str(subnet.get("cidr", "")).strip()
-        if not subnet_name or not subnet_uuid or not subnet_cidr:
-            raise RuntimeError(f"GCE range subnet requires name, uuid, and cidr: {subnet!r}")
+        if not subnet_name or not subnet_uuid:
+            raise RuntimeError(f"GCE range subnet requires name and uuid: {subnet!r}")
+        if require_images and not subnet_cidr:
+            raise RuntimeError(f"GCE range subnet requires a cidr to provision: {subnet!r}")
         instances = _resource_dicts(subnet.get("instances"))
         resource_name = _short_resource_name("shifter-r", range_id, subnet_name)
         plans.append(
@@ -256,7 +266,7 @@ def _build_subnet_plans(
                 "region": config.region,
                 "tag": _subnet_tag(range_id, subnet_name),
                 "connected_source_ranges": _connected_source_ranges(subnet, subnet_by_name),
-                "ip_assignments": _assign_instance_ips(subnet_cidr, instances),
+                "ip_assignments": _assign_instance_ips(subnet_cidr, instances) if subnet_cidr else {},
                 "instances": instances,
             }
         )
@@ -336,7 +346,9 @@ def _build_instance_plans(
                     "subnet_name": subnet_plan["name"],
                     "subnet_resource_name": subnet_plan["resource_name"],
                     "subnetwork_link": subnet_plan["self_link"],
-                    "private_ip": subnet_plan["ip_assignments"][key],
+                    # Destroy (no CIDR, empty ip_assignments) deletes by resource
+                    # name and needs no private IP; provision always has the key.
+                    "private_ip": subnet_plan["ip_assignments"].get(key, ""),
                     "role": role,
                     "os_type": os_type,
                     "asset_type": "gce_vm",
@@ -438,6 +450,7 @@ def render_range_cell_plan(
         config=resolved_config,
         network_name=network_name,
         network_link=network_link,
+        require_images=require_images,
     )
     instance_plans = _build_instance_plans(
         variables=variables,

--- a/shifter/engine/provisioner/tests/test_gcp_range_cells.py
+++ b/shifter/engine/provisioner/tests/test_gcp_range_cells.py
@@ -237,6 +237,15 @@ def test_render_plan_provision_requires_subnet_cidr():
         render_range_cell_plan("req-123", variables, _sample_config())
 
 
+def test_render_plan_requires_subnet_name_and_uuid():
+    # name/uuid identify the subnet for both provision and destroy, so they are
+    # required in either mode.
+    variables = _variables()
+    variables["subnets"][0]["uuid"] = ""
+    with pytest.raises(RuntimeError, match="requires name and uuid"):
+        render_range_cell_plan("req-123", variables, _sample_config(), require_images=False)
+
+
 def test_render_plan_translates_polaris_vm_to_docker_host_access():
     """A polaris-vm Docker host uses the host login user + management sshd port.
 

--- a/shifter/engine/provisioner/tests/test_gcp_range_cells.py
+++ b/shifter/engine/provisioner/tests/test_gcp_range_cells.py
@@ -217,6 +217,26 @@ def test_render_range_cell_plan_uses_vpc_per_range_and_deterministic_ips():
     }
 
 
+def test_render_plan_destroy_tolerates_missing_subnet_cidr():
+    # Auto-cleanup after a provision that failed before CIDR allocation renders
+    # the destroy plan with require_images=False; the subnet is deleted by
+    # resource name, so an empty CIDR must not raise.
+    variables = _variables()
+    variables["subnets"][0]["cidr"] = ""
+    plan = render_range_cell_plan("req-123", variables, _sample_config(), require_images=False)
+    subnet = plan["subnets"][0]
+    assert subnet["cidr"] == ""
+    assert subnet["ip_assignments"] == {}
+    assert subnet["resource_name"]
+
+
+def test_render_plan_provision_requires_subnet_cidr():
+    variables = _variables()
+    variables["subnets"][0]["cidr"] = ""
+    with pytest.raises(RuntimeError, match="requires a cidr"):
+        render_range_cell_plan("req-123", variables, _sample_config())
+
+
 def test_render_plan_translates_polaris_vm_to_docker_host_access():
     """A polaris-vm Docker host uses the host login user + management sshd port.
 


### PR DESCRIPTION
## Summary

Third fix in the live GCE range chain (no-defer). On a provision that fails before subnet-CIDR allocation, the auto-cleanup path rendered the destroy plan and raised `GCE range subnet requires name, uuid, and cidr` because the CIDR was empty — so auto-cleanup itself failed and logged "orphaned resources may exist."

## Fix

Destroy deletes subnets by resource name and needs no CIDR:
- `_build_subnet_plans` requires a CIDR only when provisioning (`require_images`); destroy tolerates an empty CIDR.
- `_build_instance_plans` reads the private IP with `.get(key, "")` so empty `ip_assignments` doesn't `KeyError`.

Provision behaviour is unchanged (CIDR still required; regression tests for both paths added).