### PR TITLE
docs(aws): sweep broader teardown leftovers in the runbook

### DIFF
--- a/docs/architecture/aws-dirty-account-lifecycle-preflight-1472.md
+++ b/docs/architecture/aws-dirty-account-lifecycle-preflight-1472.md
@@ -1,0 +1,227 @@
+# AWS Dirty-Account Lifecycle Preflight (#1472)
+
+Status: pre-implementation guidance
+
+Date: 2026-07-13
+
+Tracking issue: <https://github.com/Brad-Edwards/shifter/issues/1472>
+
+> **Decision (2026-07-13).** #1472 ships as a runbook-only fix: an active
+> post-destroy leftover sweep folded into `docs/dev/aws-teardown-runbook.md`,
+> matching how #1431 / #1425 closed the earlier teardown gaps. The automated
+> bootstrap-CLI recovery command described below (the extensibility seam and its
+> safety constraints) is deferred to **#1618**, and complements #1287. The rest
+> of this note stands as the design record for that follow-up.
+
+## Scope Boundary
+
+Issue #1472 is the shipping contract: an AWS environment that was previously
+deployed and incompletely torn down must be deployable again without hand-run
+AWS cleanup. The reported residue spans the Core and Portal Terraform roots:
+Budgets, RDS parameter/subnet groups, ElastiCache subnet groups, EventBridge
+Scheduler schedules, portal SSM parameters, the CTFd EC2 key pair, RDS event
+subscriptions, and security groups.
+
+This is environment-infrastructure lifecycle work. It is not application range
+teardown, runtime reconciliation, or a reason to add Django schemas, services,
+repositories, exceptions, or APIs. Issue #1431 owns the separate `global/iam`
+bootstrap residue. Issue #1287 tracks turning the AWS teardown runbook into a
+first-class destroy workflow; #1472 may build on that work, but must not create a
+second teardown orchestration model.
+
+## Architecture Decisions
+
+- Terraform state remains the authoritative ownership and dependency graph.
+  With usable state, fix and run the existing reverse-order destroy: Portal,
+  Range, Core, followed by the separately owned runner and `global/iam` roots as
+  documented in `docs/dev/aws-teardown-runbook.md`. Do not replace normal
+  `terraform destroy` with a catalog of AWS CLI deletes.
+- Dirty-account recovery is a narrow fallback for resources whose state is
+  absent. It must be implemented through the existing `scripts/bootstrap` CLI
+  support layer, not duplicated as workflow YAML or a standalone shell script.
+  Local and CI entrypoints, if both are exposed, must call the same Python
+  operation.
+- Discovery is read-only by default. Mutation requires an explicit recovery or
+  teardown action, the resolved AWS account id and region in the summary, the
+  selected `dev|proof|prod` environment, and the existing interactive
+  confirmation convention. A headless path must require an equally explicit
+  opt-in; merely naming an environment is not destructive authorization.
+- A same name is a lookup key, not ownership proof. An orphan may be mutated
+  only when its identity is derived from the canonical Terraform naming and the
+  strongest available ownership evidence agrees: account, region (or explicit
+  global scope), environment, expected VPC/dependencies, and
+  `Project=shifter`, matching `Environment`, and `ManagedBy=terraform` tags
+  where the resource supports tags. Missing or conflicting evidence fails
+  closed and reports names/IDs only.
+- Prefer deletion and clean recreation for replaceable control-plane residue
+  when state is gone. Adoption/import is allowed only for an explicitly mapped
+  Terraform address after compatibility checks show that preserving the object
+  is intentional and safe. Never auto-import a security group merely because
+  its name matches: unmanaged rules and a wrong VPC turn adoption into a
+  network-policy bypass. Never auto-delete or auto-adopt a live database,
+  snapshot, secret value, KMS key, bucket contents, or other data-bearing
+  resource under this issue.
+- The Portal Parameter Store boundary is exactly
+  `/shifter/<env>/portal/`. Terraform owns most names through
+  `modules/portal/ssm`; `_shifter-platform.yml` also writes `image-digest` and
+  the optional bootstrap-admin parameters and updates Terraform's `image-tag`.
+  Teardown/recovery may enumerate and delete parameter *names* below that exact
+  prefix without reading values. It must preserve `/shifter/ami/*` and every
+  other environment's prefix.
+- Recovery is convergent and retry-safe. “Absent” is success, dependency or
+  eventual-consistency failures use bounded retries, and a partial run can be
+  rerun. Dependency order must be explicit where AWS requires it: consumers
+  before subnet/parameter groups and security groups; schedule before its role;
+  RDS event subscription before its topic/key teardown; SSM prefix cleanup only
+  after Portal workloads are stopped.
+- No new ADR is required. These constraints apply the repository's existing
+  Terraform ownership, environment binding, least-privilege, and bootstrap CLI
+  decisions. A future implementation that creates a new general account
+  adoption policy, weakens ownership evidence, or adds a destructive CI
+  workflow is architecture work and must update the ADR registry in that
+  change.
+
+## Canonical Incumbents To Reuse
+
+| Concern | Canonical incumbent | Guardrail for #1472 |
+| --- | --- | --- |
+| Stack ownership/order | `platform/terraform/environments/{dev,proof,prod}`, their `portal` and `range` roots; `docs/dev/aws-terraform-apply-order.md`; `docs/dev/aws-teardown-runbook.md` | Preserve the existing root/state-key boundaries and reverse dependency order. Do not duplicate resource definitions in cleanup code. |
+| CLI orchestration | `scripts/bootstrap/cli.py`, compatibility facade `deploy.py`, focused modules such as `terraform_deploy.py`, and `bootstrap_core.run_cmd` | Add one focused lifecycle operation behind the existing CLI conventions, dry-run/reporting, confirmations, subprocess redaction, and tests. Do not grow the facade with implementation logic. |
+| Account/env identity | `BootstrapConfig`, `AWS_ENVIRONMENTS`, `get_aws_account_id()`, and `scripts/bootstrap/preflight.py` | Reuse `dev|proof|prod`, `us-east-2`, AWS profile handling, caller-identity lookup, and fail-safe prerequisite reporting. Do not add a second environment parser. |
+| Backend/state mapping | `scripts/bootstrap/terraform_backend.py` and `scripts/terraform/render_aws_backend_configs.py` | Resolve the existing backend and stack keys; do not guess state locations or introduce another registry. |
+| Ownership/naming | AWS provider `default_tags`, environment `terraform.tfvars`, module `common_tags`, and `docs/technical/dev/terraform.md` | Derive expected names from Terraform inputs and require tags/dependency context where supported. Keep prod's naming differences explicit. |
+| Reported Core residue | `aws_budgets_budget.s3_cost_alert` in each environment Core root | Treat AWS Budgets as account/global-service scoped even though the provider runs in `us-east-2`; select the exact environment budget name, never all Shifter-looking budgets. |
+| Reported Portal residue | `modules/portal/{rds,redis,cognito,ssm,ctfd,backup-alerts}`, `modules/guacamole/{rds,security}`, plus Portal VPC/EC2/ALB security groups | Terraform resources and their module inputs are the resource contract. Recovery code may map exceptional residue to these existing addresses but must not create parallel resource schemas. |
+| Workflow-owned SSM names | `.github/workflows/_shifter-platform.yml` (`PS_PREFIX`, image digest/tag, optional bootstrap-admin parameters) | Include these exact non-Terraform writes in the Portal prefix cleanup; keep secret values out of discovery, logs, argv, and reports. |
+| Deletion-protection/stalls | `docs/architecture/network-firewall-delete-protection-preflight-934.md` and the teardown runbook's protection, bucket, ENI, log-group, and ECR ordering | Converge protection off before destroy and preserve existing special ordering. Do not use state removal as the ordinary solution. |
+| IaC validation | `platform/terraform/validation-inventory.yaml`, `.tflint.hcl`, `platform/terraform/.checkov.yaml`, `_quality.yml`, `scripts/adr_guard` | Keep every root in the canonical inventory and all checks blocking. New exceptions still require an owner, rationale, and expiry in `docs/adr/exceptions.yaml`. |
+
+No controller, DTO, persistence repository, or application exception incumbent is
+applicable: this path ends at the operator CLI, Terraform, and AWS APIs.
+Application range lifecycle services and provisioner Terraform are separate
+ownership domains and must not be reused for environment teardown.
+
+## Cross-Cutting Layers The Design Must Pass
+
+- **Authentication/authorization:** local execution uses the selected AWS CLI
+  profile; CI continues to use GitHub OIDC and the environment-specific deploy
+  role. Before mutation, call STS and display the account id. Do not add static
+  AWS credentials, broaden the deploy-role policy without evidence, or let a
+  GitHub event implicitly authorize destruction. GitHub runner deregistration
+  remains its separate token lifecycle from the teardown runbook.
+- **Secret handling:** SSM recovery calls list names and delete by name; they do
+  not call `GetParameter(s)` with decryption. Secrets Manager values, Terraform
+  secret outputs/state, tfvars payloads, GitHub secrets, registration tokens,
+  and database credentials must never enter reports. Reuse `run_cmd`'s logging
+  and redaction conventions. Pass structured argv; do not interpolate secrets
+  into shell strings or process argv. The environment prefix and AWS resource
+  IDs are non-secret but should still be bounded in log volume.
+- **Environment/config shape:** `AWS_ENVIRONMENTS`, `BootstrapConfig`, Terraform
+  typed variables/validations, existing tfvars overlays, and
+  `terraform_backend.py` remain canonical. Recovery accepts the same env,
+  profile, region, bucket/backend, and dry-run/headless shapes; it does not add
+  `shifter.yaml`, Django settings, SSM runtime configuration, or a generic
+  `environment_mode` toggle.
+- **Ownership/policy validation:** Terraform provider validation, tags, exact
+  name derivation, VPC/dependency checks, and the resource-specific compatibility
+  check all run before mutation. Security-group recovery verifies VPC plus tag
+  ownership and refuses unexpected attachments/rules; it never weakens ingress
+  or egress to make deletion succeed. SSM is constrained to the exact
+  environment Portal prefix.
+- **OS/process exposure:** use subprocess argument lists through the existing
+  helper. Do not use `shell=True`, generated executable scripts, command strings
+  containing credentials/config blobs, world-readable temp files, or local
+  files under the repository for backend/tfvars material. Continue using the
+  per-instance config directory outside the checkout and runner temp paths in
+  CI.
+- **Errors and observability:** operator failures use the existing
+  `info/warn/error/success` CLI surface and non-zero exit behavior. Report a
+  per-resource action (`kept`, `absent`, `would-delete`, `deleted`, `blocked`,
+  `failed`) plus account/env/region and a final count; redact values and raw AWS
+  response bodies. Terraform/provider failures remain Terraform failures. Do
+  not introduce Django/API error envelopes or a parallel exception hierarchy.
+- **Workflow and concurrency:** preserve deploy workflow concurrency and
+  environment gates. A future destroy workflow must be manually dispatched,
+  environment-protected, non-cancellable during Terraform mutation, and a thin
+  caller of the same lifecycle code—not inline resource cleanup duplicated in
+  YAML.
+
+## Extensibility Seam
+
+The required seam is the existing environment/stack boundary plus a small,
+resource-specific recovery operation: environment, account id, region, and
+dry-run/mutate intent are inputs; each exceptional resource handler owns its
+identity, ownership proof, dependency check, and idempotent delete/import
+behavior. Shared command execution and reporting belong in the bootstrap
+support layer.
+
+Do not create a second manifest that copies every Terraform resource. Add a
+handler only for a provider resource class that demonstrably survives normal
+destroy or for a non-Terraform write such as workflow-owned SSM parameters. The
+next residue type should be addable without editing environment-specific
+workflow YAML or cloning the whole orchestration path.
+
+## Gotchas And Anti-Patterns
+
+- `terraform destroy` does not update deletion-protection attributes first.
+  Apply the owning root with protection disabled before destroy.
+- Destroy success does not prove absence: AWS services can recreate log groups,
+  Lambda ENIs can delay subnet/SG removal, and eventual consistency can make a
+  just-deleted global name appear occupied. Verify absence with bounded polling.
+- Terraform-managed SSM parameters and workflow-written parameters share one
+  prefix. Cleaning only the module misses deployment parameters; recursively
+  deleting `/shifter/*` destroys shared AMI references and other environments.
+- `image-tag` is Terraform-owned but intentionally updated by the deploy
+  workflow with `ignore_changes`. Do not “fix” that dual writer as part of this
+  issue; teardown only needs to remove the parameter after workloads stop.
+- Importing an object transfers lifecycle authority to Terraform. Never import
+  without an exact resource address, compatibility check, and a post-import
+  plan showing no unexpected security or data mutation.
+- `terraform state rm` abandons an object and is not cleanup. Keep it limited to
+  documented `prevent_destroy` exceptions that intentionally survive; do not
+  use it to make the destroy command green.
+- Do not discover by broad substring (`contains(name, "shifter")`) and delete
+  the results. Prod/non-prod naming differs, some AWS resources are untaggable,
+  and a previously used account may contain unrelated installations.
+- Do not swallow AWS errors with `|| true`. Only an explicit not-found response
+  is success; authorization, throttling exhaustion, dependency, and ownership
+  failures remain blocking and visible.
+- Do not place cleanup logic in `_shifter-platform.yml`, copy the same logic into
+  all three environment roots, or add lifecycle behavior to Portal application
+  services. These create duplicate workflow logic and concept confusion.
+
+## Non-Goals And Implementation Boundaries
+
+- No application range/NGFW cleanup, provisioner state reconciliation, CMS/CTF
+  lifecycle behavior, database migration, model, serializer, API, or UI change.
+- No global IAM/OIDC/boundary-policy fix from #1431, and no change to GitHub
+  runner registration-token handling.
+- No automatic deletion of databases, snapshots, secrets, KMS keys, buckets or
+  bucket contents, AMIs, `/shifter/ami/*`, or resources belonging to another
+  environment/account/VPC.
+- No attempt to make arbitrary third-party or manually created same-name
+  infrastructure adoptable. Ambiguous ownership is a blocker, not a heuristic.
+- No generic cloud-neutral lifecycle framework and no GCP behavior change.
+- No weakening of deletion protection, network policy, Terraform checks,
+  Checkov, TFLint, actionlint, ADR guard, environment protections, or deploy
+  concurrency.
+
+## Validation Expectations For The Implementation
+
+Unit tests should exercise discovery/classification, exact prefix/name bounds,
+ownership conflicts, dry-run, confirmation/headless gates, not-found
+idempotency, pagination, bounded retry, partial failure, redaction, and
+environment/account separation with injected command results—never live AWS.
+Add a disposable-account acceptance sequence that proves create, destroy,
+absence verification, recreate, plus a seeded verified-orphan recovery case.
+
+Run the repository-required architecture and Terraform checks:
+
+```bash
+python3 scripts/adr_guard/adr_guard.py --all --level ci
+TFLINT_CONFIG="$(pwd)/.tflint.hcl"; cd platform/terraform && tflint --recursive --config "$TFLINT_CONFIG"
+```
+
+Also run the bootstrap unit suite, Terraform formatting and validation for each
+affected root from `platform/terraform/validation-inventory.yaml`, and Checkov.
+If workflow YAML changes, run `actionlint`.

