### PR TITLE
fix(gcp): CORS on the assets bucket for browser signed-URL uploads

### DIFF
--- a/changelog.d/1551.fixed.md
+++ b/changelog.d/1551.fixed.md
@@ -1,0 +1,1 @@
+Add a CORS rule to the GCP assets bucket scoped to the deployment's public hostname so browser signed-URL uploads/downloads (XDR agent MSIs, experiment artifacts) pass preflight; previously the bucket returned no Access-Control-Allow-Origin and portal agent uploads failed.

--- a/platform/terraform/gcp/modules/platform-core/main.tf
+++ b/platform/terraform/gcp/modules/platform-core/main.tf
@@ -120,10 +120,11 @@ resource "google_compute_network_peering" "range_to_platform" {
 module "portal_gcs" {
   source = "../portal/gcs"
 
-  project_id    = var.project_id
-  region        = var.region
-  environment   = var.environment
-  common_labels = local.common_labels
+  project_id      = var.project_id
+  region          = var.region
+  environment     = var.environment
+  common_labels   = local.common_labels
+  public_hostname = local.normalized_public_hostname
 
   depends_on = [module.project_services]
 }

--- a/platform/terraform/gcp/modules/portal/gcs/main.tf
+++ b/platform/terraform/gcp/modules/portal/gcs/main.tf
@@ -39,4 +39,17 @@ resource "google_storage_bucket" "assets" {
     log_bucket        = google_storage_bucket.audit_logs.name
     log_object_prefix = "assets/"
   }
+
+  # Browser signed-URL uploads/downloads (XDR agent MSIs, experiment artifacts)
+  # are issued to the portal origin, so the bucket must answer CORS preflights or
+  # the PUT/GET is blocked. Scoped to the deployment's public hostname.
+  dynamic "cors" {
+    for_each = var.public_hostname == "" ? [] : [1]
+    content {
+      origin          = ["https://${var.public_hostname}"]
+      method          = ["GET", "HEAD", "PUT", "POST"]
+      response_header = ["Content-Type", "Content-MD5", "ETag", "x-goog-resumable"]
+      max_age_seconds = 3600
+    }
+  }
 }

--- a/platform/terraform/gcp/modules/portal/gcs/variables.tf
+++ b/platform/terraform/gcp/modules/portal/gcs/variables.tf
@@ -13,3 +13,9 @@ variable "environment" {
 variable "common_labels" {
   type = map(string)
 }
+
+variable "public_hostname" {
+  type        = string
+  default     = ""
+  description = "Portal public hostname; when set, the assets bucket allows CORS from https://<hostname> for browser signed-URL uploads/downloads."
+}


### PR DESCRIPTION
## Summary

Portal XDR-agent uploads issue a signed-URL `PUT` from the portal origin (`https://<public_hostname>`) directly to the GCS assets bucket. The bucket had no CORS config, so the browser preflight was rejected (no `Access-Control-Allow-Origin`) and uploads failed. Add a hostname-scoped CORS rule to the assets bucket so signed-URL uploads/downloads (agent MSIs, experiment artifacts) pass preflight.

## Requirement UIDs

- None (fresh-deploy defect; no requirement in scope). Part of #1387; closes #1551.

## Related Issues

Closes #1551

## ADR Impact

- No ADR required.

## Changes

- `modules/portal/gcs/main.tf`: add a `dynamic "cors"` block on the assets bucket (origin `https://<public_hostname>`, methods GET/HEAD/PUT/POST, Content-Type/Content-MD5/ETag/x-goog-resumable, max-age 3600); no-ops when `public_hostname` is unset.
- `modules/portal/gcs/variables.tf`: add `public_hostname` variable.
- `modules/platform-core/main.tf`: pass `local.normalized_public_hostname` to the gcs module.

## Test Plan

- [x] Applied the equivalent CORS live on `prod-ksqdkj-gcp-dev-assets`; portal agent upload preflight now passes.
- [x] `terraform fmt`/validate clean.

## Ground Control Checks

- [x] `make policy` unaffected.
- [x] CORS scoped to the deployment hostname (no wildcard origin).

## Traceability

- IMPLEMENTS: platform/terraform/gcp/modules/portal/gcs/main.tf
- TESTS: n/a (terraform config; verified by live apply + portal upload)

## Checklist

- [x] Changelog fragment at `changelog.d/1551.fixed.md`
