### PR TITLE
fix: bake the polaris compose stack into the GCE polaris-vm image

### DIFF
--- a/.github/workflows/packer-gcp.yml
+++ b/.github/workflows/packer-gcp.yml
@@ -109,6 +109,10 @@ jobs:
           GCP_PACKER_MACHINE_TYPE: ${{ vars.GCP_PACKER_MACHINE_TYPE || 'e2-standard-2' }}
           GCP_PACKER_USE_INTERNAL_IP: ${{ vars.GCP_PACKER_USE_INTERNAL_IP || 'false' }}
           GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          # GCS bucket holding the polaris compose-stack tarball (polaris-vm build
+          # only). host-setup.sh fetches gs://<bucket>/<POLARIS_STACK_KEY> and
+          # bakes the stack in; empty leaves the host range-ready without it.
+          GCP_POLARIS_STACK_BUCKET: ${{ vars.GCP_POLARIS_STACK_BUCKET }}
         run: |
           if [ -z "${GCP_PROJECT_ID}" ]; then
             echo "::error::Required secret GCP_PROJECT_ID is not set. See docs/dev/deploy-secrets.md."
@@ -129,6 +133,7 @@ jobs:
             echo "PKR_VAR_image_prefix=shifter"
             echo "PKR_VAR_machine_type=${GCP_PACKER_MACHINE_TYPE}"
             echo "PKR_VAR_use_internal_ip=${GCP_PACKER_USE_INTERNAL_IP}"
+            echo "PKR_VAR_polaris_stack_bucket=${GCP_POLARIS_STACK_BUCKET}"
           } >> "$GITHUB_ENV"
           # Kali has no public GCP image; the kali builder instead converts the
           # debian-12 GCE base into Kali Rolling in its first provisioning script

--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -90,6 +90,7 @@ above, plus the following:
 | `GCP_PACKER_MACHINE_TYPE` | variable | no | Builder machine type. Default `e2-standard-2`. |
 | `GCP_PACKER_USE_INTERNAL_IP` | variable | no | `true` builds without an external IP (requires IAP `35.235.240.0/20` to the builder). Default `false`. |
 | `GCP_GDC_VM_IMAGE_BUCKET` | variable | for export | GCS bucket the built image is exported into as a `gs://` qcow2 for the GDC VM Runtime (Terraform output `gdc_vm_image_bucket`). The export step fails loud if unset. See `docs/architecture/gcp-guest-images.md`. |
+| `GCP_POLARIS_STACK_BUCKET` | variable | polaris-vm | GCS bucket holding the Polaris compose-stack tarball (`<bucket>/polaris/stack/polaris-stack.tar.gz`). The `polaris-vm` build's `host-setup.sh` fetches it and `docker compose build`s the stack into the image; empty leaves the host range-ready without the stack baked. The packer builder SA needs `roles/storage.objectViewer` on the bucket. See "Baking the polaris-vm host image" in `docs/dev/gcp-range-cell-deploy.md`. |
 | `GCP_DEV_PROJECT_ID` | secret | for promote | Source (dev) project for `packer-gcp-promote.yml`; the prod project is the `prod` environment's `GCP_PROJECT_ID`. |
 
 Images are published to the image family `shifter-<type>` (the version pointer;
@@ -386,6 +387,7 @@ fall back to the code defaults in `config.py`. See
 | `RANGE_NETWORK_ZONE` | yes | Compute Engine zone for range guests, for example `us-central1-a`. |
 | `GCP_RANGE_LINUX_IMAGE` | yes | Full image or family URL for the Linux/host profile. For a Polaris deployment this is the `shifter-polaris-vm` family (the Docker host). |
 | `GCP_RANGE_DC_IMAGE` | yes | Windows domain-controller image, pre-promoted at bake time. Baked per-domain from `dc-prebaked.pkr.hcl` into family `shifter-<purpose>-dc` (see "Baking a new pre-promoted DC image" in `docs/dev/gcp-range-cell-deploy.md`). For Polaris this is `shifter-polaris-dc` (BOREAS.LOCAL). |
+| `DC_DOMAIN_PASSWORD` | DC scenarios | **Sensitive.** Domain Administrator password the provisioner sets on the pre-promoted DC (`set_admin_password`). Must match the password baked into the DC image by `a2_setup.ps1` at bake time (its `-AdminPassword` default). Provide via the GCP deploy config secret so it is rendered into the runtime env and forwarded to the provisioner job (`_GCP_PROVISIONER_ENV_KEYS`); if unset, DC setup fails setting the admin password. |
 | `GCP_RANGE_KALI_IMAGE` | scenario | Kali image for non-Polaris scenarios (Polaris runs Kali as a container inside the host). |
 | `GCP_RANGE_WINDOWS_IMAGE` | scenario | Generic Windows guest image for non-Polaris scenarios. |
 | `GCP_RANGE_HOST_SERVICE_ACCOUNT_EMAIL` | yes | Service account attached to range guests. Minimal scope: logging and monitoring write. |

--- a/docs/dev/gcp-range-cell-deploy.md
+++ b/docs/dev/gcp-range-cell-deploy.md
@@ -132,6 +132,44 @@ the image family `shifter-<purpose>-dc`). To add a DC for a new domain:
 The `polaris` profile reproduces the Polaris `shifter-polaris-dc`
 (`BOREAS.LOCAL`) image and is the default.
 
