### PR TITLE
docs: add SPA cohesive UX design foundation (IA, use cases, layout system)

### DIFF
--- a/docs/architecture/spa-cohesive-ux-preflight-1368.md
+++ b/docs/architecture/spa-cohesive-ux-preflight-1368.md
@@ -1,0 +1,248 @@
+# SPA Cohesive UX Preflight (#1368)
+
+Status: pre-implementation guidance
+
+Date: 2026-07-08
+
+Issue: GitHub #1368, "SPA Cutover -- cohesive UX: use cases, IA & wireframes (all surfaces)"
+
+Requirement: none. The GitHub issue title, body, acceptance criteria, and
+blocked implementation issues are the shipping contract.
+
+This note sets repo-wide design guardrails before the cohesive UX pass. It is
+not an implementation plan and does not implement the SPA, routes, APIs,
+components, or wireframes.
+
+## Scope Boundary
+
+#1368 owns a product design artifact: use cases, shared IA, global navigation,
+layout/pattern system, all-surface wireframes, major-departure rationale, and
+Risk Register alignment notes. It may revise the maintained IA/design artifacts
+when the UX pass validates a better model.
+
+It must build on these locked foundations:
+
+- ADR-013: one shared, role-aware platform navigation contract.
+- ADR-029: React 18, TypeScript, Vite, React Router v7, TanStack Query v5,
+  single Django origin, canonical `/api/v1/`, session plus CSRF for browser
+  calls, and no browser-held `shf_` API tokens.
+- The existing Tailwind v4 plus shadcn/ui frontend under
+  `shifter/shifter_platform/frontend/`.
+- The Apple-dark theme and Shifter chevron mark/favicons.
+- The SPA design-system and Risk Register foundation docs.
+
+No new ADR is needed for #1368 by itself. Update ADR docs only if the UX pass
+changes an enforceable guardrail: frontend stack, API boundary, auth posture,
+route-retirement policy, static asset policy, navigation source-of-truth rule,
+CI gates, import/layer rules, or a documented exception.
+
+## Architecture Decisions And Guardrails
+
+- Treat `docs/design/ux-003-information-architecture-sitemap.md` as the
+  maintained IA/taxonomy source. #1368 may update that artifact after validation,
+  but it must not create a competing sitemap, navigation vocabulary, or
+  per-surface taxonomy.
+- Expand the existing SPA shell concept, do not fork it. The Risk Register shell
+  in `frontend/src/components/app-shell.tsx` is a bounded first cut; the
+  cohesive design should define the shared platform shell contract that later
+  implementation issues extend centrally.
+- Navigation data belongs behind one shared platform boundary. A nav item must
+  keep the UX-003 minimum contract: `surface`, `audience`, `route_name`,
+  `permission_policy`, `owner_app`, and `purpose`. The cohesive pass may add
+  presentation fields such as group, icon key, route path, active-context
+  target, feature flag, and child/contextual entries, but those additions should
+  parameterize one contract rather than create app-local schemas.
+- Mode is not role. Participant/Organizer are UX modes; CTF participant,
+  CTF organizer, staff, superuser, Threat Research, and risk-register access
+  are authorization facts. Wireframes may hide or disable controls for clarity,
+  but every backend endpoint and service remains the authority.
+- UI status is not domain state. Design-system intents such as danger, warning,
+  info, success, and neutral render domain values; they do not define range,
+  event, challenge, scenario, risk, upload, Guacamole, or terminal state
+  machines.
+- Use-case catalog entries should name actor, job, current pain, authoritative
+  backend owner, and known API/readiness gaps. Do not invent new durable
+  workflow states when existing services, models, serializers, or context
+  processors already own them.
+- Wireframes must include operational states, not only happy paths: loading,
+  empty, filtered-empty, permission denied, validation error, backend error with
+  request id, stale/not found, long-running, degraded/offline, destructive
+  confirmation, read-only/deleted, and no-JavaScript where applicable.
+- Risk Register alignment notes are deltas from the current #1301/#1302 design.
+  Do not make Risk Register the visual template for every surface; use it as the
+  first validated module and adjust it when the all-surface system requires.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #1368 |
+| --- | --- | --- |
+| IA and taxonomy | ADR-013; `docs/design/ux-003-information-architecture-sitemap.md`; `docs/design/ux-003-oss-shifter-research-personas.md` | Update the maintained artifact if the cohesive pass changes IA. Do not add a second sitemap or module-local vocabulary. |
+| Visual system | `frontend/src/index.css`; `frontend/components.json`; `frontend/src/components/ui/*`; `frontend/src/components/logo.tsx`; `docs/design/spa-design-system-foundation-1299.md` | Use Tailwind v4, shadcn/ui, lucide icons, the existing Apple-dark token direction, and the Shifter mark. No new theme or logo. |
+| SPA architecture | ADR-029; `docs/architecture/spa-cutover-architecture-1300.md`; `frontend/src/router.tsx`; `frontend/src/api/client.ts`; `frontend/src/api/queryClient.ts`; `frontend/src/app/bootstrap-context.tsx` | One router, one query-cache policy, one typed fetch client, one generated OpenAPI type surface. Do not add per-surface clients or stores. |
+| Bootstrap and shell state | `shared/api/bootstrap.py`; `shared.context_processors.user_permissions`; `mission_control.context_processors.active_range`; `ctf.context_processors.ctf_navigation` | Shell metadata, modes, permission flags, and active range/event summaries should extend bootstrap serializers/generated types, not frontend-only constants. |
+| API mount and schema | `config/api_urls.py`; `/api/v1/schema/`; module API URL files under `risk_register/api`, `mission_control/api`, `ctf/api`, `cms/api` | Wireframes should be buildable against `/api/v1/`. App-local HTML routes and legacy JSON helpers are compatibility surfaces, not SPA data contracts. |
+| Auth and sessions | `config.views.platform_login`; `identity_platform_session`; `logout_view`; `config._drf_settings`; `shared.api_tokens.authentication` | Provider login remains server/provider-driven. Browser calls use session cookies plus `X-CSRFToken`; API tokens stay programmatic only. |
+| Authorization | `shared.auth`; `risk_register.access`; `risk_register.api.permissions`; `mission_control.api.permissions`; CTF access predicates and bridges; CMS authoring checks | Navigation visibility and disabled controls are advisory. Endpoint permission classes and service ownership checks remain decisive. |
+| Validation and schemas | DRF serializers; generated `frontend/src/api/schema.d.ts`; `shared.schemas`; `cms/scenarios/schema.py`; upload validators | Client affordances may pre-check form shape, but authoritative validation stays in serializers/domain schemas. Do not hand-copy DTOs or enums. |
+| Errors | `shared/api/errors.py`; `shared.errors`; `frontend/src/api/errors.ts`; `frontend/src/api/client.ts` | Use the shared error envelope and safe message classification. UI may show safe message plus request id, not raw exception text. |
+| Logging and audit | `config.middleware.RequestIDMiddleware`; `config/_logging_config.py`; `shared.log_sanitize`; `risk_register.services`; `shared.api_tokens.audit` | Preserve request-id correlation and redaction. The UX pass should not define a second audit/log vocabulary. |
+| Static SPA hosting | `shared/spa.py`; `risk_register/spa_views.py`; `templates/spa/risk_register.html`; `config/settings.py` staticfiles/WhiteNoise | Static assets are public build artifacts. No committed Vite output, no per-user bootstrap data in bundles, no second origin. |
+| Legacy coexistence | `risk_register/urls.py` rollout flag pattern; Django base templates and static CSS under `templates/**` and `static/css/**` | Design for phased takeover. Legacy page routes remain until module-specific issues retire them. |
+| Special flows | `mission_control/api/guacamole.py`; `mission_control/routing.py`; `config/asgi.py`; upload APIs; CTF file/invite/range APIs | Wireframes must reuse existing Guacamole, websocket, upload, download, invite, and long-running lifecycle boundaries instead of defining new transports. |
+| Quality gates | `frontend/package.json`; root `package.json`; `eslint.config.js`; `.stylelintrc.json`; `.importlinter`; `scripts/adr_guard/adr_guard.py` | Add or extend checks only through the existing gate surfaces. Do not weaken legacy JS/CSS/Python checks while adding SPA checks. |
+
+## Cross-Cutting Layers The Design Must Pass
+
+- Auth surface: login, Identity Platform session exchange, OIDC, dev-login, CTF
+  magic-link paths, and logout remain server/provider flows. SPA-owned
+  authenticated pages start after a Django session exists; unsafe API calls go
+  through `CsrfViewMiddleware` and DRF `SessionAuthentication` with
+  `X-CSRFToken`.
+- API-token surface: `ApiTokenAuthentication` remains fail-closed. A supplied
+  bad bearer token must not fall through to a logged-in browser session, and the
+  browser SPA must never store or send `shf_` tokens.
+- Domain authorization surface: CTF event membership, organizer rights,
+  challenge availability, CMS authoring rights, Mission Control ownership,
+  terminal/range ownership, risk-register group access, staff/admin gates, and
+  token scopes remain backend checks. The UX model may expose advisory
+  permission flags only.
+- Secret-handling surface: session cookies, CSRF tokens, bearer tokens, ID
+  tokens, invite tokens, upload tokens, presigned URLs, signed Guacamole URLs,
+  credentials, private hostnames, live cloud identifiers, challenge flags, and
+  provider payloads must not appear in wireframe fixtures, screenshots, static
+  bundles, localStorage, URLs, logs, error messages, test snapshots, GitHub
+  summaries, process argv, or schema examples.
+- Config/env surface: #1368 should not add environment bindings. If a later
+  implementation needs public runtime UI configuration, prefer the bootstrap
+  payload and documented serializers; secret or deployment-owned values must
+  stay out of Vite build-time variables.
+- Payload and query validation surface: generated TypeScript types come from
+  `/api/v1/schema/`; DRF serializers validate HTTP shapes; existing domain
+  schemas and services validate scenarios, uploads, credentials, range specs,
+  CTF workflows, and risk data. Do not split one business rule between the
+  client and backend.
+- Error-envelope surface: non-2xx API responses use the shared envelope
+  `{"error": {"code", "message", "details?", "request_id?"}}`. Wireframes
+  should include safe page, field, and toast/banner treatments without rendering
+  stack traces, SQL/provider errors, tokens, cookies, signed URLs, or raw audit
+  blobs.
+- WebSocket/special-transport surface: terminal, range status, and NGFW status
+  sockets remain Django Channels routes protected by `AllowedHostsOriginValidator`
+  and `AuthMiddlewareStack`. Do not introduce a second websocket auth scheme or
+  client-generated secret channel.
+- Static asset surface: Tailwind output, shadcn components, icons, images, and
+  Vite bundles are public cacheable assets served through Django staticfiles and
+  WhiteNoise. They must contain no per-user state, tenant data, live cloud IDs,
+  or secret-bearing URLs.
+- OS/runtime exposure surface: Node scripts, Playwright commands, management
+  commands, local demos, CI logs, and generated reports must not carry cookies,
+  bearer tokens, CSRF tokens, provider tokens, presigned URLs, or credentials in
+  argv or emitted artifacts.
+- Logging/observability surface: server logs stay ECS-formatted and sanitized;
+  request correlation flows through `X-Request-ID` / `RequestIDMiddleware`.
+  Browser diagnostics should be generic and secret-free.
+- Accessibility/i18n surface: AA accessibility is part of the wireframe
+  contract: semantic landmarks, skip link, keyboard paths, focus order, focus
+  traps, accessible names, form-error linkage, non-color-only status, reduced
+  motion, and contrast. Django template strings remain under ADR-016; SPA
+  strings need an explicit extraction/translation path before broad cutover.
+- Import/layer surface: frontend code stays outside the Python import graph.
+  Backend work implied by wireframes must respect ADR-001 and `.importlinter`:
+  apps call public service facades and shared contracts, not each other's models
+  or private modules.
+
+## Extensibility Seams
+
+- Navigation seam: centralize surface metadata and derive shell nav,
+  breadcrumbs, contextual subnav, mode switching, and route ownership from that
+  metadata. Required parameters are mode/audience, route, permission policy,
+  owner app, feature flag, active context, icon key, and children. Adding a new
+  surface should add one metadata entry, not edit every shell component.
+- Bootstrap seam: current principal, permission flags, feature flags, and active
+  range/event summaries should extend `BootstrapSerializer` and generated
+  `Bootstrap` types. Avoid build-time globals and client-only role heuristics.
+- Layout seam: wireframes should define reusable page templates and shell slots
+  for overview, list, detail, editor, terminal/workspace, admin table, and
+  destructive confirmation. Feature modules fill slots with domain data; they do
+  not invent new shells.
+- State-mapping seam: keep one mapping from domain statuses/severities to
+  design-system intents and accessible labels. The next status value should add
+  one mapping, not new badge components or color tokens.
+- API-readiness seam: keep a surface capability matrix that records canonical
+  API availability, serializer maturity, special transports, route ownership,
+  and known backend gaps. Per-surface implementation issues should consume that
+  matrix instead of rediscovering gaps.
+
+## Whole-Repo Scope
+
+The cohesive UX pass should evaluate these surfaces together:
+
+- Architecture/design docs: ADR-013, ADR-016, ADR-029,
+  `docs/design/ux-003-*`, `docs/design/spa-design-system-foundation-1299.md`,
+  `docs/design/spa-risk-register-workspace-1301.md`, and SPA preflight notes.
+- Frontend: `shifter/shifter_platform/frontend/package.json`,
+  `components.json`, `src/index.css`, `src/router.tsx`, `src/api/*`,
+  `src/app/*`, `src/components/*`, and `src/features/risk-register/*`.
+- Django shell/auth/config: `config/urls.py`, `config/api_urls.py`,
+  `config/settings.py`, `config/_drf_settings.py`, `config/views.py`,
+  `config/asgi.py`, `config/middleware.py`, and `shared/spa.py`.
+- Shared backend contracts: `shared/api/*`, `shared/api_tokens/*`,
+  `shared/auth.py`, `shared/context_processors.py`, `shared/errors.py`,
+  `shared/log_sanitize.py`, `shared/schemas/*`, `shared/db/*`, and
+  `shared/channels/*`.
+- Module surfaces: `mission_control/api/*`, `mission_control/routing.py`,
+  `mission_control/context_processors.py`, `ctf/api/*`, `ctf/views/api/*`,
+  `ctf/context_processors.py`, `cms/api/*`, `cms/scenario_editor/*`,
+  `risk_register/api/*`, `risk_register/urls.py`, and their services.
+- Legacy templates/static assets for migration evidence only:
+  `templates/**`, `static/css/**`, `static/js/**`.
+- Enforcement and workflow surfaces when checks change: `.importlinter`,
+  `scripts/check_layer_imports/layer_imports.yaml`,
+  `scripts/adr_guard/adr_guard.py`, `frontend/eslint.config.js`,
+  `.stylelintrc.json`, root/frontend package scripts, and
+  `.github/workflows/**`.
+
+## Gotchas And Anti-Patterns
+
+- Do not redesign the locked theme, Tailwind/shadcn foundation, logo, or favicon.
+- Do not build a marketing landing page as the product shell. The first
+  authenticated screen should be a usable operational dashboard/home.
+- Do not create separate nav constants, shell layouts, fetch clients, error
+  classes, DTOs, validation tables, status enums, or workflow state machines per
+  surface.
+- Do not treat Risk Register's first module shell as the final all-platform IA.
+- Do not collapse participant mode and organizer mode into one role list, or use
+  role names as user-facing modes.
+- Do not use "range", "event", "scenario", "challenge", "asset", "credential",
+  "risk", "mitigation", or "audit" interchangeably. UX copy should preserve
+  the taxonomy unless the maintained IA is updated.
+- Do not make client-side route guards, hidden links, or disabled buttons the
+  security boundary.
+- Do not call legacy Django form/action URLs or app-local JSON endpoints from
+  SPA data code.
+- Do not render user-entered risk text, challenge text, scenario YAML,
+  comments, audit JSON, provider messages, or upload metadata as HTML/Markdown
+  unless a sanitizer policy is explicitly accepted.
+- Do not store drafts, tokens, signed URLs, credentials, challenge flags, or
+  provider payloads in localStorage/sessionStorage to preserve flow state.
+- Do not auto-retry unsafe mutations or long-running destructive actions.
+- Do not weaken ADR guard, import-linter, Django i18n, collectstatic,
+  Stylelint, ESLint, Vitest, Playwright, or legacy Jest checks to land design or
+  SPA work.
+
+## Non-Goals
+
+- No implementation of SPA routes, app shell code, nav registry, APIs, backend
+  serializers, migrations, services, components, tests, feature flags, or route
+  cutovers in this preflight.
+- No retirement of Django template routes; each surface needs its own
+  implementation issue and route-retirement decision.
+- No replacement of Django sessions, OIDC, Identity Platform, CTF magic links,
+  CSRF, API-token auth, DRF permissions, or provider login/logout flows.
+- No new runtime secret delivery, cloud infrastructure, Terraform, Kubernetes,
+  workers, websocket auth scheme, or second origin/server.
+- No replacement of existing domain services, repositories, schemas,
+  validation, exception handling, audit stores, logging format, or persistence
+  policy.
+- No inclusion of MkDocs documentation-site redesign or the static privacy
+  notice; both are out of scope for #1368.

