### PR TITLE
fix(aces): guard ACES_PACKAGE_ROOT default against IndexError in the container

### DIFF
--- a/changelog.d/1557.fixed.md
+++ b/changelog.d/1557.fixed.md
@@ -1,0 +1,1 @@
+Guard the default `ACES_PACKAGE_ROOT` path computation so it no longer raises `IndexError` in the deployed container (where the app tree is flattened to `/app`); the settings import and image build previously failed. Falls back to the app root when the source-tree depth is unavailable.

--- a/shifter/shifter_platform/config/_aces_settings.py
+++ b/shifter/shifter_platform/config/_aces_settings.py
@@ -48,7 +48,15 @@ ACES_NATIVE_PROVISIONING_ENABLED = os.environ.get("SHIFTER_ACES_NATIVE_PROVISION
 # the repo root so in-repo scenario packages (e.g. scenario-dev/...) resolve out
 # of the box; override per environment when packages live elsewhere. Read via the
 # literal os.environ.get form so config/env-manifest.json picks it up.
-ACES_PACKAGE_ROOT = os.environ.get("SHIFTER_ACES_PACKAGE_ROOT", str(Path(__file__).resolve().parents[3]))
+# In the source tree config/ sits at shifter/shifter_platform/config, so
+# parents[3] is the repo root (where in-repo scenario packages like scenario-dev/
+# live). In the deployed container the tree is flattened to /app, so parents[3]
+# does not exist; fall back to the app root instead of raising IndexError at
+# import (which would break every image build / settings load). The default is
+# only a starting point anyway — override SHIFTER_ACES_PACKAGE_ROOT per env.
+_aces_settings_parents = Path(__file__).resolve().parents
+_aces_default_package_root = _aces_settings_parents[3] if len(_aces_settings_parents) > 3 else _aces_settings_parents[1]
+ACES_PACKAGE_ROOT = os.environ.get("SHIFTER_ACES_PACKAGE_ROOT", str(_aces_default_package_root))
 
 # Days a runtime snapshot / operation-record row is retained before it becomes
 # eligible for pruning. Measured from the row's source_timestamp so idempotent

--- a/shifter/shifter_platform/config/env-manifest.json
+++ b/shifter/shifter_platform/config/env-manifest.json
@@ -488,7 +488,7 @@
       "source_file": "config/_aces_settings.py"
     },
     {
-      "default": "str(Path(__file__).resolve().parents[3])",
+      "default": "str(_aces_default_package_root)",
       "name": "SHIFTER_ACES_PACKAGE_ROOT",
       "source_file": "config/_aces_settings.py"
     },


### PR DESCRIPTION
## Summary

`config/_aces_settings.py` computed the default `ACES_PACKAGE_ROOT` as `Path(__file__).resolve().parents[3]` — the repo root in the source tree, but the deployed image flattens `shifter_platform` to `/app`, so `/app/config/_aces_settings.py` has only three parents and `parents[3]` raises `IndexError` at settings import. That breaks the portal image build (`manage.py compilemessages` / `collectstatic` load settings) and any container settings load — i.e. **dev is currently not deployable**.

Guard the index: use `parents[3]` when the path is deep enough (source tree → repo root, unchanged behaviour), else fall back to the app root. The default is only a starting point; `SHIFTER_ACES_PACKAGE_ROOT` overrides per environment. Regenerated `config/env-manifest.json` for the new default expression.

## Requirement UIDs

- None (deploy-blocking defect; no requirement in scope). Closes #1557.

## Related Issues

Closes #1557

## ADR Impact

- No ADR required.

## Changes

- `config/_aces_settings.py`: guard `parents[3]` with a length check, falling back to the app root.
- `config/env-manifest.json`: regenerated (default expression for `SHIFTER_ACES_PACKAGE_ROOT`).

## Test Plan

- [x] `test_env_manifest_is_current` passes (manifest regenerated).
- [x] Reproduced the container failure mode (3-parent path → previously `IndexError`, now falls back).

## Ground Control Checks

- [x] Settings import no longer raises in the flattened container layout.

## Traceability

- IMPLEMENTS: shifter/shifter_platform/config/_aces_settings.py
- TESTS: shifter/shifter_platform/tests/config/test_env_manifest.py

## Checklist

- [x] Changelog fragment at `changelog.d/1557.fixed.md`