+## Baking the polaris-vm host image (compose stack)
+
+The Polaris range host (`shifter-polaris-vm`) is a Debian Docker host that boots
+the **prebaked** Polaris docker-compose stack (~17 containers including the
+participant `a14-kali`). Genuine dynamic realization is separate future work; for
+now the stack is baked into the image so time-to-serve is a range launch, not a
+full container build. `host-setup.sh` fetches the stack tarball from GCS at bake
+time and `docker compose build`s it in; the range bootstrap then only rewrites
+the DC IP into `docker-compose.override.yml` and `docker compose up`.
+
+The compose stack lives outside this repo (the AWS polaris-vm AMI is baked from
+the same external stack), so the GCE bake fetches it from GCS:
+
+1. **Get the stack tarball.** It is the assembled `scenario-dev/polaris/build/`
+   tree (a `docker-compose.yml` plus each service's local build context). It is
+   platform-neutral: every service is a local `docker build` (no registry/ECR or
+   cloud-specific references), so the GCS copy is the same content as the AWS S3
+   build tarball (`s3://shifter-polaris-bake-<env>-<acct>/polaris/build-*.tar.gz`).
+2. **Pack it for GCP's layout.** `host-setup.sh` extracts *into*
+   `.../scenario-dev/polaris/build` and expects `docker-compose.yml` at the
+   tarball root, so pack the *contents* of `build/` at the root
+   (`cd build && tar czf polaris-stack.tar.gz .`), not the `scenario-dev/...`
+   prefix the AWS tarball uses.
+3. **Upload** to `gs://<GCP_POLARIS_STACK_BUCKET>/polaris/stack/polaris-stack.tar.gz`
+   (the default `POLARIS_STACK_KEY`), and grant the packer builder SA
+   `roles/storage.objectViewer` on the bucket.
+4. **Set the `GCP_POLARIS_STACK_BUCKET` repository variable** to that bucket
+   (see `docs/dev/deploy-secrets.md`). The build exports it as
+   `PKR_VAR_polaris_stack_bucket`; empty leaves the host range-ready without the
+   stack baked.
+5. **Run the Packer GCE Image Build** workflow with `image_type=polaris-vm`. It
+   publishes image family `shifter-polaris-vm`, which `GCP_RANGE_LINUX_IMAGE`
+   points at.
+
+The DC's Administrator password baked by `a2_setup.ps1` must match
+`DC_DOMAIN_PASSWORD` in the deploy config (see `docs/dev/deploy-secrets.md`), so
+the provisioner's `set_admin_password` step succeeds against the prebaked DC.
+
 ## NGFW
 
 There is no GCE-native NGFW (Palo Alto VM-Series) path; that path exists only


### PR DESCRIPTION
The `polaris-vm` GCE image is a Docker host that must **bake in the polaris compose stack** (the ~17 containers incl. the participant Kali). `host-setup.sh` fetches `gs://<POLARIS_STACK_BUCKET>/<POLARIS_STACK_KEY>` and `docker compose build`s it — but the workflow never passed the bucket, so the stack was never baked and the range host came up empty.

Export `PKR_VAR_polaris_stack_bucket` from a new `GCP_POLARIS_STACK_BUCKET` repo variable (env-neutral; empty preserves the prior range-ready-without-stack behavior). The stack tarball is platform-neutral (every service is a local `docker build`, no ECR/registry/AWS refs), so the GCS copy is the same content as the AWS S3 build tarball.

This is the prebaked path (dynamic realization is separate future work): the range boots with the stack baked in, and the range bootstrap rewrites the DC IP + `docker compose up`.