### PR TITLE
changed: retire branch-targeted CI routing for dispatch-only deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,18 @@ name: Deploy
 on:
   pull_request:
   push:
-    branches: [main, dev, aws-dev, aws-proof, gcp-dev]
+    # Validation only. Env deploys are now manual (workflow_dispatch below);
+    # pushing dev/main runs quality/pre-commit but never a provider deploy.
+    branches: [main, dev]
   workflow_dispatch:
     inputs:
+      environment:
+        description: Which environment to deploy (the branch you run this from is the code that deploys).
+        type: choice
+        options:
+          - aws-dev
+          - aws-proof
+          - gcp-dev
       gcp_require_active_certificate:
         description: >-
           Fail the GCP deploy if the GKE ManagedCertificate is not Active for the
@@ -26,10 +35,12 @@ on:
         default: false
 
 concurrency:
-  group: deploy-${{ github.ref }}
-  # PR runs may be superseded safely, but env-branch deploys can be mid-apply.
-  # Queue branch/manual deploy runs so Terraform is not killed after mutating
-  # remote state or while holding the backend lock.
+  # Dispatch deploys queue per environment so two deploys to the same env cannot
+  # race on Terraform state or the backend lock; PR/push validation keys on the ref.
+  group: deploy-${{ github.event.inputs.environment || github.ref }}
+  # PR runs may be superseded safely, but a dispatch deploy can be mid-apply.
+  # Queue manual deploy runs so Terraform is not killed after mutating remote
+  # state or while holding the backend lock.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -67,7 +78,6 @@ jobs:
       run_gcp: ${{ steps.env.outputs.run_gcp }}
       apply_aws: ${{ steps.env.outputs.apply_aws }}
       deploy_gcp: ${{ steps.env.outputs.deploy_gcp }}
-      fast_gcp_deploy: ${{ steps.env.outputs.fast_gcp_deploy }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -212,6 +222,10 @@ jobs:
 
       - name: Set environment
         id: env
+        env:
+          # Which environment to deploy, from the workflow_dispatch input (a
+          # closed choice enum). Empty on push / pull_request, which never deploy.
+          ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           AWS_ENV="dev"
           AWS_IS_DEV="true"
@@ -222,22 +236,12 @@ jobs:
           RUN_GCP="false"
           APPLY_AWS="false"
           DEPLOY_GCP="false"
-          FAST_GCP_DEPLOY="false"
 
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            # PR-triggered deploy workflow runs are hosted-only quality gates.
-            # Never route provider deploy jobs from untrusted PR code.
-            :
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            BRANCH="${GITHUB_REF#refs/heads/}"
-            case "$BRANCH" in
-              main)
-                AWS_ENV="prod"
-                AWS_IS_DEV="false"
-                AWS_GITHUB_ENV="aws-prod"
-                RUN_AWS="true"
-                APPLY_AWS="true"
-                ;;
+          # Deployment is manual only: a workflow_dispatch that names the target
+          # environment. The branch names no longer select the target, and push /
+          # pull_request run validation only (all deploy flags stay false).
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            case "$ENVIRONMENT" in
               aws-dev)
                 RUN_AWS="true"
                 APPLY_AWS="true"
@@ -252,31 +256,6 @@ jobs:
               gcp-dev)
                 RUN_GCP="true"
                 DEPLOY_GCP="true"
-                FAST_GCP_DEPLOY="true"
-                ;;
-              dev)
-                RUN_AWS="true"
-                RUN_GCP="true"
-                ;;
-            esac
-          elif [ "${{ github.event_name }}" == "push" ]; then
-            BRANCH="${GITHUB_REF#refs/heads/}"
-            case "$BRANCH" in
-              aws-dev)
-                RUN_AWS="true"
-                APPLY_AWS="true"
-                ;;
-              aws-proof)
-                AWS_ENV="proof"
-                AWS_IS_DEV="false"
-                AWS_GITHUB_ENV="aws-proof"
-                RUN_AWS="true"
-                APPLY_AWS="true"
-                ;;
-              gcp-dev)
-                RUN_GCP="true"
-                DEPLOY_GCP="true"
-                FAST_GCP_DEPLOY="true"
                 ;;
             esac
           fi
