### PR TITLE
docs(adr): add ADR-033 product/dev surfaces and ADR-034 uniform content-ingestion contract

### DIFF
--- a/docs/adr/index.yaml
+++ b/docs/adr/index.yaml
@@ -1432,5 +1432,76 @@
       "shifter/shifter_platform/pyproject.toml",
       "shifter/shifter_platform/shared/aces/runtime_target.py"
     ]
+  },
+  {
+    "id": "ADR-033",
+    "title": "Product, distribution, and development surfaces",
+    "status": "accepted",
+    "scope": "repository",
+    "decision": "Shifter separates product (tenant), distribution, and development surfaces. A capability is product-plane if a bare operator tenant needs it to run or extend Shifter; such dual-use capabilities (content ingestion, image baking) are built once as product capabilities and produced by maintainers through that same path (dogfood), not as maintainer-bespoke implementations. The CI/build/deploy runner fleet is development-plane and must not live in a deploy-target account. Operator content acquisition and entitlement are resolved outside the platform.",
+    "rules": [
+      {
+        "id": "ADR-033-R1",
+        "description": "Capabilities a bare operator tenant needs to run or extend Shifter (including content ingestion and image baking) are product-plane; maintainers produce shipped/blessed artifacts through the same product capability rather than a maintainer-bespoke implementation.",
+        "checks": []
+      },
+      {
+        "id": "ADR-033-R2",
+        "description": "The CI/build/deploy runner fleet is development-plane and must not reside in a deploy-target account; environment deploy/bake uses ephemeral compute in the target tenant or maintainer-isolated infrastructure, so environment teardown never removes the deploy mechanism.",
+        "checks": []
+      },
+      {
+        "id": "ADR-033-R3",
+        "description": "Operator content acquisition and entitlement are resolved outside the platform; the platform contains no entitlement system (see ADR-034).",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": [
+      "agent-policy"
+    ],
+    "evidence": [
+      "docs/architecture/product-development-surfaces.md",
+      "docs/architecture/uniform-content-ingestion-contract.md",
+      "docs/adr/index.yaml"
+    ]
+  },
+  {
+    "id": "ADR-034",
+    "title": "Uniform content-ingestion contract",
+    "status": "accepted",
+    "scope": "repository",
+    "decision": "Content ingestion is one uniform, source-agnostic, entitlement-blind contract. The pack is the universal unit and the in-box catalog is not a privileged path. Image materialization is per-pack pull-or-bake (reference and/or recipe); packs may carry no images or parameterized experiment runs. Ingestion validates realizability against the backend manifest and surfaces non-realizability to the author without creating loopholes. Content is the source of truth and a published image is a cache.",
+    "rules": [
+      {
+        "id": "ADR-034-R1",
+        "description": "Registering a pack is a single source-agnostic, entitlement-blind operation; shipped, public, private, and self-authored packs use the identical import path and the in-box catalog is not a privileged path.",
+        "checks": []
+      },
+      {
+        "id": "ADR-034-R2",
+        "description": "Image materialization is per-pack pull-or-bake (reference and/or recipe); packs may carry zero images and may define parameterized experiment runs.",
+        "checks": []
+      },
+      {
+        "id": "ADR-034-R3",
+        "description": "Ingestion validates realizability against the backend manifest and does not create loopholes; non-realizable packs are flagged and surfaced to the author.",
+        "checks": []
+      },
+      {
+        "id": "ADR-034-R4",
+        "description": "Content is the source of truth and published images are a cache; private-distribution entitlement is handled at acquisition, not by a platform entitlement system.",
+        "checks": []
+      }
+    ],
+    "exceptions": [],
+    "enforcement": [
+      "agent-policy"
+    ],
+    "evidence": [
+      "docs/architecture/uniform-content-ingestion-contract.md",
+      "docs/architecture/product-development-surfaces.md",
+      "docs/adr/index.yaml"
+    ]
   }
 ]