--- a/docs/architecture/spa-cohesive-ux-preflight-1368.md
+++ b/docs/architecture/spa-cohesive-ux-preflight-1368.md
@@ -213,9 +213,9 @@ The cohesive UX pass should evaluate these surfaces together:
 - Do not treat Risk Register's first module shell as the final all-platform IA.
 - Do not collapse participant mode and organizer mode into one role list, or use
   role names as user-facing modes.
-- Do not use "range", "event", "scenario", "challenge", "asset", "credential",
-  "risk", "mitigation", or "audit" interchangeably. UX copy should preserve
-  the taxonomy unless the maintained IA is updated.
+- Do not use the terms `range`, `event`, `scenario`, `challenge`, `asset`,
+  `credential`, `risk`, `mitigation`, or `audit` interchangeably. UX copy should
+  preserve the taxonomy unless the maintained IA is updated.
 - Do not make client-side route guards, hidden links, or disabled buttons the
   security boundary.
 - Do not call legacy Django form/action URLs or app-local JSON endpoints from

--- a/docs/design/spa-cohesive-ux-1368.md
+++ b/docs/design/spa-cohesive-ux-1368.md
@@ -1,0 +1,406 @@
+# SPA Cohesive UX: Use Cases, Layout System, and Rationale (#1368)
+
+Date: 2026-07-08
+
+Issue: #1368, "SPA Cutover -- cohesive UX: use cases, IA & wireframes (all surfaces)"
+
+Milestone: SPA Cutover, Phase 2
+
+Status: Design foundation for review
+
+Related artifacts:
+
+- `docs/design/ux-003-information-architecture-sitemap.md` (the maintained IA,
+  sitemap, navigation model, and taxonomy; updated by this pass per ADR-013).
+- `docs/design/ux-003-oss-shifter-research-personas.md` (personas and JTBD).
+- `docs/design/spa-design-system-foundation-1299.md` (the locked Apple-dark
+  Tailwind v4 plus shadcn/ui system).
+- `docs/design/spa-risk-register-workspace-1301.md` (the first built SPA module).
+- `docs/architecture/spa-cohesive-ux-preflight-1368.md` (binding guardrails).
+
+## Purpose and Scope
+
+This document is the design foundation for Phase 2 of the SPA cutover. It
+develops the use cases per surface, the shared layout and pattern system, the
+rationale for departures from today's experience, and the Risk Register
+alignment notes. The canonical information architecture, sitemap, navigation
+model, and taxonomy live in the maintained UX-003 artifact, which this pass
+updates rather than duplicates (ADR-013).
+
+This is a design artifact. It does not implement SPA routes, shell components, a
+navigation registry, feature flags, serializers, or wireframe fixtures. The
+maintainer scoped this issue to the design foundation. The real platform shell
+scaffolding is delivered by #1369, and the per-surface workspaces by #1370
+through #1374.
+
+In scope surfaces:
+
+- App shell, global navigation, home and dashboard, and the authentication
+  surfaces.
+- Mission Control (range operations, terminals, assets).
+- Scenario Editor (scenario authoring).
+- CTF (participant and organizer).
+- Admin (users, cost tracking, platform settings).
+- Risk Register (already built; included so it fits the cohesive system).
+
+Out of scope: the MkDocs documentation site and the static privacy notice, per
+the issue.
+
+## Method
+
+The information architecture was derived fresh from the personas and the current
+surfaces rather than adopted from the prior model, then compared against UX-003
+at the end. The derivation, the points where it confirms the prior model, and
+the points where it departs are recorded in the "Rationale" section below and
+folded into the maintained UX-003 artifact. The persona and JTBD anchors are the
+ones published in `ux-003-oss-shifter-research-personas.md`:
+`persona-panw-consultant-demo-operator`, `persona-conference-ctf-attendee`,
+`persona-internal-trainer`, `persona-oss-contributor-evaluator`, and
+`persona-self-hosting-oss-adopter`.
+
+## Modes, Not Roles
+
+Two operating frames emerge from the personas:
+
+- Participant mode: the bounded CTF and learning experience. Serves
+  `persona-conference-ctf-attendee`, plus the demo operator and trainer when
+  they take part.
+- Operator mode: the operational, authoring, governance, and administration
+  experience. Serves the demo operator, trainer, self-hoster, and contributor
+  evaluator.
+
+Mode is a user-facing frame. It is not an authorization fact. A user with access
+to both modes switches between them, which changes the navigation structure and
+the default landing page but never grants permission. CTF participant, CTF
+organizer, staff, superuser, Threat Research, and Risk Register access remain
+authorization facts enforced by the backend. The navigation may hide or disable
+controls for clarity, and every endpoint and service stays the authority. This
+follows ADR-013-R3 and ADR-013-R4.
+
+## Use-Case Catalog
+
+Each entry names the actor (a persona anchor), the job to be done, the current
+pain, the authoritative backend owner, and known API or readiness gaps that the
+per-surface implementation issues must close. Backend owners and API readiness
+are drawn from the current route and API modules; where an item needs
+verification, the implementing issue confirms the endpoint shape before
+building.
+
+### App Shell, Home, Dashboard, and Authentication
+
+Backend owners: `config.views` (`home`, `dashboard_router`, `platform_login`,
+`identity_platform_session`, `logout_view`, `dev_login`), `shared/api/bootstrap.py`
+(the SPA session bootstrap), `shared.auth`, and the provider auth stack (OIDC,
+Identity Platform, CTF magic links).
+
+| Actor | Job | Current pain | Backend owner | API and readiness gaps |
+| --- | --- | --- | --- | --- |
+| Demo operator | Land after login on a usable operational view, not a placeholder | Home is a public placeholder; the dashboard router only redirects | `config.views.dashboard_router`; `bootstrap` | No aggregate dashboard read; the home and dashboard need a summary payload (verify whether it extends bootstrap or adds a read endpoint in #1369) |
+| Any operator or participant | Sign in through the configured provider and land in the right mode | Login is a separate provider round trip; mode is implicit | `platform_login`; `identity_platform_session`; provider stack | Auth stays server and provider driven; the SPA starts after a Django session exists (no change needed here) |
+| Any authenticated user | See who I am, my current mode, and my active range or event context | Context is scattered across app headers | `bootstrap`; `mission_control.context_processors.active_range`; `ctf.context_processors.ctf_navigation` | Active range and event summaries should extend the bootstrap serializer and generated types (design seam; built in #1369) |
+| Any user hitting a surface they cannot access | Get a clear access-denied state, not a raw error | Access errors vary by surface | resource permission classes; `bootstrap` advisory flags | Reuse the Risk Register access-denied workspace state as the canonical pattern |
+
+### Mission Control
+
+Personas served: demo operator, trainer, self-hoster.
+
+Backend owner: the `mission_control` app, with a mature `/api/v1` surface
+(`mission_control/api/urls.py`): range lifecycle (launch, cancel, destroy,
+pause, resume), current range, agents, scenarios, uploads (initiate, complete,
+cancel), Guacamole RDP and SSH URL issuance, NGFW create, list, and destroy,
+and credential create and delete. Terminal and range status use Django Channels
+websockets (`mission_control/routing.py`).
+
+| Actor | Job | Current pain | Backend owner | API and readiness gaps |
+| --- | --- | --- | --- | --- |
+| Demo operator | Launch and monitor a range with one operational view of provisioning, health, credentials, terminal access, and cleanup | `pain-fragmented-operational-state`: range state crosses several pages | `mission_control` range and status views; active-range context processor | Range lifecycle and status APIs exist; confirm a single status read plus websocket for live updates in #1370 |
+| Demo operator | When something fails, see the next action clearly: retry, inspect, reset, deprovision, or escalate | Ambiguous states such as provisioning, available, running, and unhealthy carry no operator meaning | range lifecycle views | Map domain lifecycle states to design-system intents and accessible labels (state-mapping seam) |
+| Self-hoster | Read state labels that map to real infrastructure lifecycle without friendly copy hiding risk | Labels do not always match infrastructure reality | range services | Preserve backend state names in UX copy; no invented states |
+| Operator | Reach a terminal or remote desktop for a range instance | Terminal access is a separate surface | Guacamole URL views; websocket terminal | Guacamole URL issuance and websocket transport exist; the workspace layout hosts them (built in #1370) |
+| Operator | Manage assets: agents, NGFW instances, and reusable credentials | Assets are separate list pages with distinct patterns | agents, NGFW, credential views | APIs exist; unify under the list and detail patterns in this document |
+
+### Scenario Editor
+
+Personas served: trainer, contributor evaluator, demo operator.
+
+Backend owner: `cms.scenario_editor` and `cms.scenarios.schema`, with a `/api/v1`
+surface (`cms/api/urls.py`) that includes the catalog list and detail and YAML
+validation. Scenario create, edit, clone, export, and enable or staff-only
+toggles currently run through the Django page and action routes.
+
+| Actor | Job | Current pain | Backend owner | API and readiness gaps |
+| --- | --- | --- | --- | --- |
+| Trainer | Create or adapt a scenario and understand required machines, services, flags, credentials, and validation before launch | `pain-authoring-confidence`: readiness is not presented as one workflow | `cms.scenario_editor`; `cms.scenarios.schema` | Confirm scenario create, edit, clone, export, and toggle endpoints on `/api/v1` for #1371; today several are Django action routes (verify) |
+| Trainer or contributor | See YAML errors tied to the domain concept being edited, not raw parser output | Validation output is parser centric | YAML validation view; scenario schema | The validate-yaml endpoint exists; surface field-linked validation in the editor pattern |
+| Contributor evaluator | Move between the editor language and repository concepts | `pain-surface-vocabulary-drift` | scenario schema and taxonomy | Preserve the taxonomy in editor labels (UX-003) |
+| Trainer | Compare scenarios by difficulty, mode, estimated time, and required resources without opening each file | Metadata is not scannable | catalog list view | Confirm the catalog list returns the comparison fields for the list pattern |
+
+### CTF Participant
+
+Personas served: conference attendee, trainer, demo operator (as facilitators).
+
+Backend owner: the `ctf` app, with a broad `/api/v1` participant surface
+(`ctf/api/urls.py`): event detail, challenges and challenge detail, flag
+submission, hint use and listing, challenge rating, submissions, range status
+and access, and scoreboard. Navigation context comes from
+`ctf.context_processors.ctf_navigation`.
+
+| Actor | Job | Current pain | Backend owner | API and readiness gaps |
+| --- | --- | --- | --- | --- |
+| Conference attendee | Understand the event, team status, available challenges, scoring, and hints on arrival | `pain-mixed-skill-onboarding`: unclear progression punishes beginners | event, challenge, and scoreboard views | Participant reads exist; the dashboard and list patterns present calm progression and explicit next steps |
+| Conference attendee | Find a solvable challenge quickly and know what to do next | Challenge instructions, range connection, scoring, and flavor blur together | challenge detail and submission views | Separate instructions, hints, files, and submission into contextual tabs (detail pattern) |
+| Conference attendee | Access range resources and recover from failed attempts without hunting through admin surfaces | Range access lives away from the challenge | range status and access views | Present range access in participant context; avoid organizer surfaces |
+| Beginner participant | Distinguish platform problems from personal mistakes | A loud UI makes the event feel harder than the task | challenge and range views | Use the operational error state with a request id, and calm status presentation |
+
+### CTF Organizer
+
+Personas served: demo operator, trainer.
+
+Backend owner: the `ctf` app organizer `/api/v1` surface: event list, detail,
+and force-delete, challenge list and detail, participants list, import, and
+detail, ranges list and provisioning, brackets, scoreboard admin,
+notifications, invitations, flags, and challenge files.
+
+| Actor | Job | Current pain | Backend owner | API and readiness gaps |
+| --- | --- | --- | --- | --- |
+| Demo operator | Run a customer event and see which teams are blocked and whether ranges are healthy | `pain-fragmented-operational-state` across event, range, and participant pages | event, participant, and range views | Reads exist; the operator dashboard aggregates event health for #1372 |
+| Demo operator | Intervene before frustration spreads by seeing participant progress and blockers | Progress is spread across pages | participant and scoreboard views | Present participant progress in the detail and list patterns |
+| Trainer | Manage challenges, brackets, scoring, and communications for a cohort | Each is a separate admin flow | challenge, bracket, scoreboard, and notification views | Function-based `api_*` views exist; confirm shapes for #1372 |
+| Organizer | Perform destructive actions such as force-delete safely | Destructive actions are easy to confuse with routine edits | force-delete and delete views | Route destructive actions through the confirmation pattern |
+
+### Admin (Shifter Admin)
+
+Personas served: self-hoster, demo operator.
+
+Backend owner: the `management` app (user profiles, groups, and Cognito or
+Identity group sync) and Django admin (`/admin/`). Cost tracking has no portal
+surface today; the operational cost tooling lives outside the portal. This is
+the largest readiness gap in this pass.
+
+| Actor | Job | Current pain | Backend owner | API and readiness gaps |
+| --- | --- | --- | --- | --- |
+| Self-hoster | Manage users, groups, and access without dropping into Django admin | User administration is Django admin only | `management` app; Django admin | No `/api/v1` user administration surface exists; #1373 needs a management API, or it hosts Django admin behind the shell as an interim step (decide in #1373) |
+| Self-hoster | See platform cost and spend to support deployment decisions | No portal cost view exists | none in the portal | Cost tracking has no portal API; #1373 must define whether cost is surfaced and from where. Do not surface live cloud identifiers or secret-bearing data |
+| Self-hoster or operator | Change platform and account settings | Settings are per-surface today | `mission_control` settings and account menu | Consolidate account and platform settings under the shell account menu and an Administer settings surface |
+
+### Risk Register
+
+Personas served: self-hoster, contributor evaluator, demo operator.
+
+Backend owner: the `risk_register` app, with a mature DRF `/api/v1` surface
+(`risk_register/api/urls.py`): a risks ViewSet and an audit-log ViewSet, plus a
+session bootstrap. This is the first built SPA module (#1301 and #1302) and the
+reference implementation for the patterns in this document.
+
+| Actor | Job | Current pain | Backend owner | API and readiness gaps |
+| --- | --- | --- | --- | --- |
+| Self-hoster | Keep risks, exceptions, and mitigations visible enough to support deployment decisions | Governance state is easy to lose | risks and audit ViewSets | Mature; the alignment notes below adjust the module to the cohesive system |
+| Contributor evaluator | See security posture directly, not behind marketing language | Posture reads as marketing elsewhere | risks ViewSet | No gap; keep the direct, operational presentation |
+| Demo operator | Know ownership, status, and next review date for a risk that affects a demo or deployment | Review cadence is not always scannable | risks ViewSet | Present ownership and review date in the list and detail patterns |
+
+## Layout and Pattern System
+
+The layout system defines a small set of reusable page templates and the shell
+regions they fill. Feature modules fill slots with domain data; they do not
+invent new shells. Every template is expressed with the locked design system:
+Tailwind v4, shadcn/ui, lucide icons, the Apple-dark tokens, and the Shifter
+mark. No new visual language is introduced.
+
+### Shell Regions
+
+- Global top bar: the Shifter mark, the current mode with a mode switch when the
+  user has both, the active range or event context when relevant, the account
+  menu, and the theme toggle.
+- Primary side navigation: role-aware, grouped by the information architecture
+  for the current mode, rendered from the shared navigation contract.
+- Page header: the current object title, breadcrumbs on nested object pages, and
+  the primary actions.
+- Content area: the page template body.
+- Contextual subnavigation: tabs within a single entity.
+- Notification region: toasts and page-level banners.
+- Modal layer: bounded, reversible, or confirmatory actions only.
+
+### Page Templates
+
+| Template | Purpose | Primary surfaces | Key shadcn primitives |
+| --- | --- | --- | --- |
+| Dashboard or Overview | Role-aware landing with scannable status, primary actions, and recent activity | Home, Operate overview, CTF participant and organizer home | Card, Badge, Skeleton |
+| List | Index with filters, table or cards, row and bulk actions, and pagination | Risks, Scenarios, Events, Ranges, Participants, Challenges, Credentials, NGFW, Agents, Users | Table, Input, Select, Badge, Button |
+| Detail | Entity header plus contextual tabs and panels | Risk, Event, Challenge, Range, Scenario, Participant | Tabs, Card, Badge, Alert |
+| Editor | Create and edit forms, including structured YAML editing, with field-linked validation | Risk form, Scenario create, edit, and YAML, Event and Challenge create and edit | Input, Textarea, Label, Select, Alert, Dialog |
+| Workspace | Full-height interactive surface with minimal chrome | Terminal and Guacamole, range console | full-bleed content region |
+| Admin table | Dense management tables | Users, cost | Table, Badge, Button |
+| Destructive confirmation | Confirm delete, deprovision, force-delete, or revoke | all surfaces with destructive actions | AlertDialog |
+
+### Required States Per Template
+
+Every template must define these states, not only the happy path:
+
+- Loading: a skeleton that matches the eventual layout.
+- Empty: no data yet, with a primary call to action.
+- Filtered-empty: no matches, with a clear-filters affordance.
+- Permission denied: the advisory access-denied workspace state; the API stays
+  the authority and returns the real status.
+- Validation error: field-linked, tied to the domain concept.
+- Backend error: the safe message plus the request id from the shared error
+  envelope; no stack traces, provider errors, tokens, or signed URLs.
+- Stale or not found: a recoverable not-found state.
+- Long-running: an in-progress state that disables re-submission and does not
+  auto-retry unsafe mutations.
+- Degraded or offline: a reduced state when a dependency is unavailable.
+- Read-only or deleted: a non-editable state for closed or soft-deleted records.
+
+### Accessibility (AA) Built In
+
+Accessibility is part of the pattern contract, not a later pass. Every template
+carries: semantic landmarks (banner, navigation, main), a skip link, keyboard
+paths and a sensible focus order, focus management on route change and on modal
+open and close (including a focus trap), accessible names, form-error linkage
+through described-by relationships, status that is not conveyed by color alone
+(icon plus text plus color), reduced-motion support, and token contrast that
+already meets AA from the design-system foundation. SPA strings need an
+extraction and translation path before broad cutover, consistent with ADR-016.
+
+### Domain Status to Intent Mapping
+
+One mapping translates domain values to design-system intents and accessible
+labels. Intents render domain state; they do not define the state machine. The
+next status value adds one mapping entry, not a new badge component or color
+token.
+
+| Domain value | Intent | Note |
+| --- | --- | --- |
+| Risk severity: critical, high, medium, low | danger, warning, neutral, neutral | Risk Register already applies this mapping |
+| Range or provisioning: provisioning, available or running, unhealthy or failed, deprovisioning | pending, success, danger, warning | Operator meaning must be explicit |
+| Event: draft, active, ended | neutral, success, muted | |
+| Challenge: locked, available, solved | muted, neutral, success | |
+| Upload or validation: uploading, valid, invalid | pending, success, danger | |
+
+## Navigation UX Rendered From the Shared Contract
+
+The canonical sitemap, navigation model, and taxonomy live in UX-003. This
+section describes only how the shared navigation contract renders across the
+shell, so the implementing issues have a consistent target.
+
+- Participant mode shows the Participate primary navigation: Event Home,
+  Challenges, Range, Scoreboard, Team, and Help.
+- Operator mode shows a role-aware landing (Home) and the operator groups:
+  Operate, Author, Govern, and Administer.
+- The top bar carries product identity, the current mode and mode switch, the
+  active range or event context, and the account menu. It does not duplicate the
+  side navigation.
+- Breadcrumbs appear on nested object pages, not on dashboards or list pages.
+- Contextual tabs appear within a single entity: event tabs, challenge tabs,
+  range tabs, scenario tabs, and risk tabs.
+
+Each navigation entry carries the UX-003 minimum contract (surface, audience,
+route name, permission policy, owner app, and purpose) plus the presentation
+fields this pass adds (group, icon key, route path, active context, feature
+flag, and children). This parameterizes one contract. Adding a surface adds one
+entry rather than editing every shell component. The centralized contract is
+built in #1369; the per-surface issues register their entries into it.
+
+## Rationale for Departures From Today's UX
+
+The fresh derivation from personas and surfaces confirmed several prior instincts
+and departed on a few. Recording both is the point of the exercise.
+
+Confirmed by the fresh derivation:
+
+- The Participant and Operator mode split. Both the attendee persona and the
+  operational personas need distinct frames, and the frames must stay
+  structurally distinct (ADR-013-R4).
+- The operator groupings Operate, Author, and Govern. The operational,
+  authoring, and governance jobs cluster cleanly and map to code ownership,
+  which serves `pain-surface-vocabulary-drift`.
+
+Departures from the prior Django-era model:
+
+- Administer is promoted to a first-class operator surface for users, cost
+  tracking, and platform settings. The prior model folded platform
+  administration into Django admin. The self-hoster persona needs deployment and
+  administration visibility as a product surface, not a framework escape hatch.
+- The first authenticated screen is a role-aware operational dashboard, not a
+  public placeholder. The demo operator persona needs range and event health on
+  landing.
+- The mode switch is explicit in the shell. Users with both accesses move
+  between modes without a permission change.
+- Learn and Docs are deferred from the SPA navigation for this cutover. The
+  documentation site remains a platform surface and stays out of scope per the
+  issue; the maintained IA records it as a surface, not as SPA navigation yet.
+
+Alternatives considered and set aside:
+
+- A single flat navigation with every surface at the top level. Rejected: it
+  produces more than ten top-level items, erases the mode distinction, and works
+  against `pain-fragmented-operational-state`.
+- A purely task-oriented navigation that cuts across surfaces by verb. Rejected:
+  it breaks the alignment between surface names and code ownership that
+  contributors and self-hosters rely on.
+- Merging Operate and Administer. Rejected: the audiences and cadence differ.
+  Administration is lower-frequency, platform-lifecycle work.
+
+## Risk Register Alignment Notes
+
+The Risk Register is the first validated module and the reference for these
+patterns. It is not the visual template for every surface. The cohesive system
+implies these deltas from the current #1301 and #1302 design; each is a change
+for the Risk Register alignment issue (#1374), not for this pass.
+
+- The current shell (`frontend/src/components/app-shell.tsx`) hardcodes one
+  navigation group (Govern, with a single Risks entry). Generalize it to the
+  shared, metadata-driven, role-aware navigation contract. The Risk Register
+  becomes one registered surface under Govern.
+- The current root layout gates the whole workspace on
+  `can_access_risk_register`. Generalize gating to a per-surface permission
+  policy read from the bootstrap payload, with the backend remaining the
+  authority.
+- The router mounts under the `/risk-register` basename. The platform mount and
+  route ownership are decided in #1369; the Risk Register route becomes a child
+  of the platform router.
+- Keep the Risk Register access-denied workspace state as the canonical
+  permission-denied pattern for all surfaces.
+- Revisit breadcrumbs on the risk detail page so nested-object breadcrumbs match
+  the shell convention.
+
+## API-Readiness and Capability Matrix
+
+The per-surface implementation issues consume this matrix instead of
+rediscovering gaps. Readiness reflects the current API modules; items marked
+"verify" require the implementing issue to confirm the endpoint shape before
+building.
+
+| Surface | Canonical `/api/v1` | Style | Special transport | Largest gap |
+| --- | --- | --- | --- | --- |
+| App shell, home, auth | bootstrap read | DRF APIView | none | No aggregate dashboard read; active-context summaries not yet in bootstrap |
+| Mission Control | range lifecycle, agents, scenarios, uploads, Guacamole URLs, NGFW, credentials | DRF APIView | Guacamole, terminal and status websockets | Confirm a single range status read for the operational view |
+| Scenario Editor | catalog list and detail, YAML validate | DRF APIView | none | Scenario create, edit, clone, export, and toggle may still be Django action routes (verify) |
+| CTF participant | event, challenges, submit, hints, submissions, range status and access, scoreboard | function-based `api_*` | range websockets | Broad but function-based; confirm shapes and pagination |
+| CTF organizer | events, participants, ranges, brackets, scoreboard, notifications, invitations, flags, files | function-based `api_*` | none | Aggregate event-health read for the organizer dashboard |
+| Admin | none for users or cost | none | none | No user-administration API and no portal cost API; #1373 defines the surface |
+| Risk Register | risks and audit ViewSets | DRF ViewSet | none | None; alignment only |
+
+## Acceptance-Criteria Mapping
+
+The issue lists wireframes as a deliverable. The maintainer replaced static
+wireframes with real SPA scaffolding as the medium, delivered in #1369 through
+#1374, and scoped this issue to the design foundation. The acceptance criteria
+map to this pass as follows.
+
+| Issue acceptance criterion | Satisfied by |
+| --- | --- |
+| Cover all in-scope surfaces with one coherent IA, navigation, and layout language | The use-case catalog covers every in-scope surface; the layout and pattern system and the UX-003 navigation model give one coherent language |
+| Use the locked Apple-dark design system and logo, with no new visual language | The layout and pattern system is expressed with the existing tokens, shadcn/ui, lucide, and the Shifter mark; the "locked foundation" is not restyled |
+| Accessibility (AA) designed in, not deferred | The "Accessibility (AA) Built In" section makes AA part of the pattern contract |
+| The per-surface implementation issues can build directly against this design | The shared navigation contract, the layout slots, the state-mapping seam, and the API-readiness matrix are the direct build target for #1369 through #1374 |
+
+## Handoff to Implementation Issues
+
+- #1369 (App shell and global navigation) builds the centralized navigation
+  contract, the shell regions, the home and dashboard, the auth-adjacent
+  surfaces, and the routing and mount pattern behind a rollout flag, with the
+  legacy path preserved.
+- #1370 (Mission Control), #1371 (Scenario Editor), #1372 (CTF), and #1373
+  (Admin) fill the layout slots for their surfaces and register their navigation
+  entries. Each reads the capability matrix for its known gaps.
+- #1374 aligns the Risk Register to the cohesive system per the alignment notes.

--- a/docs/design/ux-003-information-architecture-sitemap.md
+++ b/docs/design/ux-003-information-architecture-sitemap.md
@@ -254,6 +254,10 @@ Shifter
 |   |-- Risk Register
 |   |-- Risk Detail
 |   `-- Audit / Review Queues
+|-- Administer
+|   |-- Users
+|   |-- Cost
+|   `-- Platform Settings
 `-- Learn
     |-- Role Start
     |   |-- Participant
@@ -310,7 +314,8 @@ Primary navigation:
 1. Operate
 2. Author
 3. Govern
-4. Learn
+4. Administer
+5. Learn
 
 Operate navigation:
 
@@ -336,6 +341,12 @@ Govern navigation:
 - Risks
 - Exceptions and Mitigations
 - Review Dates
+
+Administer navigation:
+
+- Users
+- Cost
+- Platform Settings
 
 Learn navigation:
 
@@ -411,6 +422,21 @@ owner_app
 purpose
 ```
 
+The SPA cohesive pass (#1368) extends this one contract with presentation
+fields so the shared shell can render navigation, breadcrumbs, contextual
+subnavigation, and mode switching from the same metadata. These additions
+parameterize the single contract; they do not create app-local schemas:
+
+```text
+mode              # participant or operator
+group             # Operate, Author, Govern, Administer, or Participate
+route_path        # SPA path
+icon_key          # lucide icon name
+active_context    # optional: range or event the surface reads or sets
+feature_flag      # optional rollout flag
+children          # optional nested or contextual entries
+```
+
 ### Top Navigation
 
 Use top navigation for platform-level context, not for every app:
@@ -484,6 +510,8 @@ Use one canonical name per concept.
 | Event | A time-bound CTF or training delivery with participants, teams, challenges, scoring, and communication. | Mission, course, campaign. |
 | Participant | A learner or competitor taking part in an event. | User when event membership matters. |
 | Organizer | A facilitator, trainer, operator, or staff user managing event or platform operations. | Admin except for Django admin. |
+| Administer | The operator surface for platform administration: users, cost, and platform settings. | Admin except when referring to Django admin. |
+| Cost | Platform spend and cost tracking surfaced under Administer. | Billing unless the billing system is specifically meant. |
 | Team | A participant grouping inside an event. | Bracket, cohort. |
 | Bracket | A scoring or grouping partition inside an event. | Team. |
 | Challenge | A CTF task solved by a participant or team for points. | Scenario, mission. |
@@ -505,6 +533,31 @@ Use one canonical name per concept.
 | Guide | Task-oriented documentation. | Reference. |
 | Reference | Stable factual documentation for APIs, architecture, or concepts. | Guide. |
 | Walkthrough | Step-by-step event or scenario assistance. | Hint, guide. |
+
+## SPA-Era Cohesive Update (#1368)
+
+The SPA cutover Phase 2 cohesive UX pass (#1368) re-derived the information
+architecture fresh from the personas and the current surfaces, then compared the
+result against this artifact. The companion design doc
+`docs/design/spa-cohesive-ux-1368.md` holds the use-case catalog, the layout and
+pattern system, the rationale, and the Risk Register alignment notes. This
+artifact remains the single maintained IA, sitemap, navigation model, and
+taxonomy source (ADR-013). The shared navigation contract is implemented
+centrally in #1369; the per-surface issues (#1370 through #1374) register their
+entries into it.
+
+The fresh derivation confirmed the participant and operator mode split and the
+Operate, Author, and Govern operator groupings. It departed from the prior
+Django-era model in these ways, which are now folded into the sections above:
+
+- Administer is a first-class operator surface for users, cost, and platform
+  settings, rather than only Django admin.
+- The first authenticated screen is a role-aware operational dashboard, not a
+  public placeholder.
+- The mode switch is explicit in the shell.
+- Learn and Docs are deferred from the SPA navigation for this cutover. The
+  documentation site remains a platform surface in this sitemap and stays out of
+  scope for the SPA work per the #1368 issue.
 
 ## Maintenance Rule
 
@@ -536,3 +589,5 @@ Minimum update checklist for future changes:
 | Issue #1093 | Navigation model covering top nav, side nav, breadcrumbs, and modal or overlay patterns. | Navigation Model. |
 | Issue #1093 | Taxonomy with one name per cross-surface concept. | Taxonomy. |
 | Issue #1093 | Decisions traced to personas and JTBD entries from research output. | Evidence And Inputs, Participant Surface, Organizer Surface. |
+| Issue #1368 | SPA-era cohesive IA re-derived fresh and folded into the maintained artifact. | SPA-Era Cohesive Update (#1368), Proposed Sitemap, Navigation Model, Taxonomy. |
+| Issue #1368 | Use cases, layout and pattern system, rationale, and Risk Register alignment notes. | Companion doc `docs/design/spa-cohesive-ux-1368.md`. |


### PR DESCRIPTION
## Summary

Design foundation for Phase 2 of the SPA cutover (#1368), scoped by the maintainer to docs only. It re-derives the platform information architecture fresh from the personas and current surfaces, folds the result into the maintained UX-003 sitemap (adding Administer as a first-class operator surface), and adds a companion design doc with the per-surface use-case catalog, the layout and pattern system, the rationale for departures, Risk Register alignment notes, and an API-readiness matrix. The real SPA shell scaffolding lands in #1369 and the per-surface workspaces in #1370 through #1374; this PR is the staged sign-off checkpoint.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1368

## ADR Impact

- ADR-013
- ADR-021
- ADR-029

## Changes

- Add docs/design/spa-cohesive-ux-1368.md: use-case catalog per surface (actor, job, pain, backend owner, API gaps), layout and pattern system (page templates, shell regions, required operational states, AA contract, domain-status-to-intent mapping), navigation UX from the shared contract, rationale for departures, Risk Register alignment notes, API-readiness matrix, and acceptance-criteria mapping.
- Update docs/design/ux-003-information-architecture-sitemap.md (the single maintained IA per ADR-013): add Administer as a first-class operator surface to the sitemap and organizer navigation, extend the nav-item contract with SPA presentation fields, add taxonomy terms, and add a SPA-era cohesive update section recording the fresh derivation and deltas.
- Include the codex architecture preflight note (docs/architecture/spa-cohesive-ux-preflight-1368.md) produced during Step 2.5.

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