@@ -290,7 +269,6 @@ jobs:
             echo "run_gcp=$RUN_GCP"
             echo "apply_aws=$APPLY_AWS"
             echo "deploy_gcp=$DEPLOY_GCP"
-            echo "fast_gcp_deploy=$FAST_GCP_DEPLOY"
           } >> "$GITHUB_OUTPUT"
 
   # Always-present CI enforcement for the fast local pre-commit baseline that
@@ -338,22 +316,14 @@ jobs:
   quality:
     name: Quality
     needs: changes
-    # Run Quality on PRs and direct pushes to `dev` unless the diff is
-    # provably ordinary docs-only. Manual dispatch remains a deliberate
-    # full-validation path, except for the existing fast GCP deploy route.
-    # Pushes to deployment branches (aws-dev, gcp-dev) only happen via merge
-    # from `dev` (per repo rule: deploy branches must never be ahead of dev),
-    # so the same SHA already passed Quality on its dev push and re-running
-    # here is pure duplicate work. Deploy jobs already tolerate skipped
-    # Quality via `(needs.quality.result == 'success' || ... == 'skipped')`.
-    # The proof tenant standup path (manual dispatch on aws-proof) also skips
-    # Quality: it redeploys a SHA already validated on dev.
+    # Run Quality on PRs, direct pushes (dev/main), and every manual deploy
+    # dispatch (the safety gate before an apply) unless the diff is provably
+    # ordinary docs-only. Deploy jobs tolerate a skipped Quality via
+    # `(needs.quality.result == 'success' || ... == 'skipped')`.
     if: |