--- a/docs/architecture/product-development-surfaces.md
+++ b/docs/architecture/product-development-surfaces.md
@@ -1,0 +1,116 @@
+# ADR-033: Product, distribution, and development surfaces
+
+## Status
+
+Accepted.
+
+## Date
+
+2026-07-11
+
+## Context
+
+Shifter is moving to OSS. Today there is no architectural distinction between
+the pipeline that *develops* Shifter and the pipeline that *stands up and runs*
+a Shifter environment. The maintainer CI/CD deploy path (GitHub Actions
+reusable workflows on a persistent fleet of self-hosted runners that live inside
+the deploy-target account, using the maintainers' GitHub org, OIDC federation,
+and secrets) is also the only way an environment comes up.
+
+That conflation has concrete failure modes:
+
+- The deploy mechanism is a resource *inside* the thing it deploys. Tearing down
+  an environment destroys the runners that would redeploy it, and those same
+  runners serve other environments (a GCP teardown can strip the fleet that
+  deploys AWS, and vice versa).
+- There is no path for an external operator who does not have the maintainers'
+  GitHub org, runner fleet, OIDC, or secrets.
+- Capabilities that an operator genuinely needs, most sharply **image baking**,
+  are implemented as maintainer-only CI constructs. Baking is not a
+  development-only concern: operators must bake to extend their own catalog, and
+  some shipped scenarios can never ship a pullable public image (licensed base
+  images, private scenario content, per-tenant secrets, size) and are therefore
+  bake-required in the operator's tenant. Baking is load-bearing product
+  surface, not a maintainer convenience.
+
+A clean split by "pipeline" is wrong in shape, because the most important
+capabilities are dual-use. The split has to be by **surface**, classifying each
+capability by whether a bare operator tenant needs it, and dual-use
+capabilities must be productized once and dogfooded, not reimplemented
+internally.
+
+## Decision
+
+Shifter recognizes three surfaces (planes), and every capability is assigned to
+one by a single test: **"does a bare operator tenant need this to run *or
+extend* Shifter?"**
+
+1. **Tenant / product plane.** Everything an operator needs to run and extend
+   Shifter in their own account with zero maintainer infrastructure: install and
+   bootstrap, run the platform, provision and destroy ranges, **bake images and
+   extend the catalog**, upgrade, and observe. Content ingestion and bake live
+   here.
+
+2. **Distribution plane.** The maintainer-to-public bridge that publishes the
+   consumable artifacts: platform container images, blessed scenario
+   packs/images (where they can be published), scenario content, and the
+   installer. Its governing principle is that **content is the source of truth
+   and a published image is a cache** of a bake; anything published can be
+   rebuilt from source.
+
+3. **Development / engineering plane.** Everything that only concerns evolving
+   Shifter's own code: CI build and test, PR gating, maintainer environments,
+   and the self-hosted runner fleet. Never shipped to operators, never required
+   by them.
+
+The following principles are binding:
+
+- **Dual-use capabilities are product-plane and maintainer-dogfooded.** A
+  capability an operator needs (baking, content ingestion) is built once as a
+  tenant-plane capability, and maintainers produce the shipped/blessed artifacts
+  by consuming that same capability. A maintainer-bespoke implementation of a
+  product capability is the anti-pattern this ADR exists to prevent; divergence
+  between the two is what produced the dev == deploy conflation.
+
+- **The CI runner fleet is development-plane and must not live in a
+  deploy-target account.** The mechanism that deploys or bakes for an
+  environment must never be a resource whose lifecycle is coupled to that
+  environment. Operator install/bake provisions its own ephemeral compute inside
+  the operator tenant; the maintainer runner fleet lives in maintainer/CI
+  infrastructure, isolated from the environments it acts on.
+
+- **Ingestion is entitlement-blind (see ADR-034).** Whether and how an operator
+  is entitled to a piece of content is resolved at *acquisition*, outside the
+  platform. The platform never contains an entitlement system.
+
+This ADR defines and enforces the surface boundary. The existing execution
+programs run *under* it: ACES Backend (ADR-024), Backend Bundles & Substrate
+(ADR-011, and the substrate-interface work in issue #1322), and Workspaces &
+Platform API. Program tracking issue: #1584.
+
+## Consequences
+
+- Baking and content ingestion are first-class product capabilities that must
+  work in a bare operator tenant; they are not deferred to a maintainer path.
+- The maintainer runner fleet is relocated out of deploy-target accounts
+  (#1437), so environments can be wiped and rebuilt without touching CI, and CI
+  never spans one environment's teardown into another's outage.
+- Distribution gains explicit public and private tiers whose entitlement is
+  handled out-of-band, and container-first distribution is preferred because VM
+  images (AMIs/GCP images/qcow2) are region/project-scoped and lean toward
+  bake-in-tenant for the long tail.
+- Maintainers accept a dogfood obligation: the blessed catalog is produced
+  through the product bake/ingestion path, not a separate internal one.
+- This is a framing/policy ADR; it introduces no CI check of its own yet.
+  Downstream issues under #1584 operationalize it and may add enforceable rules
+  in later ADRs.
+
+## Alternatives considered
+
+- **Keep one pipeline, document an operator path on top.** Rejected: leaves the
+  deploy mechanism coupled to the environment and provides no productized bake
+  or ingestion, so operators still cannot extend a tenant.
+- **Treat baking as development-only and pre-publish every image.** Rejected:
+  some shipped scenarios can never ship a public image, and operators must be
+  able to bake their own content, so in-tenant bake is unavoidable product
+  surface.

--- a/docs/architecture/uniform-content-ingestion-contract.md
+++ b/docs/architecture/uniform-content-ingestion-contract.md
@@ -1,0 +1,105 @@
+# ADR-034: Uniform content-ingestion contract
+
+## Status
+
+Accepted.
+
+## Date
+
+2026-07-11
+
+## Context
+
+An operator running a packaged Shifter tenant must be able to add new images to
+the runtime catalog, import scenario packs (see `../aces-scenario-packs` for the
+pack format), and author their own scenarios. Today these read as three
+different mechanisms, and the shipped catalog is loaded through a privileged
+in-box path distinct from how an operator would add anything.
+
+Several facts constrain the design:
+
+- **Provenance is diverse and mostly irrelevant to the platform.** Content may
+  ship in-box, come from a public source Shifter hosts, be licensed/private, or
+  be authored by the operator. Whether an operator is *entitled* to a piece of
+  content is a question resolved at acquisition, outside the platform. Only if
+  the platform itself auto-fetches gated content does a credential enter, and
+  even then it is operator-supplied config (like a private registry login), not
+  an entitlement system the platform owns.
+- **Trust is a separate axis from entitlement.** Once content is in hand, the
+  platform does care whether a pack is authentic and safe to run (it bakes
+  images and runs privileged content). That is optional signing/verification, a
+  trust signal keyed on the producer, not an access gate keyed on the operator.
+- **Not every pack has images.** Some packs are structure only; large parts of
+  an experiment (the multi-run unit of a scenario) are parameterized, with
+  images supplied per run or not at all.
+- **We do not create loopholes in ACES.** If a scenario requires an image or
+  capability the backend cannot provide, that scenario is not realizable, and
+  the author should be told, ideally in the scenario editor, rather than
+  discovering it at provision time.
+- Image distribution is asymmetric: container images distribute globally via a
+  public registry, while VM images are region/project-scoped and expensive to
+  host and cross-copy.
+
+## Decision
+
+Content ingestion is one uniform contract, governed by the surface separation in
+ADR-033.
+
+- **The pack is the universal unit.** "Add an image to the catalog," "import a
+  scenario pack," and "author a scenario" are the same operation: register a
+  pack. The in-box catalog is simply the packs that ship by default; it is not a
+  privileged path.
+
+- **Import is source-agnostic and entitlement-blind.** The ingestion path is
+  identical for shipped, public, private, and self-authored packs. The platform
+  never asks how the operator obtained a pack. Adding content is *just a content
+  update*; how the operator got it is out of scope.
+
+- **Materialization is per-pack pull-or-bake.** Each image a pack needs carries
+  a reference (pull) and/or a bake recipe (build). At provision time the tenant
+  pulls a published image when one is available for its cloud/region, otherwise
+  bakes it in-tenant from the recipe. Pull-vs-bake is a property of the pack, not
+  a global mode; a pack may offer both.
+
+- **Packs may carry no images and may define parameterized experiment runs.**
+  Ingestion, the catalog, and realizability treat "image-bearing" as optional.
+
+- **Ingestion validates realizability against the backend manifest.** A pack
+  that a conformant Shifter backend cannot realize is flagged (no silent
+  loopholes) and surfaced to the author (the scenario editor is the natural
+  place). This uses the ACES backend manifest and realizability ledger.
+
+- **Content is the source of truth; a published image is a cache.** Distribution
+  (ADR-033) publishes finished images as a convenience over the real artifact
+  (content + recipe). Public and private distribution tiers differ only in where
+  the output is served; entitlement for the private tier is handled out-of-band,
+  and trust/verification is an orthogonal, optional signal.
+
+## Consequences
+
+- One ingestion path serves operators and maintainers; the shipped catalog loads
+  through it (dogfooding, per ADR-033).
+- The pack schema must express, per image, a reference and/or a bake recipe, and
+  must allow zero images and parameterized runs.
+- Realizability becomes a first-class, author-visible check, wired from the
+  manifest/ledger into the scenario editor.
+- The platform carries no entitlement system; private content is gated at
+  acquisition. In-platform pull-through, if added, consumes an operator-supplied
+  credential only.
+- This contract is realized by the issues under program #1584 and cross-links
+  the REV1.2 realizability ledger (#1563) and object-storage package sources
+  (#1567), and the ACES catalog/registry work under ADR-024 (#1252, #1253,
+  #1254). It builds on backend bundles (ADR-011) and the substrate interface
+  (#1322).
+
+## Alternatives considered
+
+- **Distinct paths for shipped vs. imported vs. authored content.** Rejected:
+  privileges the in-box catalog, blocks turnkey operator extension, and
+  duplicates logic.
+- **A platform-owned entitlement system for private content.** Rejected:
+  entitlement is an acquisition/business concern; embedding it couples the
+  product to a licensing system and violates entitlement-blind ingestion.
+- **Global "ship images" or global "ship content-to-bake" policy.** Rejected in
+  favor of per-pack pull-or-bake, because image types distribute asymmetrically
+  and some packs cannot ship a pullable image at all.


### PR DESCRIPTION
## Summary

Add the two north-star ADRs that separate Shifter's product surface (what an operator tenant runs and extends) from the distribution (maintainer->public) and development (CI/build/test) surfaces, and define how content enters a tenant. Contract-first foundation for program #1584 (Product & Development Surfaces); blocks the rest of that program.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1577

## ADR Impact

- ADR-033
- ADR-034

## Changes

- Add docs/architecture/product-development-surfaces.md (ADR-033): three planes (tenant/product, distribution, development); classification test; dogfood principle; CI runner fleet is dev-plane and never in a deploy-target account; content-ingestion and bake are product surface; ingestion is entitlement-blind.
- Add docs/architecture/uniform-content-ingestion-contract.md (ADR-034): pack = universal unit; source-agnostic, entitlement-blind import; per-pack pull-or-bake; packs may carry no images / parameterized experiment runs; realizability validated against the backend manifest; content is truth, published image is a cache.
- Register ADR-033 and ADR-034 in docs/adr/index.yaml (additions-only; existing entries untouched).

## Test Plan

- Unit tests / integration tests: N/A — docs-only change (two ADR documents + registry entries)
- `python3 scripts/adr_guard/adr_guard.py --checks adr-registry guardrail-docs no-agent-attribution no-live-cloud-identifiers documentation-coverage --all` passes

## Ground Control Checks

- [x] ADR guard passes (adr-registry, guardrail-docs, no-agent-attribution, no-live-cloud-identifiers, documentation-coverage)
- [x] No live cloud identifiers or secrets introduced
- [x] Existing ADR entries untouched (index.yaml diff is additions-only)

## Traceability

- IMPLEMENTS: (none — architecture/decision-record run)
- TESTS: (none — documentation run)

## Checklist

- [x] Follows the repo ADR format (docs/architecture narrative + docs/adr/index.yaml registry)
- [x] ADRs cross-reference related decisions (ADR-011, ADR-024) and the substrate work (#1322)
- Changelog fragment: N/A — docs-only change
- [x] Architectural decisions recorded under program #1584
