### PR TITLE
docs: TechVault purple-team scenario docs and bake runbook

### DIFF
--- a/changelog.d/+techvault-scenario-docs.added.md
+++ b/changelog.d/+techvault-scenario-docs.added.md
@@ -1,0 +1,1 @@
+Add TechVault purple-team scenario documentation and the golden-AMI bake runbook.

--- a/docs/ops/techvault-bake-runbook.md
+++ b/docs/ops/techvault-bake-runbook.md
@@ -1,0 +1,157 @@
+# TechVault Golden AMI Bake Runbook
+
+Region: `us-east-2` (all resources)
+Scenario: [`cms/scenarios/templates/techvault.yaml`](../../shifter/shifter_platform/cms/scenarios/templates/techvault.yaml)
+User docs: `documentation/docs/scenarios/techvault.md`
+Precedent: this mirrors the POLARIS bake pattern. See
+[`docs/architecture/polaris-scenario-bake-preflight-618.md`](../architecture/polaris-scenario-bake-preflight-618.md).
+
+This is the operator procedure for producing the **TechVault golden AMI**: one
+Ubuntu host running the APTL `techvault-operational` Docker Compose stack (~31
+containers) plus the VS Code + Claude Code + MCP seat, baked so a range launch
+only boots it, never rebuilds or reprovisions it.
+
+## Why pre-bake
+
+The stack is ~14 locally built images plus ~23 pulled images and takes tens of
+minutes to build and converge. Baking it once means range launch is a boot plus
+the containers' own `restart: unless-stopped` auto-start (seconds to minutes),
+with per-range work limited to injecting SSH/RDP creds and the Bedrock shard.
+**Do not run `aptl lab start` at range launch; that re-runs provisioning
+(cert-gen, seeding, ACES realization). Range launch = boot plus auto-start only.**
+
+## Prerequisites
+
+- AWS creds for the target account (`us-east-2`).
+- The pinned wheel version. Bake is tied to a version. Current: **`aptl-labs==4.1.2`**.
+- Base image: Canonical Ubuntu 24.04 (`/aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id`).
+- For the **runtime agent** (not the bake): AWS Bedrock model access must be
+  granted in the account for the `us.anthropic.claude-*` inference profiles the
+  seat uses. Invoking without the grant fails with an AWS Marketplace
+  subscribe error. This is an account admin action, done once.
+
+## Isolated bake environment
+
+Build in a **standalone VPC** (no peering to the portal/engine VPCs) so the bake
+cannot touch a live deployment:
+
+- VPC `10.99.0.0/16`, one public subnet, IGW plus default route, SG with no
+  inbound plus egress-all.
+- IAM role plus instance profile with `AmazonSSMManagedInstanceCore` (drive the
+  host over SSM RunCommand: no SSH keys, no inbound).
+- Tag everything `Project=techvault-bake` for clean teardown.
+
+Launch the bake host: Ubuntu 24.04, **r5.2xlarge**, ~**100 GB** gp3 root,
+the SSM instance profile, IMDSv2 required.
+
+## Bake procedure
+
+Run everything through SSM against the bake host.
+
+### 1. Toolchain
+
+```bash
+curl -fsSL https://get.docker.com | sh && systemctl enable --now docker
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs
+npm install -g @anthropic-ai/claude-code
+apt-get install -y pipx jq
+```
+
+### 2. Stand up the full stack (as the `ubuntu` user, uid 1000)
+
+> **Gotcha (root versus uid 1000):** aptl writes the Wazuh TLS certs `0400` owned
+> by the running user. The `wazuh-indexer` / `wazuh-dashboard` containers run as
+> **uid 1000**. Run the lab as **`ubuntu` (uid 1000)** so those certs are
+> readable. Running the whole thing as root leaves the indexer unhealthy
+> (`Unable to read .../root-ca.pem`).
+
+```bash
+sudo -u ubuntu env HOME=/home/ubuntu pipx install "aptl-labs==4.1.2"
+sudo -u ubuntu env HOME=/home/ubuntu bash -c '
+  cd /home/ubuntu && ~/.local/bin/aptl lab init techvault && cd techvault
+  # Gotcha: the default aptl.json disables enterprise/soc/mail/fileshare/dns.
+  # Enable all container groups for the full stack. (--scenario alone does NOT.)
+  jq ".containers = {wazuh:true,victim:true,kali:true,reverse:true,enterprise:true,soc:true,mail:true,fileshare:true,dns:true}" aptl.json > t && mv t aptl.json
+  ~/.local/bin/aptl lab start
+  [ -f .mcp.json.example ] && cp -n .mcp.json.example .mcp.json
+'
+```
+
+Expect **31 running `aptl-*` containers** (`aptl lab status`). Note:
+`techvault-operational` is the public startup contract and deliberately
+**excludes** the `mail` and `reverse` containers even with those groups enabled.
+31 containers is the full operational stack.
+
+### 3. Seat: VS Code over RDP (the Shifter access pattern)
+
+```bash
+apt-get install -y --no-install-recommends xfce4 xfce4-terminal xfce4-goodies dbus-x11 xorgxrdp xrdp
+# VS Code Desktop from the Microsoft apt repo (real VS Code, not code-server)
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list
+apt-get update && apt-get install -y code
+echo "xfce4-session" > /home/ubuntu/.xsession && chown ubuntu:ubuntu /home/ubuntu/.xsession
+adduser xrdp ssl-cert
+systemctl enable xrdp
+# Auto-open the lab in VS Code on RDP login (optional UX):
+#   /home/ubuntu/.config/autostart/code.desktop -> Exec=code --no-sandbox /home/ubuntu/techvault
+```
+
+Access is **Guacamole RDP** into this XFCE desktop (`os_type: kali` in the
+template selects the RDP path). The seat user stays `ubuntu`; the range bootstrap
+records `ssh_username=ubuntu` and sets the per-range RDP password.
+
+### 4. Quiesce and image (leave the stack RUNNING)
+
+Do **not** `aptl lab stop`. Kill any transient test processes, then create the
+image with the stack running so the containers auto-start on the next boot:
+
+```bash
+aws ec2 create-image --instance-id <bake-host> --name "techvault-golden-4.1.2-ide-<date>" \
+  --description "TechVault techvault-operational + VS Code seat, aptl-labs 4.1.2" \
+  --tag-specifications 'ResourceType=image,Tags=[{Key=Project,Value=techvault-bake},{Key=aptl_version,Value=4.1.2}]'
+```
+
+`create-image` (default, no `--no-reboot`) stops the instance for a consistent
+snapshot; on boot docker restarts the `unless-stopped`/`always` containers.
+
+### 5. Golden verify (non-negotiable)
+
+Launch a **fresh instance from the new AMI**, let docker auto-start the stack, and
+confirm before trusting it:
+
+- `aptl lab status` shows all containers running/healthy (Wazuh indexer, TheHive,
+  Cassandra, ES take a couple minutes).
+- Purple-team loop: SQLi from Kali produces Wazuh `web_attack` alerts.
+- MCP smoke: `aptl-red` `kali_info` / `kali_run_command` over JSON-RPC.
+
+Use APTL's own protocol: `docs/components/mcp-smoke-test-protocol.md` in the aptl
+repo (manual-fallback plus agent-MCP sections).
+
+### 6. Register the AMI
+
+Set the per-environment SSM parameter (this is how the provisioner resolves it;
+see `shifter/engine/provisioner/provisioner_ami.py`). It is **additive**; it
+does not touch the base `/shifter/ami/{kali,ubuntu,windows,dc}` params:
+
+```bash
+aws ssm put-parameter --name /shifter/ami/techvault --type String \
+  --value <ami-id> --description "TechVault golden AMI (aptl-labs 4.1.2)"
+```
+
+The repo references the AMI by **key** (`ami_key: techvault` in the scenario
+template), never by id; nothing else to commit.
+
+## Sizing notes
+
+The full stack idles at ~9 GB / 62 GB RAM and ~4% CPU on `r5.2xlarge`; an nmap
+sweep from Kali stays under load 0.3. The size is comfortable with headroom for
+participant work plus Claude Code (which is remote compute via Bedrock).
+
+## Reproducible pipeline (follow-up)
+
+This runbook is the manual operator path. The reproducible version (a
+`workflow_dispatch` `techvault-scenario-bake.yml` plus a
+`scripts/techvault-aws-range/` bake range that images and updates the SSM
+parameter) should mirror `.github/workflows/packer.yml` and the POLARIS bake
+range, per the #618 pattern.

