### PR TITLE
fix(gcp): project-prefix the gdc-vm-images bucket name for global uniqueness

### DIFF
--- a/platform/terraform/gcp/modules/cicd-github-oidc/build-infra.tf
+++ b/platform/terraform/gcp/modules/cicd-github-oidc/build-infra.tf
@@ -47,8 +47,12 @@ resource "google_compute_firewall" "packer_iap_ingress" {
 }
 
 resource "google_storage_bucket" "gdc_vm_images" {
-  project                     = var.project_id
-  name                        = "${var.name_prefix}-gdc-vm-images"
+  project = var.project_id
+  # Project-prefixed for global uniqueness (GCS bucket names are global). The bare
+  # "${name_prefix}-gdc-vm-images" collides across projects and stays reserved in
+  # GCS's deletion cooldown after a project teardown, matching the project-prefixed
+  # naming the portal GCS buckets already use.
+  name                        = "${var.project_id}-${var.name_prefix}-gdc-vm-images"
   location                    = var.image_bucket_location
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"


### PR DESCRIPTION
## Summary
GCS bucket names are global. The `cicd-github-oidc` module named the image bucket `${name_prefix}-gdc-vm-images` (= `shifter-gcp-dev-gdc-vm-images`), which is not project-scoped. It collides across projects and stays reserved in GCS's deletion cooldown after a project teardown, so a fresh deploy into a new GCP project fails at `terraform apply` with `409 The requested bucket name is not available`.

Fix: project-prefix the name to `${project_id}-${name_prefix}-gdc-vm-images`, matching the portal GCS buckets (audit-logs/assets already use `${project_id}-...`).

## Testing
Surfaced during a fresh control-plane deploy into a new project (prod-ksqdkj); the renamed bucket created cleanly. `terraform fmt`/`tflint`/`validate` pass.

## Ground Control Checks
- Requirements: none (infra bug fix)
- ADR impact: none
- Traceability: n/a