### PR TITLE
fix(iam): grant CI role read on scenario bake S3 buckets

### DIFF
--- a/changelog.d/1500.fixed.md
+++ b/changelog.d/1500.fixed.md
@@ -1,0 +1,1 @@
+Granted the GitHub Actions CI role read-only access to the scenario bake S3 buckets (`shifter-*-bake-*`). The polaris scenario bake verifies its operator-uploaded build tarball in the bake bucket, and the CI role's `data` policy previously scoped S3 to infra/state/user-storage/portal buckets only, so the check failed with an `AccessDenied`.

--- a/platform/terraform/global/iam/github-oidc.tf
+++ b/platform/terraform/global/iam/github-oidc.tf
@@ -559,6 +559,23 @@ resource "aws_iam_policy" "data" {
         ]
       },
       {
+        Sid    = "S3BakeBucketsRead"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject"
+        ]
+        # Scenario bake buckets (e.g. shifter-polaris-bake-<account>). The
+        # polaris bake verifies the operator-uploaded build tarball exists
+        # before standing up a golden range. Read-only: the operator uploads
+        # the tarball out of band and the range instance role (granted in
+        # scripts/polaris-aws-range) does the actual download.
+        Resource = [
+          "arn:aws:s3:::shifter-*-bake-*",
+          "arn:aws:s3:::shifter-*-bake-*/*"
+        ]
+      },
+      {
         Sid    = "S3UserStorage"
         Effect = "Allow"
         Action = ["s3:*"]


### PR DESCRIPTION
## Summary
The polaris scenario bake verifies its operator-uploaded build tarball in `s3://shifter-<env>-bake-<account>/`. The CI role's `data` managed policy scoped S3 to infra/state/user-storage/portal buckets only, so the check failed with `AccessDenied`.

Adds a read-only `S3BakeBucketsRead` statement (`s3:GetObject`/`s3:ListBucket` on `shifter-*-bake-*`). Read-only by design: the operator uploads the tarball out of band and the range instance role (granted in `scripts/polaris-aws-range`) does the actual download.

Applied to the proof `data` policy (targeted apply) to unblock the polaris bake now; this PR is the durable fix.

Closes #1500