--- a/shifter/shifter_platform/documentation/docs/scenarios/index.md
+++ b/shifter/shifter_platform/documentation/docs/scenarios/index.md
@@ -10,6 +10,7 @@ A scenario defines what your range contains. Choose based on your demo needs.
 | [AD Attack Lab](ad-attack-lab) | Kali, DC, Workstation | No | Active Directory attacks |
 | [Basic Range with NGFW](ngfw-range) | Kali, Workstation | Yes | Traffic logging demos |
 | AD Attack Lab with NGFW | Kali, DC, Workstation | Yes | AD attacks with network visibility + Cortex XDR |
+| [TechVault Purple-Team Lab](techvault) | One host: Kali + enterprise + full SOC (~31 containers) | No | Agent-driven purple teaming (attack, detect, respond) via VS Code + Claude Code |
 
 ## Quick Comparison
 
@@ -29,5 +30,6 @@ A scenario defines what your range contains. Choose based on your demo needs.
 | AD Attack Lab | 5-10 minutes |
 | Basic Range with NGFW | 3-7 minutes |
 | AD Attack Lab with NGFW | 6-12 minutes |
+| TechVault Purple-Team Lab | 3-6 minutes (pre-baked; boots + auto-starts the stack) |
 
 Times vary based on infrastructure load.