--- a/docs/dev/aws-teardown-runbook.md
+++ b/docs/dev/aws-teardown-runbook.md
@@ -148,6 +148,89 @@ These recur on a full portal destroy and are safe to resolve directly:
     --output text); do aws logs delete-log-group --log-group-name "$lg"; done
   ```
 
+### Broader leftover sweep (resources that block a fresh apply)
+
+The env stacks manage every resource below, so a clean `terraform destroy`
+removes them. They survive only when a stack destroy is abandoned partway (see
+the stalls above) or the `{uuid}` state bucket is deleted before a complete
+destroy, which orphans the live resource. A later fresh bootstrap starts from
+empty state and collides (`AlreadyExists` / `ResourceAlreadyExistsException`).
+This is the #1472 leftover set. Run this sweep after the Portal/Range/Core
+destroys report success. Discovery is read-only; delete only what the discovery
+lists. Set the environment and account first:
+
+```bash
+ENV=<env>                                                   # dev | proof | prod
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+```
+
+`aws ... --query` uses JMESPath single-quote string literals so the surrounding
+double-quoted shell string does not trigger backtick command substitution.
+
+- **AWS Budgets** (`shifter-<env>-s3-cost-alert`, account-scoped, Core stack):
+  ```bash
+  aws budgets describe-budgets --account-id "$ACCOUNT_ID" \
+    --query "Budgets[?starts_with(BudgetName, 'shifter-$ENV-')].BudgetName" --output text
+  aws budgets delete-budget --account-id "$ACCOUNT_ID" --budget-name "shifter-$ENV-s3-cost-alert"
+  ```
+- **RDS DB parameter groups** (`<env>-portal-postgres-pg`, `<env>-portal-guacamole-postgres-pg`):
+  ```bash
+  aws rds describe-db-parameter-groups \
+    --query "DBParameterGroups[?starts_with(DBParameterGroupName, '$ENV-portal')].DBParameterGroupName" --output text
+  aws rds delete-db-parameter-group --db-parameter-group-name <name>
+  ```
+- **RDS DB subnet groups** (`<env>-portal-db-subnet`, `<env>-portal-guacamole-db-subnet`):
+  ```bash
+  aws rds describe-db-subnet-groups \
+    --query "DBSubnetGroups[?starts_with(DBSubnetGroupName, '$ENV-portal')].DBSubnetGroupName" --output text
+  aws rds delete-db-subnet-group --db-subnet-group-name <name>
+  ```
+- **ElastiCache subnet group** (`<env>-portal-redis`):
+  ```bash
+  aws elasticache describe-cache-subnet-groups \
+    --query "CacheSubnetGroups[?starts_with(CacheSubnetGroupName, '$ENV-portal')].CacheSubnetGroupName" --output text
+  aws elasticache delete-cache-subnet-group --cache-subnet-group-name "$ENV-portal-redis"
+  ```
+- **EventBridge Scheduler schedules** (`<env>-portal-cognito-rotation-reminder`; the
+  dev-box `shifter-dev-box-nightly-shutdown` only if the `global/dev-box` stack was
+  applied and you are retiring it):
+  ```bash
+  aws scheduler list-schedules \
+    --query "Schedules[?starts_with(Name, '$ENV-portal')].Name" --output text
+  aws scheduler delete-schedule --name <name>
+  ```
+- **SSM parameters** under `/shifter/<env>/portal` (~38). Enumerate names only; do
+  not print values. The range AMI params live under `/shifter/ami/*` and are
+  outside this path, so they are preserved:
+  ```bash
+  aws ssm get-parameters-by-path --path "/shifter/$ENV/portal" --recursive \
+    --query 'Parameters[].Name' --output text | tr '\t' '\n' | \
+    while read -r p; do [ -n "$p" ] && aws ssm delete-parameter --name "$p"; done
+  ```
+- **EC2 key pairs** (`<env>-portal-ctfd-ssh`):
+  ```bash
+  aws ec2 describe-key-pairs \
+    --filters "Name=tag:Project,Values=shifter" "Name=tag:Environment,Values=$ENV" \
+    --query "KeyPairs[?starts_with(KeyName, '$ENV-portal')].KeyName" --output text
+  aws ec2 delete-key-pair --key-name "$ENV-portal-ctfd-ssh"
+  ```
+- **RDS event subscriptions** (`<env>-portal-db-backup-events`):
+  ```bash
+  aws rds describe-event-subscriptions \
+    --query "EventSubscriptionsList[?starts_with(CustSubscriptionId, '$ENV-portal')].CustSubscriptionId" --output text
+  aws rds delete-event-subscription --subscription-name "$ENV-portal-db-backup-events"
+  ```
+- **Security groups** (`<env>-portal*`, tagged `Project=shifter`). A leftover SG
+  usually lingers because an ENI still references it (the redis rotation SG stall
+  above is the common case); delete it once the ENI is gone. Never delete a VPC
+  `default` SG:
+  ```bash
+  aws ec2 describe-security-groups \
+    --filters "Name=tag:Project,Values=shifter" "Name=tag:Environment,Values=$ENV" \
+    --query "SecurityGroups[?GroupName!='default' && starts_with(GroupName, '$ENV-portal')].[GroupId,GroupName]" --output text
+  aws ec2 delete-security-group --group-id <sg-id>
+  ```
+
 ## 4. Destroy the runner root and deregister runners
 
 ```bash
@@ -206,6 +289,11 @@ secrets (`AWS_ROLE_ARN`, `TF_INFRA_STATE_BUCKET`, `TF_VARS_PROD_PORTAL`,
 Confirm no residual EC2, ASG, RDS, ALB, Network Firewall, ECR, IAM
 `github-actions-shifter-*` roles, `shifter-<env>-*` policies, OIDC provider,
 `<env>-range` / `/vpc/` CloudWatch log groups, or `{uuid}` state bucket remain
-before a fresh bootstrap. Preserve
-only what you intend to reuse (for example range AMIs and their `/shifter/ami/*`
-SSM parameters).
+before a fresh bootstrap. Also confirm the §3 broader leftover set is gone: the
+`shifter-<env>-s3-cost-alert` budget, `<env>-portal*` RDS DB parameter and subnet
+groups, the `<env>-portal-redis` ElastiCache subnet group, `<env>-portal*`
+EventBridge Scheduler schedules, `/shifter/<env>/portal` SSM parameters,
+`<env>-portal*` EC2 key pairs, the `<env>-portal-db-backup-events` RDS event
+subscription, and `<env>-portal*` security groups. If any remain, re-run the §3
+broader leftover sweep. Preserve only what you intend to reuse (for example range
+AMIs and their `/shifter/ami/*` SSM parameters).


### PR DESCRIPTION
## Summary

- **What changed:** Extend `docs/dev/aws-teardown-runbook.md` with an active post-destroy "Broader leftover sweep" (§3) — read-only discovery followed by narrowly scoped deletion — for the shifter-owned resource types a fresh bootstrap collides on, and make the §8 verify-empty step actively cover the same set.
- **Why:** A from-zero stand-up into a previously-used ("dirty") AWS account collides on leftovers that survive an abandoned/partial `terraform destroy` (the runbook already documents several portal-destroy stalls) or a state-bucket deletion that orphaned state: AWS Budgets, RDS DB parameter/subnet groups, ElastiCache subnet groups, EventBridge Scheduler schedules, ~38 `/shifter/<env>/portal` SSM parameters, EC2 key pairs, RDS event subscriptions, and security groups. All are Terraform-managed and named deterministically, so a clean destroy removes them; the sweep is the safety net when a destroy is incomplete. Goal: a fresh deploy into a dirty account with zero manual cleanup. Mirrors how #1431 / #1425 folded teardown-leftover gaps into the same runbook.

Each command keys on the resources' real names/tags, uses JMESPath single-quote literals to avoid shell backtick command substitution, bounds SSM cleanup to `/shifter/<env>/portal` (enumerating names, not values) while preserving `/shifter/ami/*`, and scopes the security-group sweep to `<env>-portal*` (never the VPC `default` SG).

Requirement UIDs: none (requirement-free maintenance; the teardown mechanism is the runbook itself).

## ADR Impact

- [x] No ADR impact

The codex architecture preflight (committed as `docs/architecture/aws-dirty-account-lifecycle-preflight-1472.md`) confirmed no ADR update is needed: this applies existing ownership, lifecycle, and bootstrap conventions.

## Guardrail Changes

- [x] No guardrail files changed

## Verification

- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci`
- [x] Vale docs prose-lint clean on the changed Markdown
- [ ] Relevant tests — N/A (docs-only)
- [x] Docs updated where behavior or enforcement changed

## Ground Control Checks

- **Requirements in scope:** none (requirement-free maintenance run).
- **Traceability:** N/A (docs-only; no requirement to link; IMPLEMENTS/TESTS not applicable).
- **No deferred work in this PR.** The automated bootstrap-CLI recovery path recommended by the codex preflight is tracked separately in #1618 (complements #1287, the future AWS destroy workflow authored from this runbook).

Closes #1472