### PR TITLE
ci: TechVault golden-AMI bake pipeline

### DIFF
--- a/.github/workflows/techvault-scenario-bake.yml
+++ b/.github/workflows/techvault-scenario-bake.yml
@@ -1,0 +1,423 @@
+name: TechVault Scenario Bake (Dev)
+
+# Operator-triggered bake of the TechVault golden AMI. Mirrors the
+# workflow_dispatch-only shape of packer.yml / polaris-scenario-bake.yml: it
+# automates the deliberate manual bake in docs/ops/techvault-bake-runbook.md
+# (stand up the APTL techvault-operational stack + the VS Code seat, create an
+# image with the stack running, golden-verify, then update SSM) and is never
+# wired to push / pull_request / schedule triggers. See
+# docs/architecture/polaris-scenario-bake-preflight-618.md for the bake
+# boundary.
+#
+# Security posture: this is a privileged self-hosted workflow that assumes the
+# dev AWS role over OIDC. Free-form operator inputs are bound to environment
+# variables and validated against strict allowlists before any AWS step; they
+# are never interpolated into shell text, so a crafted input cannot inject
+# commands on the runner. The bake host is driven entirely over SSM RunCommand
+# (no SSH, no inbound), and the isolated bake VPC/subnet, security group and
+# SSM-enabled instance profile are supplied by the operator.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'AWS environment to bake in'
+        required: true
+        type: choice
+        options:
+          - dev
+          - proof
+        default: dev
+      aptl_version:
+        description: 'aptl-labs wheel version to bake (bake is pinned to a version)'
+        required: false
+        type: string
+        default: '4.1.2'
+      ssm_param:
+        description: 'SSM parameter to update (must be under /shifter/ami/)'
+        required: false
+        type: string
+        default: '/shifter/ami/techvault'
+      instance_type:
+        description: 'EC2 instance type for the bake host'
+        required: false
+        type: string
+        default: 'r5.2xlarge'
+      subnet_id:
+        description: 'Subnet ID in the isolated bake VPC to launch the bake host into'
+        required: true
+        type: string
+      security_group_id:
+        description: 'Security group ID for the bake host (no inbound, egress-all)'
+        required: true
+        type: string
+      instance_profile:
+        description: 'SSM-enabled instance profile name (AmazonSSMManagedInstanceCore)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  bake:
+    name: Bake TechVault AMI in ${{ inputs.environment }}
+    runs-on: self-hosted
+
+    env:
+      AWS_REGION: us-east-2
+      RUN_ID: ${{ github.run_id }}
+      # Canonical Ubuntu 24.04 published AMI pointer (per the runbook).
+      UBUNTU_SSM_PARAM: /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+      # Free-form inputs are bound here as plain environment variables. Env-var
+      # *values* are never re-parsed as shell code, so referencing them as
+      # "$APTL_VERSION" etc. in run blocks is injection-safe — unlike
+      # ${{ inputs.* }} which expands into the script text before bash.
+      APTL_VERSION: ${{ inputs.aptl_version }}
+      SSM_PARAM: ${{ inputs.ssm_param }}
+      INSTANCE_TYPE: ${{ inputs.instance_type }}
+      SUBNET_ID: ${{ inputs.subnet_id }}
+      SECURITY_GROUP_ID: ${{ inputs.security_group_id }}
+      INSTANCE_PROFILE: ${{ inputs.instance_profile }}
+
+    steps:
+      - name: Validate operator inputs
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$APTL_VERSION" | grep -qE '^[0-9][0-9A-Za-z._-]*$'; then
+            echo "::error::aptl_version is not a valid version string"
+            exit 1
+          fi
+          if ! printf '%s' "$SSM_PARAM" | grep -qE '^/shifter/ami/[A-Za-z0-9._-]+$'; then
+            echo "::error::ssm_param must match /shifter/ami/<name>"
+            exit 1
+          fi
+          if ! printf '%s' "$INSTANCE_TYPE" | grep -qE '^[a-z0-9]+\.[a-z0-9]+$'; then
+            echo "::error::instance_type is not a valid EC2 instance type"
+            exit 1
+          fi
+          if ! printf '%s' "$SUBNET_ID" | grep -qE '^subnet-[0-9a-f]+$'; then
+            echo "::error::subnet_id is not a valid subnet id"
+            exit 1
+          fi
+          if ! printf '%s' "$SECURITY_GROUP_ID" | grep -qE '^sg-[0-9a-f]+$'; then
+            echo "::error::security_group_id is not a valid security group id"
+            exit 1
+          fi
+          if ! printf '%s' "$INSTANCE_PROFILE" | grep -qE '^[A-Za-z0-9_+=,.@/-]+$'; then
+            echo "::error::instance_profile contains characters outside the IAM name set"
+            exit 1
+          fi
+
+      - name: Resolve AWS deploy role
+        id: aws-role
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}
+          AWS_ROLE_ARN_DEV: ${{ secrets.AWS_ROLE_ARN_DEV }}
+          AWS_ROLE_ARN_PROOF: ${{ secrets.AWS_ROLE_ARN_PROOF }}
+        run: |
+          set -euo pipefail
+          case "$ENVIRONMENT" in
+            dev)
+              ROLE_SECRET_NAME="AWS_ROLE_ARN_DEV"
+              ROLE_ARN="$AWS_ROLE_ARN_DEV"
+              ;;
+            proof)
+              ROLE_SECRET_NAME="AWS_ROLE_ARN_PROOF"
+              ROLE_ARN="$AWS_ROLE_ARN_PROOF"
+              ;;
+            *)
+              echo "::error::Unsupported AWS environment: $ENVIRONMENT"
+              exit 1
+              ;;
+          esac
+          if [ -z "$ROLE_ARN" ]; then
+            echo "::error::Required secret ${ROLE_SECRET_NAME} is not set"
+            exit 1
+          fi
+          echo "role_arn=$ROLE_ARN" >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (${{ inputs.environment }})
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ steps.aws-role.outputs.role_arn }}
+          aws-region: us-east-2
+
+      - name: Launch the bake host
+        run: |
+          set -euo pipefail
+          UBUNTU_AMI="$(aws ssm get-parameter --name "$UBUNTU_SSM_PARAM" \
+            --query 'Parameter.Value' --output text)"
+          echo "base Ubuntu 24.04 AMI: ${UBUNTU_AMI}"
+          ROOT_DEV="$(aws ec2 describe-images --image-ids "$UBUNTU_AMI" \
+            --query 'Images[0].RootDeviceName' --output text)"
+          INSTANCE_ID="$(aws ec2 run-instances \
+            --image-id "$UBUNTU_AMI" \
+            --instance-type "$INSTANCE_TYPE" \
+            --subnet-id "$SUBNET_ID" \
+            --security-group-ids "$SECURITY_GROUP_ID" \
+            --iam-instance-profile "Name=${INSTANCE_PROFILE}" \
+            --metadata-options 'HttpTokens=required,HttpEndpoint=enabled' \
+            --block-device-mappings "[{\"DeviceName\":\"${ROOT_DEV}\",\"Ebs\":{\"VolumeSize\":100,\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]" \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=techvault-bake-${RUN_ID}},{Key=Project,Value=techvault-bake},{Key=aptl_version,Value=${APTL_VERSION}}]" \
+            --count 1 \
+            --query 'Instances[0].InstanceId' --output text)"
+          echo "INSTANCE_ID=${INSTANCE_ID}" >> "$GITHUB_ENV"
+          echo "launched bake host ${INSTANCE_ID}; waiting for it to pass status checks..."
+          aws ec2 wait instance-running --instance-ids "$INSTANCE_ID"
+          aws ec2 wait instance-status-ok --instance-ids "$INSTANCE_ID"
+          echo "waiting for the SSM agent to come online..."
+          deadline=$(( $(date +%s) + 600 ))
+          until aws ssm describe-instance-information \
+            --filters "Key=InstanceIds,Values=${INSTANCE_ID}" \
+            --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null \
+            | grep -q Online; do
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::SSM agent did not come online within 10 minutes"
+              exit 1
+            fi
+            sleep 15
+          done
+          echo "bake host ${INSTANCE_ID} is online"
+
+      - name: Bake the TechVault stack over SSM
+        run: |
+          set -euo pipefail
+
+          # --- SSM RunCommand driver -------------------------------------
+          # run_phase FILE COMMENT EXEC_TIMEOUT WAIT_DEADLINE
+          # Sends the base64-encoded script FILE to the bake host and blocks
+          # until the command reaches a terminal state. base64 payloads only
+          # contain [A-Za-z0-9+/=], so nothing in the script can break out of
+          # the JSON string or the runner shell.
+          ssm_wait() {
+            local cid="$1" deadline
+            deadline=$(( $(date +%s) + $2 ))
+            while true; do
+              local st
+              st="$(aws ssm get-command-invocation --command-id "$cid" \
+                --instance-id "$INSTANCE_ID" --query Status --output text 2>/dev/null || echo Pending)"
+              case "$st" in
+                Success) return 0 ;;
+                Failed|Cancelled|TimedOut|Cancelling|Undeliverable|Terminated)
+                  echo "::error::SSM command ${cid} ended ${st}"
+                  aws ssm get-command-invocation --command-id "$cid" \
+                    --instance-id "$INSTANCE_ID" --query StandardErrorContent \
+                    --output text 2>/dev/null | tail -n 80 || true
+                  return 1 ;;
+              esac
+              if [ "$(date +%s)" -ge "$deadline" ]; then
+                echo "::error::timed out waiting on SSM command ${cid}"
+                return 1
+              fi
+              sleep 15
+            done
+          }
+          run_phase() {
+            local file="$1" comment="$2" exec_to="$3" wait_to="$4" b64 cid
+            b64="$(base64 -w0 < "$file")"
+            cid="$(aws ssm send-command \
+              --instance-ids "$INSTANCE_ID" \
+              --document-name AWS-RunShellScript \
+              --comment "$comment" \
+              --timeout-seconds 600 \
+              --parameters "{\"commands\":[\"echo ${b64} | base64 -d | bash\"],\"executionTimeout\":[\"${exec_to}\"]}" \
+              --query 'Command.CommandId' --output text)"
+            echo "phase '${comment}' -> command ${cid}"
+            ssm_wait "$cid" "$wait_to"
+          }
+
+          # --- Phase 1: toolchain (runs as root via SSM) -----------------
+          cat > "${RUNNER_TEMP}/phase-toolchain.sh" <<'REMOTE'
+          set -euxo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          cloud-init status --wait || true
+          curl -fsSL https://get.docker.com | sh
+          systemctl enable --now docker
+          curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+          apt-get install -y nodejs
+          npm install -g @anthropic-ai/claude-code
+          apt-get install -y pipx jq
+          REMOTE
+          run_phase "${RUNNER_TEMP}/phase-toolchain.sh" 'techvault bake: toolchain' 1800 2100
+
+          # --- Phase 2: stand up the full stack as the ubuntu user -------
+          # Gotcha: aptl writes the Wazuh TLS certs 0400 owned by the running
+          # user, and wazuh-indexer/dashboard run as uid 1000, so the lab must
+          # run as ubuntu (uid 1000). The default aptl.json disables several
+          # container groups; enable them all for the full stack.
+          {
+            printf 'APTL_VERSION=%q\nexport APTL_VERSION\n' "$APTL_VERSION"
+            cat <<'REMOTE'
+          set -euxo pipefail
+          sudo -u ubuntu env HOME=/home/ubuntu pipx install "aptl-labs==${APTL_VERSION}"
+          sudo -u ubuntu env HOME=/home/ubuntu bash -c '
+            set -euxo pipefail
+            cd /home/ubuntu
+            ~/.local/bin/aptl lab init techvault
+            cd techvault
+            jq ".containers = {wazuh:true,victim:true,kali:true,reverse:true,enterprise:true,soc:true,mail:true,fileshare:true,dns:true}" aptl.json > t && mv t aptl.json
+            ~/.local/bin/aptl lab start
+            if [ -f .mcp.json.example ]; then cp -n .mcp.json.example .mcp.json || true; fi
+          '
+          REMOTE
+          } > "${RUNNER_TEMP}/phase-stack.sh"
+          run_phase "${RUNNER_TEMP}/phase-stack.sh" 'techvault bake: stack' 5400 6000
+
+          # --- Phase 3: VS Code over RDP seat (the Shifter access path) ---
+          cat > "${RUNNER_TEMP}/phase-seat.sh" <<'REMOTE'
+          set -euxo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get install -y --no-install-recommends xfce4 xfce4-terminal xfce4-goodies dbus-x11 xorgxrdp xrdp
+          wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /usr/share/keyrings/microsoft.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list
+          apt-get update
+          apt-get install -y code
+          echo "xfce4-session" > /home/ubuntu/.xsession
+          chown ubuntu:ubuntu /home/ubuntu/.xsession
+          adduser xrdp ssl-cert
+          systemctl enable xrdp
+          REMOTE
+          run_phase "${RUNNER_TEMP}/phase-seat.sh" 'techvault bake: seat' 2400 2700
+
+          # --- Phase 4: confirm the operational stack is fully up --------
+          # The public startup contract (techvault-operational) is 31 running
+          # aptl-* containers. Poll until they converge before imaging.
+          echo "waiting for the stack to reach 31 running aptl containers..."
+          deadline=$(( $(date +%s) + 900 ))
+          while true; do
+            cid="$(aws ssm send-command --instance-ids "$INSTANCE_ID" \
+              --document-name AWS-RunShellScript \
+              --comment 'techvault bake: count containers' \
+              --parameters '{"commands":["docker ps --filter name=aptl- --filter status=running -q | wc -l"]}' \
+              --query 'Command.CommandId' --output text)"
+            sleep 10
+            count="$(aws ssm get-command-invocation --command-id "$cid" \
+              --instance-id "$INSTANCE_ID" --query StandardOutputContent \
+              --output text 2>/dev/null | tr -dc '0-9' || echo 0)"
+            echo "running aptl containers: ${count:-0}"
+            if [ "${count:-0}" -ge 31 ]; then
+              echo "stack is up (${count} containers)"
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::stack did not reach 31 running containers (last=${count:-0})"
+              exit 1
+            fi
+            sleep 20
+          done
+
+      - name: Create the golden AMI (stack left running)
+        run: |
+          set -euo pipefail
+          BAKE_DATE="$(date -u +%Y%m%d)"
+          AMI_NAME="techvault-golden-${APTL_VERSION}-ide-${BAKE_DATE}-${RUN_ID}"
+          # Default (no --no-reboot): create-image stops the instance for a
+          # consistent snapshot; on boot docker restarts the unless-stopped /
+          # always containers. Do NOT aptl lab stop first — the stack must be
+          # baked running so a range launch is a boot plus auto-start only.
+          AMI_ID="$(aws ec2 create-image \
+            --instance-id "$INSTANCE_ID" \
+            --name "$AMI_NAME" \
+            --description "TechVault techvault-operational + VS Code seat, aptl-labs ${APTL_VERSION}, run ${RUN_ID}" \
+            --tag-specifications "ResourceType=image,Tags=[{Key=Project,Value=techvault-bake},{Key=aptl_version,Value=${APTL_VERSION}}]" \
+            --query 'ImageId' --output text)"
+          echo "AMI_ID=${AMI_ID}" >> "$GITHUB_ENV"
+          echo "waiting for AMI ${AMI_ID} to become available..."
+          aws ec2 wait image-available --image-ids "$AMI_ID"
+          {
+            echo "## TechVault AMI Bake Complete"
+            echo "- **AMI name:** \`${AMI_NAME}\`"
+            echo "- **AMI ID:** \`${AMI_ID}\`"
+            echo "- **aptl-labs version:** \`${APTL_VERSION}\`"
+            echo "- **Region:** us-east-2"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Golden verify (fresh instance auto-starts the stack)
+        run: |
+          set -euo pipefail
+          ROOT_DEV="$(aws ec2 describe-images --image-ids "$AMI_ID" \
+            --query 'Images[0].RootDeviceName' --output text)"
+          VERIFY_INSTANCE_ID="$(aws ec2 run-instances \
+            --image-id "$AMI_ID" \
+            --instance-type "$INSTANCE_TYPE" \
+            --subnet-id "$SUBNET_ID" \
+            --security-group-ids "$SECURITY_GROUP_ID" \
+            --iam-instance-profile "Name=${INSTANCE_PROFILE}" \
+            --metadata-options 'HttpTokens=required,HttpEndpoint=enabled' \
+            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=techvault-verify-${RUN_ID}},{Key=Project,Value=techvault-bake}]" \
+            --count 1 \
+            --query 'Instances[0].InstanceId' --output text)"
+          echo "VERIFY_INSTANCE_ID=${VERIFY_INSTANCE_ID}" >> "$GITHUB_ENV"
+          echo "launched golden-verify host ${VERIFY_INSTANCE_ID}"
+          aws ec2 wait instance-running --instance-ids "$VERIFY_INSTANCE_ID"
+          aws ec2 wait instance-status-ok --instance-ids "$VERIFY_INSTANCE_ID"
+          echo "waiting for the SSM agent to come online..."
+          deadline=$(( $(date +%s) + 600 ))
+          until aws ssm describe-instance-information \
+            --filters "Key=InstanceIds,Values=${VERIFY_INSTANCE_ID}" \
+            --query 'InstanceInformationList[0].PingStatus' --output text 2>/dev/null \
+            | grep -q Online; do
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::verify host SSM agent did not come online within 10 minutes"
+              exit 1
+            fi
+            sleep 15
+          done
+          # No `aptl lab start` here: docker must auto-start the baked stack on
+          # first boot. Poll until the 31 operational containers converge.
+          echo "waiting for docker to auto-start the baked stack..."
+          deadline=$(( $(date +%s) + 900 ))
+          while true; do
+            cid="$(aws ssm send-command --instance-ids "$VERIFY_INSTANCE_ID" \
+              --document-name AWS-RunShellScript \
+              --comment 'techvault verify: count containers' \
+              --parameters '{"commands":["docker ps --filter name=aptl- --filter status=running -q | wc -l"]}' \
+              --query 'Command.CommandId' --output text)"
+            sleep 10
+            count="$(aws ssm get-command-invocation --command-id "$cid" \
+              --instance-id "$VERIFY_INSTANCE_ID" --query StandardOutputContent \
+              --output text 2>/dev/null | tr -dc '0-9' || echo 0)"
+            echo "auto-started aptl containers: ${count:-0}"
+            if [ "${count:-0}" -ge 31 ]; then
+              echo "golden verify PASSED (${count} containers auto-started)"
+              break
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::golden verify FAILED: stack did not auto-start (last=${count:-0})"
+              exit 1
+            fi
+            sleep 20
+          done
+          aws ec2 terminate-instances --instance-ids "$VERIFY_INSTANCE_ID" >/dev/null
+          echo "VERIFY_INSTANCE_ID=" >> "$GITHUB_ENV"
+          {
+            echo "- **Golden verify:** passed (docker auto-started the stack, no \`aptl lab start\`)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record the AMI in SSM
+        run: |
+          set -euo pipefail
+          aws ssm put-parameter \
+            --name "$SSM_PARAM" \
+            --type String \
+            --value "$AMI_ID" \
+            --overwrite \
+            --description "TechVault golden AMI (aptl-labs ${APTL_VERSION}) baked by GitHub Actions run ${RUN_ID}"
+          {
+            echo "- **SSM parameter:** \`${SSM_PARAM}\` -> \`${AMI_ID}\`"
+            echo ""
+            echo "**Next step:** test the new AMI in a TechVault range before relying on it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Tear down bake instances
+        if: always()
+        run: |
+          set -euo pipefail
+          for id in "${INSTANCE_ID:-}" "${VERIFY_INSTANCE_ID:-}"; do
+            if [ -n "$id" ]; then
+              echo "terminating ${id}"
+              aws ec2 terminate-instances --instance-ids "$id" >/dev/null || true
+            fi
+          done

--- a/.github/workflows/techvault-scenario-bake.yml
+++ b/.github/workflows/techvault-scenario-bake.yml
@@ -337,8 +337,6 @@ jobs:
       - name: Golden verify (fresh instance auto-starts the stack)
         run: |
           set -euo pipefail
-          ROOT_DEV="$(aws ec2 describe-images --image-ids "$AMI_ID" \
-            --query 'Images[0].RootDeviceName' --output text)"
           VERIFY_INSTANCE_ID="$(aws ec2 run-instances \
             --image-id "$AMI_ID" \
             --instance-type "$INSTANCE_TYPE" \

--- a/changelog.d/+techvault-bake-pipeline.added.md
+++ b/changelog.d/+techvault-bake-pipeline.added.md
@@ -1,0 +1,1 @@
+Added an operator-triggered `techvault-scenario-bake` workflow that bakes the TechVault golden AMI (the APTL `techvault-operational` stack plus the VS Code seat) and records it in the `/shifter/ami/techvault` SSM parameter, automating the manual bake runbook.


### PR DESCRIPTION
## Summary

- **What changed:** Adds `.github/workflows/techvault-scenario-bake.yml`, a `workflow_dispatch`-only pipeline that automates the manual TechVault golden-AMI bake in `docs/ops/techvault-bake-runbook.md` (PR #1449), plus a towncrier fragment.
- **Why:** The manual runbook is the operator path; this makes the bake reproducible and one-click, mirroring the POLARIS scenario bake per the #618 boundary.

What the workflow does (all inline bash + AWS CLI + SSM RunCommand, no new `scripts/` directory):

1. Launches an Ubuntu 24.04 host (`r5.2xlarge`, 100 GB gp3, IMDSv2 required) in the operator-provided isolated bake VPC subnet + security group + SSM-enabled instance profile.
2. Drives it over SSM to install docker + Node + Claude Code + pipx + `aptl-labs==<version>`, then stands up the APTL `techvault-operational` stack **as the `ubuntu` user (uid 1000)** with all `aptl.json` container groups enabled and `aptl lab start`.
3. Installs the XFCE + xrdp + VS Code Desktop seat and leaves the stack **running**.
4. `create-image` (default reboot) once the 31 operational containers are up.
5. **Golden-verify:** boots a fresh instance from the new AMI and confirms docker auto-starts the stack with **no** `aptl lab start`.
6. `aws ssm put-parameter --name /shifter/ami/techvault --overwrite` and emits a step summary with the AMI id + SSM param.

Inputs: `environment` (dev/proof), `aptl_version` (default `4.1.2`), `ssm_param` (default `/shifter/ami/techvault`), `instance_type` (default `r5.2xlarge`), `subnet_id`, `security_group_id`, `instance_profile`.

Security posture mirrors `packer.yml` / `polaris-scenario-bake.yml`: OIDC AWS auth (`id-token: write`, `contents: read`), free-form inputs validated against strict allowlists and bound to env vars (never interpolated into shell), SSM-only host access (no SSH/inbound), and bake instances torn down in an `always()` step. Never wired to push/pull_request/schedule.

## ADR Impact

- [x] No ADR impact

ADRs touched: none. No new `scripts/` directory and no guarded paths touched, so no ADR-012 registration or `docs/adr` change is required.

## Guardrail Changes

- [x] No guardrail files changed

## Verification

- [x] `actionlint .github/workflows/techvault-scenario-bake.yml` — clean (also via pre-commit)
- [x] `bash -n` on every workflow `run:` block and the generated SSM phase scripts — clean
- [ ] Full bake is operator-run (`workflow_dispatch`); not executed in CI
