### PR TITLE
test(provisioner): cover GCE range-cell modules to clear SonarCloud new-code gate

### DIFF
--- a/shifter/engine/provisioner/tests/test_gcp_range_cell_naming.py
+++ b/shifter/engine/provisioner/tests/test_gcp_range_cell_naming.py
@@ -1,0 +1,104 @@
+"""Tests for GCE range-cell naming/URI/label/tag helpers.
+
+These are pure functions: they normalize scenario values into Compute Engine
+resource names/labels and build relative self-links and network tags.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gcp_range_cell_naming import (
+    _disk_type_self_link,
+    _label_value,
+    _machine_type_self_link,
+    _network_name_from_id,
+    _network_self_link,
+    _network_tag,
+    _sanitize_name,
+    _short_resource_name,
+    _subnet_tag,
+    _subnetwork_self_link,
+)
+
+
+class TestSanitizeName:
+    def test_lowercases_and_replaces_invalid_chars(self):
+        assert _sanitize_name("Polaris Range #1") == "polaris-range-1"
+
+    def test_collapses_and_trims_dashes(self):
+        assert _sanitize_name("--a__b--") == "a-b"
+
+    def test_empty_value_falls_back_to_range(self):
+        assert _sanitize_name("   ") == "range"
+
+    def test_leading_non_alpha_is_prefixed(self):
+        # A name that normalizes to digits must start with a letter (GCE rule).
+        assert _sanitize_name("123") == "r-123"
+
+    def test_truncates_to_max_length_without_trailing_dash(self):
+        result = _sanitize_name("a" * 70, max_length=10)
+        assert result == "a" * 10
+        assert len(result) == 10
+
+    def test_truncation_strips_dash_landing_on_boundary(self):
+        # Cut lands on a dash; the result must not end with one.
+        assert _sanitize_name("ab-cdefgh", max_length=3) == "ab"
+
+
+class TestLabelValue:
+    def test_underscores_are_allowed(self):
+        assert _label_value("Role_DC") == "role_dc"
+
+    def test_invalid_chars_replaced_and_trimmed(self):
+        assert _label_value(" Kali/Attacker! ") == "kali-attacker"
+
+    def test_empty_falls_back_to_unknown(self):
+        assert _label_value("***") == "unknown"
+
+    def test_non_string_is_coerced(self):
+        assert _label_value(42) == "42"
+
+
+class TestShortResourceName:
+    def test_joins_prefix_and_parts(self):
+        assert _short_resource_name("shifter-range", 42, "polaris") == "shifter-range-42-polaris"
+
+    def test_skips_none_and_empty_parts(self):
+        assert _short_resource_name("shifter-r", None, "", "dc01") == "shifter-r-dc01"
+
+
+class TestSelfLinks:
+    def test_network_self_link(self):
+        assert _network_self_link("proj", "net") == "projects/proj/global/networks/net"
+
+    def test_subnetwork_self_link(self):
+        assert _subnetwork_self_link("proj", "us-central1", "sn") == "projects/proj/regions/us-central1/subnetworks/sn"
+
+    def test_machine_type_self_link(self):
+        assert _machine_type_self_link("us-central1-b", "e2-medium") == "zones/us-central1-b/machineTypes/e2-medium"
+
+    def test_disk_type_self_link(self):
+        assert _disk_type_self_link("us-central1-b", "pd-balanced") == "zones/us-central1-b/diskTypes/pd-balanced"
+
+
+class TestNetworkNameFromId:
+    @pytest.mark.parametrize(
+        "network_id,expected",
+        [
+            ("net", "net"),
+            ("projects/p/global/networks/shared-net", "shared-net"),
+            ("https://www.googleapis.com/compute/v1/projects/p/global/networks/n", "n"),
+            ("projects/p/global/networks/n/", "n"),
+        ],
+    )
+    def test_extracts_trailing_name(self, network_id, expected):
+        assert _network_name_from_id(network_id) == expected
+
+
+class TestNetworkTags:
+    def test_network_tag(self):
+        assert _network_tag(42) == "shifter-range-42"
+
+    def test_subnet_tag(self):
+        assert _subnet_tag(42, "polaris") == "shifter-range-42-polaris"

--- a/shifter/engine/provisioner/tests/test_gcp_range_cell_resources.py
+++ b/shifter/engine/provisioner/tests/test_gcp_range_cell_resources.py
@@ -1,0 +1,200 @@
+"""Tests for GCE range-cell Compute Engine resource bodies.
+
+These render the ``*_resource=`` dicts passed to the Compute clients. Field names
+are the proto-plus (snake_case) message fields, including the quirks
+``I_p_protocol`` and ``network_i_p``. The functions are pure: given a plan and
+config they return a dict, with no cloud calls.
+"""
+
+from __future__ import annotations
+
+from config import GCERangeCellConfig, GCERangeImageProfile
+from gcp_range_cell_resources import (
+    HOST_PUBLIC_KEY_METADATA_KEY,
+    address_resource,
+    firewall_resource,
+    instance_resource,
+    network_resource,
+    subnetwork_resource,
+)
+
+
+def _plan() -> dict:
+    return {
+        "region": "us-central1",
+        "zone": "us-central1-b",
+        "private_google_access": True,
+        "labels": {"range": "shifter-range-42", "managed-by": "shifter"},
+        "network": {"name": "shifter-range-42", "self_link": "projects/p/global/networks/shifter-range-42"},
+    }
+
+
+def _instance(*, os_type: str = "kali") -> dict:
+    return {
+        "resource_name": "shifter-r-42-kali",
+        "address_name": "shifter-r-42-kali-ip",
+        "subnet_name": "polaris",
+        "subnetwork_link": "projects/p/regions/us-central1/subnetworks/sn",
+        "private_ip": "10.50.2.4",
+        "role": "attacker",
+        "os_type": os_type,
+        "tags": ["shifter-range-42", "shifter-range-42-polaris"],
+        "host_ssh_username": "ubuntu",
+        "profile": GCERangeImageProfile(
+            source_image="projects/kali/global/images/kali",
+            machine_type="e2-standard-4",
+            disk_size_gb=80,
+            disk_type="pd-ssd",
+        ),
+    }
+
+
+def _config(*, service_account_email: str = "") -> GCERangeCellConfig:
+    return GCERangeCellConfig(
+        project_id="test-project",
+        region="us-central1",
+        zone="us-central1-b",
+        network_mode="vpc-per-range",
+        service_account_email=service_account_email,
+    )
+
+
+class TestNetworkResource:
+    def test_disables_auto_subnets_and_uses_regional_routing(self):
+        body = network_resource(_plan())
+        assert body == {
+            "name": "shifter-range-42",
+            "auto_create_subnetworks": False,
+            "routing_config": {"routing_mode": "REGIONAL"},
+        }
+
+
+class TestSubnetworkResource:
+    def test_renders_cidr_region_and_pga_flag(self):
+        subnet = {
+            "resource_name": "shifter-r-42-polaris",
+            "network_link": "projects/p/global/networks/shifter-range-42",
+            "cidr": "10.50.2.0/28",
+        }
+        body = subnetwork_resource(_plan(), subnet)
+        assert body["name"] == "shifter-r-42-polaris"
+        assert body["ip_cidr_range"] == "10.50.2.0/28"
+        assert body["region"] == "us-central1"
+        assert body["private_ip_google_access"] is True
+
+
+class TestFirewallResource:
+    def test_ingress_with_allowed_translates_proto_fields(self):
+        firewall = {
+            "name": "shifter-r-42-allow-ssh",
+            "direction": "INGRESS",
+            "priority": 1000,
+            "target_tags": ["shifter-range-42"],
+            "source_ranges": ["10.40.0.0/20"],
+            "allowed": [{"IPProtocol": "tcp", "ports": ["22", "3389"]}],
+        }
+        body = firewall_resource(_plan(), firewall)
+        assert body["network"] == "projects/p/global/networks/shifter-range-42"
+        assert body["source_ranges"] == ["10.40.0.0/20"]
+        # IPProtocol -> I_p_protocol proto quirk.
+        assert body["allowed"] == [{"I_p_protocol": "tcp", "ports": ["22", "3389"]}]
+        assert "destination_ranges" not in body
+        assert "denied" not in body
+
+    def test_egress_with_denied_and_destination_ranges(self):
+        firewall = {
+            "name": "shifter-r-42-egress-deny",
+            "direction": "EGRESS",
+            "priority": 1100,
+            "target_tags": ["shifter-range-42"],
+            "destination_ranges": ["0.0.0.0/0"],
+            "denied": [{"IPProtocol": "all"}],
+        }
+        body = firewall_resource(_plan(), firewall)
+        assert body["destination_ranges"] == ["0.0.0.0/0"]
+        assert body["denied"] == [{"I_p_protocol": "all"}]
+        assert "source_ranges" not in body
+        assert "allowed" not in body
+
+
+class TestAddressResource:
+    def test_internal_address_body(self):
+        body = address_resource(_instance())
+        assert body == {
+            "name": "shifter-r-42-kali-ip",
+            "address_type": "INTERNAL",
+            "address": "10.50.2.4",
+            "subnetwork": "projects/p/regions/us-central1/subnetworks/sn",
+        }
+
+
+def _metadata_map(body: dict) -> dict[str, str]:
+    return {item["key"]: item["value"] for item in body["metadata"]["items"]}
+
+
+class TestInstanceResource:
+    def test_linux_instance_full_body(self):
+        body = instance_resource(
+            _plan(),
+            _instance(os_type="kali"),
+            _config(service_account_email="range-host@test-project.iam.gserviceaccount.com"),
+            ssh_public_key="ssh-ed25519 AAAAkey",
+            host_private_key_b64="Ym9ndXM=",
+            host_public_key="ssh-ed25519 AAAAhost",
+        )
+        assert body["machine_type"] == "zones/us-central1-b/machineTypes/e2-standard-4"
+        assert body["labels"]["subnet"] == "polaris"
+        assert body["labels"]["role"] == "attacker"
+        assert body["labels"]["range"] == "shifter-range-42"
+        assert body["tags"] == {"items": ["shifter-range-42", "shifter-range-42-polaris"]}
+        assert body["network_interfaces"][0]["network_i_p"] == "10.50.2.4"
+        disk = body["disks"][0]["initialize_params"]
+        assert disk["source_image"] == "projects/kali/global/images/kali"
+        assert disk["disk_size_gb"] == 80
+        assert disk["disk_type"] == "zones/us-central1-b/diskTypes/pd-ssd"
+        assert body["shielded_instance_config"]["enable_secure_boot"] is True
+        assert body["deletion_protection"] is False
+
+        meta = _metadata_map(body)
+        # Base config metadata carried through.
+        assert meta["block-project-ssh-keys"] == "true"
+        # Provisioned key installed for the host OS login user, not the participant.
+        assert meta["ssh-keys"] == "ubuntu:ssh-ed25519 AAAAkey"
+        assert meta[HOST_PUBLIC_KEY_METADATA_KEY] == "ssh-ed25519 AAAAhost"
+        # Linux host-key install runs as a startup-script, not the windows PS1 key.
+        assert "startup-script" in meta
+        assert "windows-startup-script-ps1" not in meta
+        assert "ssh_host_ed25519_key" in meta["startup-script"]
+
+        # service_account_email set -> service_accounts block present with scopes.
+        assert body["service_accounts"][0]["email"] == "range-host@test-project.iam.gserviceaccount.com"
+        assert body["service_accounts"][0]["scopes"] == ["https://www.googleapis.com/auth/cloud-platform"]
+
+    def test_windows_instance_uses_powershell_boot_script(self):
+        body = instance_resource(
+            _plan(),
+            _instance(os_type="windows"),
+            _config(),
+            ssh_public_key="ssh-ed25519 AAAAkey",
+            host_private_key_b64="Ym9ndXM=",
+            host_public_key="ssh-ed25519 AAAAhost",
+        )
+        meta = _metadata_map(body)
+        assert "windows-startup-script-ps1" in meta
+        assert "startup-script" not in meta
+        assert "administrators_authorized_keys" in meta["windows-startup-script-ps1"]
+
+    def test_no_service_account_and_no_host_keys(self):
+        body = instance_resource(
+            _plan(),
+            _instance(os_type="kali"),
+            _config(),
+            ssh_public_key="ssh-ed25519 AAAAkey",
+        )
+        meta = _metadata_map(body)
+        # No service account configured -> no service_accounts block.
+        assert "service_accounts" not in body
+        # No host key material -> no host pubkey entry and no startup-script.
+        assert HOST_PUBLIC_KEY_METADATA_KEY not in meta
+        assert "startup-script" not in meta
+        assert meta["ssh-keys"] == "ubuntu:ssh-ed25519 AAAAkey"

--- a/shifter/engine/provisioner/tests/test_gcp_range_cells.py
+++ b/shifter/engine/provisioner/tests/test_gcp_range_cells.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, call
@@ -173,6 +174,38 @@ def test_render_range_cell_plan_shared_vpc_uses_existing_network():
     # Per-range subnets are still created, but inside the shared VPC.
     assert plan["subnets"][0]["resource_name"] == "shifter-r-42-polaris"
     assert plan["subnets"][0]["network_link"] == "projects/test-project/global/networks/shared-range"
+
+
+def test_render_range_cell_plan_vpc_per_range_mints_own_network():
+    plan = render_range_cell_plan("req-123", _variables(), _sample_config())
+
+    # vpc-per-range mode: the range owns (creates/deletes) its own VPC.
+    assert plan["manage_network"] is True
+    assert plan["network"]["name"] == "shifter-range-42"
+    assert plan["network"]["self_link"] == "projects/test-project/global/networks/shifter-range-42"
+
+
+def test_render_range_cell_plan_private_google_access_adds_egress_hole():
+    config = dataclasses.replace(_sample_config(), private_google_access=True)
+
+    plan = render_range_cell_plan("req-123", _variables(), config)
+
+    firewall_names = {fw["name"] for fw in plan["firewalls"]}
+    assert "shifter-r-42-egress-googleapis" in firewall_names
+
+
+def test_render_range_cell_plan_rejects_subnet_without_uuid():
+    variables = {"range_id": 42, "subnets": [{"name": "polaris", "cidr": "10.50.2.0/28"}]}
+
+    with pytest.raises(RuntimeError, match="requires name and uuid"):
+        render_range_cell_plan("req-123", variables, _sample_config())
+
+
+def test_render_range_cell_plan_rejects_subnet_without_cidr_when_images_required():
+    variables = {"range_id": 42, "subnets": [{"name": "polaris", "uuid": "subnet-uuid"}]}
+
+    with pytest.raises(RuntimeError, match="requires a cidr"):
+        render_range_cell_plan("req-123", variables, _sample_config())
 
 
 def test_apply_shared_vpc_skips_network_create(mocker):


### PR DESCRIPTION
## Summary

- **What changed:** Added provisioner unit tests for the GCE range-cell backend modules that landed at 0% coverage.
- **Why:** The `dev` SonarCloud quality gate fails on **new-code coverage 74.4% (< 80%)**, which blocks the `dev` → `main` promotion PR #1480. Fixes #1483.

## Tests added

- `tests/test_gcp_range_cell_naming.py` — all naming/URI/label/tag helpers (sanitize, label, self-links, network/subnet tags) → **100%**.
- `tests/test_gcp_range_cell_resources.py` — network/subnetwork/firewall/address/instance resource bodies, the proto field-name quirks (`I_p_protocol`, `network_i_p`), Linux vs Windows boot scripts, host-key metadata, and the service-account branch → **100%**.
- `tests/test_gcp_range_cells.py` — added renders for the vpc-per-range plan (`manage_network`), the Private Google Access egress firewall, and subnet name/uuid/cidr validation errors.

## Verification

Local coverage on the target files:

```
gcp_range_cell_naming.py       31   0  100%
gcp_range_cell_resources.py    52   0  100%
gcp_range_cell_plan.py        174   8   95%
gcp_range_cells.py            153   6   96%
```

- `pytest tests/test_gcp_range_cell_naming.py tests/test_gcp_range_cell_resources.py tests/test_gcp_range_cells.py` → 60 passed
- Full `pytest (provisioner)` pre-commit hook → passed
- `ruff check` / `ruff format --check` → clean

This moves ~75 of the 291 uncovered new lines into covered, raising new-code coverage above the 80% gate.

## ADR Impact

- [x] No ADR impact