### PR TITLE
docs(gcp): note operator verification for GCE candidate-boot validation

### DIFF
--- a/docs/architecture/gcp-guest-images.md
+++ b/docs/architecture/gcp-guest-images.md
@@ -181,6 +181,33 @@ hygiene rather than relying on sysprep:
 - The **live** domain Administrator credential is rotated **per range at
   runtime** by `plans/dc_setup.py` (`DC_DOMAIN_PASSWORD`), not baked.
 
+### First live validation run (operator verification)
+
+The candidate-boot validation subsystem (`packer-gcp-validate.yml` and
+`shifter/packer/gcp/scripts/validate/*`) is exercised in CI only for template,
+workflow, and script **shape** (`packer validate`, `actionlint`, `shellcheck`,
+and the structural and behavioral unit tests). Its live behaviour is GCP-only
+and is not exercised until an operator dispatches the workflow against a real
+project: the IAP tunnel to the candidate VM, the runner's SSH to the polaris-vm
+management port (2222), and the DC LDAP rootDSE probe.
+
+Treat the **first `packer-gcp-validate.yml` run per environment** as the smoke
+test for that live path, and confirm:
+
+- `start-iap-tunnel` reaches the candidate on the SSH port (22 for generic
+  Linux, the configured management port for polaris-vm) and on 389 for a DC.
+- The injected instance SSH key lets the runner reach the guest as the
+  `validator` user (project SSH keys are blocked, so an instance key is used).
+- `ldapsearch` on the runner returns the expected forest rootDSE for a
+  `dc-prebaked` candidate.
+- The disposable validation VM is deleted on both success and failure.
+
+A failure on that first run is a wiring issue in the validation path, not a
+candidate-image defect; fix it before relying on the `validated=passed` label as
+a promotion gate. Follow-up hardening of this subsystem is tracked in #1621
+(attestation-bound evidence, dispatch-ref workflow trust) and #1622 (real
+source-image disk check, deeper DC service/content probing).
+
 ## Operating the pipeline
 
 Build + export one guest (Actions → "Packer GCE Image Build" → pick type/env, or):


### PR DESCRIPTION
## Summary

Documents operator verification for the GCE candidate-boot validation subsystem shipped in #1343. CI gates that subsystem for template/workflow/script shape only; its live behaviour (IAP tunnel, SSH to the polaris-vm management port, DC LDAP rootDSE probe) is GCP-only and is not exercised until an operator runs packer-gcp-validate.yml against a real project. Adds a "First live validation run" section to docs/architecture/gcp-guest-images.md with the concrete checks to confirm on that first run, and points at follow-ups #1621/#1622.

## Requirement UIDs

- (none — bug/refactor/maintenance run; see Traceability section below)

## Related Issues

Closes #1343

## ADR Impact

- ADR-037

## Changes

- Add a 'First live validation run (operator verification)' subsection to docs/architecture/gcp-guest-images.md describing what the first packer-gcp-validate.yml dispatch per environment must confirm (IAP tunnel reachability, instance-key SSH as the validator user, DC rootDSE, disposable-VM cleanup) and that a first-run failure is a validation-path wiring issue, not a candidate-image defect

## Test Plan

- [x] `make check` passes (Spotless, SpotBugs, Error Prone, Checkstyle, JaCoCo)
- [x] `make policy` passes (documentation/workflow guardrails)
- Unit tests / integration tests: N/A — docs-only change

## Ground Control Checks

- [x] `make policy` passes
- [x] `gc_evaluate_quality_gates` passes or is unchanged by this repo-only change
- [x] `gc_run_sweep` reviewed; findings fixed or recorded with rationale

## Traceability

- IMPLEMENTS: (none — bug/refactor/maintenance run)
- TESTS: (none — documentation/configuration/structural-invariant run)

## Checklist

- [x] Code follows project coding standards (`docs/CODING_STANDARDS.md`)
- [x] No business logic in API layer
- [x] Domain layer has no framework imports
- [x] Envers `@Audited` on new entities if applicable
- Changelog fragment: N/A — docs-only change
- [x] Architectural docs updated if stack, package structure, or key behaviors changed