--- a/shifter/shifter_platform/documentation/docs/scenarios/techvault.md
+++ b/shifter/shifter_platform/documentation/docs/scenarios/techvault.md
@@ -1,0 +1,99 @@
+# TechVault Purple-Team Lab
+
+A full purple-team range for the fictional *TechVault Solutions* company:
+vulnerable enterprise targets, a production-grade SOC stack, and a Kali
+attacker, all on a single host, driven by an AI agent through VS Code.
+
+Unlike the other scenarios (one EC2 instance per box), TechVault is **one host
+running a Docker Compose stack** of ~31 containers, baked ahead of time into a
+single AMI. It is the [APTL](https://github.com/Brad-Edwards/aptl)
+`techvault-operational` scenario delivered as a Shifter range.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph Host["TechVault host (one EC2 instance)"]
+        subgraph Seat["Seat: VS Code + Claude Code + MCP servers"]
+        end
+        subgraph RT["Red Team (172.20.4.0/24)"]
+            K[Kali attacker]
+        end
+        subgraph DMZ["DMZ (172.20.1.0/24)"]
+            WEB[Flask webapp] --- DNS[BIND DNS]
+        end
+        subgraph INT["Internal (172.20.2.0/24)"]
+            AD[Samba AD DC] --- DB[(PostgreSQL)] --- FS[Samba file share]
+            WS[Workstation] --- VIC[Victim host]
+        end
+        subgraph SEC["Security (172.20.0.0/24)"]
+            WZ[Wazuh SIEM] --- SUR[Suricata] --- MISP[MISP]
+            TH[TheHive + Cortex] --- SH[Shuffle SOAR]
+        end
+    end
+    Seat -->|MCP| K
+    Seat -->|MCP| SEC
+    K -->|attack| DMZ
+    K -->|attack| INT
+    INT -.->|telemetry| SEC
+    DMZ -.->|telemetry| SEC
+```
+
+## Instances
+
+| Instance | OS | Role | Notes |
+|----------|-----|------|-------|
+| TechVault | Ubuntu host (presents as Kali attacker) | Attacker / seat | Runs the whole compose stack; `r5.2xlarge` |
+
+The enterprise targets, SOC, and Kali are **containers inside this one host**,
+not separate Shifter instances.
+
+## Network
+
+Four Docker networks inside the host: Security `172.20.0.0/24`, DMZ
+`172.20.1.0/24`, Internal `172.20.2.0/24`, and Red Team `172.20.4.0/24`. The Kali
+attacker can reach the DMZ and Internal targets; targets report telemetry to the
+SOC.
+
+## Access
+
+- **RDP from the portal (Guacamole)** into the host desktop (XFCE).
+- The desktop runs **VS Code Desktop**, opened on the lab workspace, with an
+  integrated terminal and the MCP/agent surface.
+- Drive the range with **Claude Code** in the VS Code terminal: it is wired to
+  the APTL MCP servers, giving the agent red-side control of Kali
+  (`kali_run_command`, and so on) and blue-side control of the SOC
+  (`wazuh_query_alerts`, `cases_create_case`, `soar_execute_workflow`, and so
+  on).
+
+## Planted vulnerabilities
+
+Application, identity, and infrastructure weaknesses across the stack: SQL and
+command injection and XSS in the webapp; weak/seasonal and kerberoastable AD
+accounts; guest-writable SMB shares leaking PII and credentials; workstation
+secrets and passwordless SSH. These are synthetic scenario content.
+
+## Use cases
+
+- Autonomous / agent-driven purple-team exercises
+- Attack, detect, enrich, and respond across a real SOC stack
+- AI red- and blue-team assessment
+
+## Launch steps
+
+1. Go to **Ranges** in the sidebar.
+2. Select the **TechVault Purple-Team Lab** scenario.
+3. Click **Launch Range**.
+4. Wait for provisioning, then **RDP** into the host from the portal.
+5. VS Code opens on the lab; use the integrated terminal and Claude Code.
+
+## What's installed
+
+- The full APTL `techvault-operational` compose stack (Kali, enterprise
+  targets, and the Wazuh/Suricata/MISP/TheHive/Cortex/Shuffle SOC).
+- **Claude Code** plus the APTL MCP servers on the host seat (model credentials
+  via AWS Bedrock).
+- **VS Code Desktop** in an XFCE + xrdp desktop.
+
+> The stack is pre-baked and starts automatically on boot, so provisioning a
+> range does not rebuild or reprovision it.


### PR DESCRIPTION
Documentation-only PR for the TechVault Purple-Team Lab scenario. Adds the user-facing scenario page (`documentation/docs/scenarios/techvault.md`), lists TechVault in the scenarios index tables, and adds the operator golden-AMI bake runbook (`docs/ops/techvault-bake-runbook.md`) plus a towncrier changelog fragment. This documents the single-host APTL `techvault-operational` stack (~31 containers, VS Code + agent seat) so operators can bake the golden AMI and users can find the scenario; the CMS scenario template, engine provisioner wiring, and reproducible bake pipeline land in separate PRs.