### PR TITLE
fix: add -DnsForwarder param to a2_setup.ps1 (unblocks GCE/GDC DC pre-bake)

### DIFF
--- a/scripts/polaris-aws-range/a2_setup.ps1
+++ b/scripts/polaris-aws-range/a2_setup.ps1
@@ -8,7 +8,11 @@
 
 [CmdletBinding()]
 param(
-    [string]$AdminPassword = "CortexSavesTheDay!"
+    [string]$AdminPassword = "CortexSavesTheDay!",
+    # DNS forwarder for non-domain lookups. Defaults to the link-local AWS Route
+    # 53 Resolver (the AWS/SSM path relies on it); the GCE pre-bake passes the
+    # GCP internal resolver instead.
+    [string]$DnsForwarder = "169.254.169.253"
 )
 
 $ErrorActionPreference = "Stop"
@@ -40,9 +44,9 @@ for ($i = 0; $i -lt 60; $i++) {
 # the AMI was baked in). When a private SSM VPC endpoint exists in the
 # range VPC with PrivateDnsEnabled=true, the resolver returns the
 # endpoint's private IP automatically.
-Write-Host "Setting DNS forwarder to AWS VPC resolver (169.254.169.253)..."
+Write-Host "Setting DNS forwarder to $DnsForwarder..."
 try {
-    Set-DnsServerForwarder -IPAddress 169.254.169.253 -PassThru -ErrorAction Stop | Out-Null
+    Set-DnsServerForwarder -IPAddress $DnsForwarder -PassThru -ErrorAction Stop | Out-Null
     Write-Host "  forwarder set"
 } catch {
     Write-Host "  forwarder set FAILED: $($_.Exception.Message)"


### PR DESCRIPTION
The GCE `dc-prebaked` bake (and the GDC bake) failed after a **successful** `Install-ADDSForest`: `finalize.ps1` (GCE) and `bake.ps1` (GDC) both invoke `a2_setup.ps1 -DnsForwarder <addr>`, but `a2_setup.ps1` only declared `-AdminPassword` and hardcoded the AWS Route 53 Resolver, so both DC pre-bakes died with `NamedParameterNotFound`.

## Fix
Add an optional `-DnsForwarder` param to `a2_setup.ps1`, defaulting to the existing AWS resolver `169.254.169.253`, and use it in `Set-DnsServerForwarder`.

## AWS is unaffected (verified)
`a2_cold_bootstrap.sh` invokes the script via `run_powershell_file` (`-File C:\polaris-wrapper.ps1`), the scheduled task (`-File "$setupLocal"`), and the content splice — **none pass `-DnsForwarder` or a second positional arg**. So AWS falls through to the default, which equals the exact value it hardcoded before. The new param is optional and appended after `$AdminPassword`, so nothing positional shifts.

Fixes both non-AWS DC pre-bakes, which already called `-DnsForwarder` on the param-less script.