-      !(github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/aws-proof') &&
       (github.event_name == 'pull_request' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.ref == 'refs/heads/dev') &&
-      needs.changes.outputs.fast_gcp_deploy != 'true' &&
+       github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch') &&
       (needs.changes.outputs.quality_relevant == 'true' ||
        github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/_quality.yml

--- a/changelog.d/730.changed.md
+++ b/changelog.d/730.changed.md
@@ -1,0 +1,1 @@
+Environment deploys are now manual: run the Deploy workflow with a `workflow_dispatch` `environment` input (`aws-dev`, `aws-proof`, or `gcp-dev`) instead of them auto-triggering on a push to the env branch. The branch you run the workflow from is the code that deploys; no branch name selects the target. Push and pull_request run validation only.

--- a/docs/dev/deploy-secrets.md
+++ b/docs/dev/deploy-secrets.md
@@ -228,7 +228,7 @@ Standup runbooks for the phases referenced below:
 - Tearing an environment down: [`aws-teardown-runbook.md`](aws-teardown-runbook.md)
 
 For a new AWS account, bootstrap the backend and CI identity before trying
-to use the `aws-dev` deploy branch:
+run an AWS dev deploy (`gh workflow run deploy.yml --ref <branch> -f environment=aws-dev`):
 
 If the account was **re-used** (a prior Shifter tenant was torn down here), first run
 `./scripts/bootstrap/deploy.py account-recovery --env dev --profile <profile>` to detect
@@ -267,13 +267,13 @@ bootstrap commands below so their confirmation prompts proceed without a termina
    the range egress allowlist). Bootstrap configures the AWS role secret and
    backend files; the deploy workflows fail loud when the active portal or range
    tfvars secret, or the range `shifter.yaml`, is missing.
-5. For the first deploy in a moved or fresh account, run the `Deploy`
-   workflow manually with `workflow_dispatch` on `aws-dev`. Manual dispatch
-   forces the full AWS chain (Core -> Range -> Engine -> Platform). A plain
-   branch push still obeys path filters, so it can skip Core or image
-   publishing if the pushed commit only touched bootstrap/backend files.
-   After the first full run has created the shared state and images, normal
-   `aws-dev` pushes can use the filtered path.
+5. For the first deploy in a moved or fresh account, run the `Deploy` workflow
+   with `gh workflow run deploy.yml --ref <branch> -f environment=aws-dev`
+   (add `-f aws_first_deploy=true` for the first-ever engine deploy, before the
+   platform Terraform apply has created the provisioner task definition). The
+   dispatch forces the full AWS chain (Core -> Range -> Engine -> Platform).
+   Deployment is always a manual dispatch; pushing to a branch runs validation
+   only.
 
 ### First-run DNS validation
 

--- a/docs/technical/dev/adr-enforcement.md
+++ b/docs/technical/dev/adr-enforcement.md
@@ -226,8 +226,8 @@ The first slice intentionally stays small:
   `portal_image` filter covering `shifter/shifter_platform/**`, exposed as a
   `changes`-job output, included in the `shifter_platform` job's trigger
   condition, and consumed by the platform `build` job through the
-  `portal_image_changes` input so an app-only push to an environment branch
-  builds and converges the portal image without running Terraform. The check
+  `portal_image_changes` input so an app-only deploy dispatch builds and
+  converges the portal image without running Terraform. The check
   also requires `.github/workflows/deploy.yml` to pass `skip_tests: false`
   literally into `_quality.yml` (no commit-message parsing or dynamic outputs)
   and requires lint, architecture, and security jobs in `_quality.yml` to stay
@@ -235,8 +235,8 @@ The first slice intentionally stays small:
   when a caller opts in; the deploy router never opts in (#760). Negative
   fixtures in `scripts/adr_guard/tests/test_adr_guard.py` include a minimal
   `_quality.yml` stub so plan-scope tests isolate one violation at a time. The check
-  requires deploy concurrency to queue branch/manual runs rather than cancel
-  in-flight applies; PR cancellation may remain enabled. It also requires every
+  requires deploy concurrency to queue dispatch deploys (keyed per environment)
+  rather than cancel in-flight applies; PR cancellation may remain enabled. It also requires every
   core, range, and platform `terraform plan` / saved-plan `terraform apply`
   command to include `-lock-timeout=5m`, and requires each apply job to create
   and execute a local saved `tfplan` instead of uploading raw binary plans as
@@ -257,8 +257,8 @@ The first slice intentionally stays small:
   `scripts/adr_guard/tests/test_deploy_workflow.py` also assert the engine
   reusable workflow carries its own hosted provisioner pytest gate and that
   `_shifter-engine.yml` image validation, image build, and deploy jobs all need
-  that gate. This keeps deploy-branch Quality skips from bypassing provisioner
-  tests on the image that is pushed and deployed. The same suite pins the engine
+  that gate. This keeps a deploy dispatch's Quality skip from bypassing
+  provisioner tests on the image that is pushed and deployed. The same suite pins the engine
   `validate` image-shape job's runner placement (#1474): it runs on the trusted
   self-hosted deploy runner class rather than `ubuntu-latest`, so a
   GitHub-hosted runner-acquisition stall can no longer cancel it before steps
@@ -266,6 +266,12 @@ The first slice intentionally stays small:
   fail-closed on `pull_request` under the `deploy-workflow-runner-exposure`
   (ADR-003-R5) invariant, keeps `contents: read` only, and carries a
   `timeout-minutes` backstop (#1220).
+
+  The manual-deploy invariant (`TestManualDeployDispatch`, #730) asserts that
+  environment deploys are a `workflow_dispatch` naming the `environment` input
+  (a closed `choice` of `aws-dev` / `aws-proof` / `gcp-dev`), that the `Set
+  environment` step keys on that input rather than a branch-name `case` router,
+  and that `push` / `pull_request` run validation only (no run/apply flags).
 
 - `portal-deploy-mode-source-of-truth`
   Enforces ADR-003-R4 for the AWS portal deploy path. `_shifter-platform.yml`

--- a/docs/technical/dev/ci-cd.md
+++ b/docs/technical/dev/ci-cd.md
@@ -15,26 +15,27 @@ which coordinates:
 
 ## Trigger Rules
 
+Environment deploys are **manual**: run the Deploy workflow and pick the
+`environment` input. Push and pull_request run validation only; no branch name
+triggers a deploy (#730).
+
 | Event | What Runs |
 |-------|-----------|
-| PR to `dev` / `main` | Quality only; no deploy or Terraform plan jobs |
-| PR to `aws-dev` | Quality + AWS plan (no apply) |
-| PR to `gcp-dev` | Quality + GCP validate (no apply) |
-| Push to `dev` | Quality only; no deploy or Terraform plan jobs |
-| Push to `aws-dev` | Quality + AWS deploy to dev |
-| Push to `gcp-dev` | Fast GCP validation + GCP deploy |
-| Push to `main` | Code branch update only; no deploy or Terraform plan jobs |
-| Manual dispatch on `main` | AWS prod deploy |
+| Pull request | Quality only; no deploy |
+| Push to `dev` / `main` | Quality only; no deploy |
+| Manual dispatch, `environment: aws-dev` | Quality, then AWS dev deploy |
+| Manual dispatch, `environment: aws-proof` | Quality, then AWS proof deploy |
+| Manual dispatch, `environment: gcp-dev` | Quality, then GCP dev deploy |
 
-Deployment-branch PRs get Terraform plan comments. `dev` is the integration
-branch for Quality only. Dev deployments happen only from `aws-dev` and
-`gcp-dev`.
+Run a deploy from the Actions UI (**Deploy → Run workflow**, pick the branch to
+deploy and the `environment`) or the CLI:
 
-`gcp-dev` pushes skip the global quality fan-out. The fast path still runs the
-provider-local guardrails in `_gcp-dev.yml`: Terraform fmt/init/validate plus
-rendered-manifest schema validation before deploy. Broad lint/test/security
-coverage runs on PRs and `dev`; production deployment is a deliberate manual
-dispatch from `main`.
+```
+gh workflow run deploy.yml --ref <branch> -f environment=aws-dev
+```
+
+The branch you run it from is the code that deploys; the `environment` input
+picks where it goes. `dev` is the integration branch (Quality only).
 
 ## Workflow Files
 
@@ -85,18 +86,18 @@ The orchestrator uses path filters to run only relevant jobs:
 | `shifter_engine` | Shifter Engine code, ECR module |
 | `shifter_platform` | Portal/Guacamole Terraform and platform deploy workflow |
 | `quality_relevant` | Any non-docs change, plus guardrail docs; controls whether Quality runs without launching deploy or Terraform plan jobs |
-| `portal_image` | Portal image build inputs (`shifter/shifter_platform/**`, `cyberscript`, `installation`, `.dockerignore`); triggers the portal image build/deploy on environment branches without running Terraform |
+| `portal_image` | Portal image build inputs (`shifter/shifter_platform/**`, `cyberscript`, `installation`, `.dockerignore`); triggers the portal image build/deploy on a deploy dispatch without running Terraform |
 | `gcp` | GCP Terraform, GCP Kubernetes assets, GCP scripts, GCP cloud adapters |
 | `mcp` | MCP package changes, routed to Quality only |
 | `quality_only` | Non-deploy test-support and guardrail surfaces (`scripts/polaris-aws-range/**`, `scenario-dev/polaris/tests/**`, `_quality.yml`, ADR/guardrail checker paths), routed to Quality only |
 
 ## Quality Gate
 
-Runs on every PR and direct push to `dev` unless the diff is ordinary
-docs-only. Guardrail docs such as `.github/pull_request_template.md`,
+Runs on every PR, direct push to `dev`/`main`, and every manual deploy dispatch
+(the safety gate before an apply) unless the diff is ordinary docs-only.
+Guardrail docs such as `.github/pull_request_template.md`,
 `.github/copilot-instructions.md`, `docs/adr/**`, and the ADR enforcement
-guide are quality-relevant and still run Quality. Manual dispatch is a
-deliberate full-validation path, except for the existing fast GCP deploy route.
+guide are quality-relevant and still run Quality.
 
 The deploy workflow exposes one `quality_relevant` output for this decision:
 non-docs changes make it true, ordinary docs-only changes make it false, and
@@ -105,9 +106,8 @@ a skipped Quality job only when `quality_relevant` is false.
 
 The Shifter Engine reusable workflow has an additional blocking provisioner
 pytest gate before local Docker validation, credentialed image build, and ECS
-deploy. This keeps deploy-triggering AWS branch runs from building or deploying
-the provisioner image when the top-level Quality job is legitimately skipped
-because the SHA was already validated on `dev`.
+deploy. This keeps a deploy dispatch from building or deploying the provisioner
+image when the top-level Quality job is legitimately skipped.
 
 - **ADR conformance**: `python3 scripts/adr_guard/adr_guard.py --all --level ci`
   Includes `adr-registry`, `layer-imports`, `cross-layer-model-imports`, and
@@ -254,35 +254,27 @@ under the first-run DNS validation and routing sections.
 ## Environment Detection
 
 ```
-Branch/Target     → Behavior
-PR to dev         → Quality only
-PR to aws-dev     → AWS dev plan
-PR to gcp-dev     → GCP validate
-PR to main        → Quality only
-Push to dev       → Quality only
-Push to aws-dev   → AWS dev deploy
-Push to gcp-dev   → Fast GCP validate + GCP deploy
-Push to main      → no deploy
-Dispatch on main  → AWS prod deploy
+Event / input                  → Behavior
+Pull request                   → Quality only
+Push to dev / main             → Quality only
+dispatch environment=aws-dev   → AWS dev deploy
+dispatch environment=aws-proof → AWS proof deploy
+dispatch environment=gcp-dev   → GCP dev deploy
 ```
 
 ## Provider Routing
 
-`deploy.yml` resolves branch intent explicitly:
-
-- `dev` is the shared integration branch. It runs the quality gate for shared code changes, but it must not plan/apply infrastructure or deploy workloads.
-- `aws-dev` is the only branch that deploys the AWS dev environment.
-- `gcp-dev` is the only branch that deploys the GCP dev environment, and it uses the narrow GCP fast path on branch pushes.
-- `main` is the production code branch; production deploys run only through deliberate `workflow_dispatch`.
-- Shared Shifter application changes run Quality on `dev`; provider-specific deployment validation runs on the deployment branches before apply.
+- `dev`/`main` are integration branches: they run the quality gate but never plan/apply infrastructure or deploy workloads.
+- A deploy is a manual `workflow_dispatch` that names the `environment`; the branch you run it from is the code that deploys. No branch name selects the target.
 - The GCP control plane is deployed through the Helm chart in `platform/charts/shifter`, with generated values layered on top of environment defaults.
 - The GCP portal auth contract is FirebaseUI/browser-side Identity Platform auth plus server-side verified-token exchange. Do not add Django credential handling to recreate Cognito semantics.
 - Multi-cloud work enters through the shared cloud adapter layers rather than provider-specific calls in domain services.
 
-## Manual Deploy Bootstrap Inputs
+## Manual Deploy Inputs
 
-`deploy.yml` exposes `workflow_dispatch` inputs for rare first-time-bootstrap deploys. They are strict by default and only take effect on a manual dispatch; automatic (push) deploys always fail closed.
+`deploy.yml` runs on `workflow_dispatch`. The `environment` input selects the deployment target; the bootstrap flags are strict by default.
 
+- `environment`: which environment to deploy: `aws-dev`, `aws-proof`, or `gcp-dev`. A closed choice enum. The branch you run the workflow from is the code that deploys.
 - `aws_first_deploy` (default `false`): allow the AWS engine deploy to skip the ECS task-family existence check. Set `true` only for the first-ever deploy to a fresh AWS environment, before the platform Terraform apply has created the provisioner task definition. On any normal deploy a missing or typo'd task family fails the run instead of skipping silently. Clear it (re-run without the flag) once the platform stack has been applied.
 - `gcp_require_active_certificate` (default `true`): require the GKE ManagedCertificate to be Active for the public hostname. Set `false` only for first-time GCP bootstrap, before DNS for the hostname has been pointed at the ingress IP.
 
@@ -317,7 +309,7 @@ Terraform plans are also posted as PR comments.
 - Check branch protection rules
 - Verify path filters match your changes
 - Look for `paths-filter` in deploy.yml
-- Confirm you are pushing to the right branch for the intended behavior: `dev` runs Quality only, `aws-dev` deploys AWS dev, `gcp-dev` deploys GCP dev, and prod deploys require manual dispatch on `main`
+- A deploy is a manual dispatch: `gh workflow run deploy.yml --ref <branch> -f environment=<aws-dev|aws-proof|gcp-dev>`. Pushes and PRs run validation only; no branch push deploys.
 
 ### Terraform Plan Fails
 - Check for formatting issues: `terraform fmt -recursive`

--- a/docs/technical/platform_infrastructure/cicd.md
+++ b/docs/technical/platform_infrastructure/cicd.md
@@ -42,15 +42,16 @@ Jobs run only when relevant files change. `deploy.yml` detects changes and trigg
 
 ## Environment Targeting
 
-- Push to `dev` → Quality only; no deploy or Terraform plan jobs
-- Push to `aws-dev` → AWS dev deploy
-- Push to `gcp-dev` → fast GCP validate + GCP dev deploy
-- Push to `main` → code branch update only; no deploy or Terraform plan jobs
-- Manual dispatch on `main` → AWS prod deploy
-- PRs to `dev` → Quality only
-- PRs to `aws-dev` → AWS dev plan
-- PRs to `gcp-dev` → GCP validate
-- PRs to `main` → Quality only
+Environment deploys are manual (`workflow_dispatch` with an `environment` input);
+push and pull_request run validation only (#730).
+
+- Pull request → Quality only
+- Push to `dev` / `main` → Quality only; no deploy
+- Manual dispatch `environment=aws-dev` → AWS dev deploy
+- Manual dispatch `environment=aws-proof` → AWS proof deploy
+- Manual dispatch `environment=gcp-dev` → GCP dev deploy
+
+Run a deploy with `gh workflow run deploy.yml --ref <branch> -f environment=<env>`.
 
 ## Authentication
 
@@ -67,11 +68,9 @@ AWS roles defined in `platform/terraform/global/iam/github-oidc.tf`. GCP WIF con
 
 ## GCP Current State
 
-GCP now deploys through CI/CD on `gcp-dev`. The branch model is:
-
-- `dev`: Quality-only integration branch
-- `aws-dev`: AWS dev deploy branch
-- `gcp-dev`: GCP dev deploy branch
+GCP deploys through CI/CD via a manual `workflow_dispatch` with `environment=gcp-dev`
+(`gh workflow run deploy.yml --ref <branch> -f environment=gcp-dev`). Branch names
+no longer trigger deploys; `dev`/`main` are Quality-only integration branches (#730).
 
 The GCP CI path:
 
@@ -81,7 +80,7 @@ The GCP CI path:
 4. renders secure Helm values from Terraform outputs and Secret Manager
 5. installs or upgrades the Shifter Helm release
 
-On `gcp-dev` pushes, this path now runs as a fast deploy lane. It skips the repo-wide quality workflow and relies on the provider-local validation in `_gcp-dev.yml` so break/fix iteration on GCP does not wait for the full cross-repo lint/test matrix. The full quality gate still runs on PRs and on `dev`; production deploys are manual dispatches from `main`.
+Every deploy dispatch runs the quality gate first as the safety gate before an apply.
 
 The bootstrap path is security-gated and fails closed unless:
 

--- a/scripts/adr_guard/tests/test_deploy_workflow.py
+++ b/scripts/adr_guard/tests/test_deploy_workflow.py
@@ -188,78 +188,56 @@ class TestUpstreamGating(unittest.TestCase):
         )
 
 
-class TestBranchEventMatrix(unittest.TestCase):
-    """#892: branch/event routing produces the intended deploy outputs."""
+class TestManualDeployDispatch(unittest.TestCase):
+    """#730: environment deploys are manual (a workflow_dispatch names the
+    environment). push and pull_request run validation only, and no branch name
+    selects a deployment target."""
+
+    ENV_OPTIONS = {"aws-dev", "aws-proof", "gcp-dev"}
 
     @classmethod
     def setUpClass(cls):
-        cls.script = ADR_GUARD._dw_extract_set_environment_script(_load("deploy.yml"))
+        cls.deploy = _load("deploy.yml")
+        cls.script = ADR_GUARD._dw_extract_set_environment_script(cls.deploy)
 
     def env(self, event_name, ref="", base_ref=""):
         return ADR_GUARD._dw_evaluate_env(
             self.script, event_name, ref=ref, base_ref=base_ref
         )
 
-    def test_push_to_dev_and_main_produce_no_deploy(self):
+    def test_push_never_deploys(self):
         for ref in ("refs/heads/dev", "refs/heads/main"):
             out = self.env("push", ref=ref)
-            self.assertEqual(out["run_aws"], "false", ref)
-            self.assertEqual(out["run_gcp"], "false", ref)
-            self.assertEqual(out["apply_aws"], "false", ref)
-            self.assertEqual(out["deploy_gcp"], "false", ref)
+            for key in ("run_aws", "run_gcp", "apply_aws", "deploy_gcp"):
+                self.assertEqual(out[key], "false", f"{ref}:{key}")
 
-    def test_no_pull_request_routes_a_provider_deploy(self):
+    def test_pull_request_never_deploys(self):
         for base in ("dev", "main", "aws-dev", "gcp-dev"):
             out = self.env("pull_request", base_ref=base)
-            self.assertEqual(out["run_aws"], "false", base)
-            self.assertEqual(out["run_gcp"], "false", base)
-            self.assertEqual(out["apply_aws"], "false", base)
-            self.assertEqual(out["deploy_gcp"], "false", base)
+            for key in ("run_aws", "run_gcp", "apply_aws", "deploy_gcp"):
+                self.assertEqual(out[key], "false", f"{base}:{key}")
 
-    def test_push_to_aws_dev_plans_and_applies(self):
-        out = self.env("push", ref="refs/heads/aws-dev")
-        self.assertEqual(out["run_aws"], "true")
-        self.assertEqual(out["apply_aws"], "true")
-        self.assertEqual(out["aws_environment"], "dev")
-        self.assertEqual(out["aws_is_dev"], "true")
+    def test_deploy_is_selected_by_the_environment_input_not_the_branch(self):
+        # The Set environment step keys on the workflow_dispatch `environment`
+        # input; the old branch-name `case` router (and prod path) are gone.
+        self.assertIn('case "$ENVIRONMENT"', self.script)
+        self.assertNotIn("GITHUB_REF#refs/heads/", self.script)
+        self.assertNotIn("aws-prod", self.script)
 
-    def test_push_to_gcp_dev_plans_and_applies(self):
-        out = self.env("push", ref="refs/heads/gcp-dev")
-        self.assertEqual(out["run_gcp"], "true")
-        self.assertEqual(out["deploy_gcp"], "true")
-        self.assertEqual(out["fast_gcp_deploy"], "true")
+    def test_environment_input_is_a_closed_choice_allowlist(self):
+        env_input = self.deploy["on"]["workflow_dispatch"]["inputs"]["environment"]
+        self.assertEqual(env_input["type"], "choice")
+        self.assertEqual(set(env_input["options"]), self.ENV_OPTIONS)
 
-    def test_workflow_dispatch_main_is_the_only_prod_apply_path(self):
-        prod = self.env("workflow_dispatch", ref="refs/heads/main")
-        self.assertEqual(prod["aws_environment"], "prod")
-        self.assertEqual(prod["aws_is_dev"], "false")
-        self.assertEqual(prod["run_aws"], "true")
-        self.assertEqual(prod["apply_aws"], "true")
-        others = [
-            ("push", "refs/heads/dev", ""),
-            ("push", "refs/heads/main", ""),
-            ("push", "refs/heads/aws-dev", ""),
-            ("push", "refs/heads/gcp-dev", ""),
-            ("pull_request", "", "dev"),
-            ("pull_request", "", "aws-dev"),
-            ("workflow_dispatch", "refs/heads/dev", ""),
-            ("workflow_dispatch", "refs/heads/aws-dev", ""),
-            ("workflow_dispatch", "refs/heads/gcp-dev", ""),
-        ]
-        for event, ref, base in others:
-            out = self.env(event, ref=ref, base_ref=base)
-            self.assertNotEqual(
-                out.get("aws_environment"),
-                "prod",
-                f"{event}/{ref or base} must not target prod",
+    def test_deploy_jobs_stay_pull_request_denied(self):
+        # Unchanged trust invariant: no deploy job runs on a pull_request event.
+        jobs = ADR_GUARD._dw_jobs(self.deploy, "deploy.yml")
+        for jid in DEPLOY_JOBS:
+            expr = ADR_GUARD._dw_job_if(jobs[jid])
+            self.assertTrue(
+                ADR_GUARD._dw_job_denied_on_pull_request(expr),
+                f"{jid} must be denied on pull_request",
             )
-
-    def test_workflow_dispatch_dev_runs_both_clouds_without_apply(self):
-        out = self.env("workflow_dispatch", ref="refs/heads/dev")
-        self.assertEqual(out["run_aws"], "true")
-        self.assertEqual(out["run_gcp"], "true")
-        self.assertEqual(out["apply_aws"], "false")
-        self.assertEqual(out["aws_environment"], "dev")
 
 
 class TestChangeFilterCoverage(unittest.TestCase):

--- a/scripts/bootstrap/README.md
+++ b/scripts/bootstrap/README.md
@@ -98,12 +98,11 @@ command below.
    GitHub Actions, or in gitignored `local.auto.tfvars` files for local
    Terraform runs.
 6. For the first deploy in the moved account, run the `Deploy` GitHub Actions
-   workflow manually with `workflow_dispatch` on `aws-dev`. Manual dispatch
-   forces the full AWS chain (Core -> Range -> Engine -> Platform). A plain
-   branch push still obeys path filters, so it can skip Core or image
-   publishing when the pushed commit only touched bootstrap/backend files.
-   After the first full run succeeds, normal filtered `aws-dev` pushes are
-   appropriate.
+   workflow with `gh workflow run deploy.yml --ref <branch> -f environment=aws-dev`
+   (add `-f aws_first_deploy=true` for the first-ever engine deploy). The
+   dispatch forces the full AWS chain (Core -> Range -> Engine -> Platform).
+   Deployment is always a manual dispatch selecting the `environment`; pushing to
+   a branch runs validation only.
 7. During that first platform apply, publish DNS records for ACM and SES
    validation in the authoritative DNS zone. ACM records come from the root
    Terraform output `acm_validation_records`. SES records come from
@@ -145,9 +144,10 @@ Deployment section of
    Memorystore, Pub/Sub), builds and pushes the control-plane images, renders
    Helm values from Terraform outputs and Secret Manager, and installs the
    Shifter Helm release.
-6. Subsequent deploys run through CI: push to the `gcp-dev` branch, the only
-   branch that deploys the GCP dev environment (see the CI/CD trigger matrix in
-   `docs/technical/dev/ci-cd.md`).
+6. Subsequent deploys run through CI as a manual dispatch:
+   `gh workflow run deploy.yml --ref <branch> -f environment=gcp-dev` (see the
+   CI/CD trigger matrix in `docs/technical/dev/ci-cd.md`). Branch names no longer
+   trigger deploys.
 7. Point the configured hostname at the reserved global ingress IP so the
    Google-managed TLS certificate can activate.
 


### PR DESCRIPTION
## Summary

Environment deploys are now **manual**. The Deploy workflow runs on `workflow_dispatch` with an `environment` input (`aws-dev`, `aws-proof`, `gcp-dev`) instead of auto-triggering on a push to the env branch. The branch you run the workflow from is the code that deploys; no branch name selects the target. Push and pull_request run validation (Quality) only. The vestigial `main` → `aws-prod` path is removed — this repo does not deploy prod (prod moves to an independent tenant model separately).

## Requirement UIDs

- `PLAT-2004`

## Related Issues

Closes #730

## ADR Impact

- ADR-011-R3 (branch names must not determine deployment targets)

## Changes

- `deploy.yml`: `workflow_dispatch` gains an `environment` choice input; the `Set environment` step keys on it (`case "$ENVIRONMENT"`) instead of the branch name; the env branches are removed from the `push:` trigger; `main`/`aws-prod` and the `fast_gcp_deploy` output are dropped; concurrency keys per environment.
- `scripts/adr_guard/tests/test_deploy_workflow.py`: `TestBranchEventMatrix` → `TestManualDeployDispatch` asserting push/PR never deploy, the `environment` input is a closed choice, deploy is selected by the input (no branch `case`, no prod), and deploy jobs stay PR-denied. All other guardrail invariants unchanged.
- Docs: `ci-cd.md`, `cicd.md`, `deploy-secrets.md`, `bootstrap/README.md`, `adr-enforcement.md` describe the manual-dispatch model.

## Test Plan

- [x] `scripts/adr_guard/tests/test_deploy_workflow.py` (44 tests)
- [x] `actionlint`, `adr_guard --all --level ci`, Vale, pre-commit

Net change is a reduction (−202/+147): it deletes the branch `case` routing and adds one dispatch input.

## Traceability

- IMPLEMENTS: PLAT-2004 <- .github/workflows/deploy.yml
- TESTS: PLAT-2004 <- scripts/adr_guard/tests/test_deploy_workflow.py

## Notes

Deployment provenance hardening (restricting which refs may deploy which environment) is intentionally **not** in scope here; it belongs with the independent prod tenant deploy model.
