### PR TITLE
ci: force pgp plugin signature to dodge tflint --init attestation panic

### DIFF
--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -265,15 +265,6 @@ jobs:
         uses: terraform-linters/setup-tflint@6e87008f9dd1fe3e34e66aca6c97b4a69f72a7f4 # v4
 
       - name: Init TFLint
-        # Authenticate the ruleset-plugin fetch. `tflint --init` calls the
-        # GitHub API for plugin release metadata; unauthenticated, it uses the
-        # 60/hr shared per-IP limit, which on shared runners is exhausted by
-        # other tenants. The throttled response is mishandled by tflint (nil
-        # panic in VerifyAttestations) and reddens terraform-lint repo-wide.
-        # Passing GITHUB_TOKEN moves the call to the per-token rate limit.
-        # Issue #1691; see tflint docs "Avoiding rate limiting".
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: tflint --init --config "${GITHUB_WORKSPACE}/.tflint.hcl"
 
       - name: Run TFLint

--- a/.github/workflows/_quality.yml
+++ b/.github/workflows/_quality.yml
@@ -265,6 +265,15 @@ jobs:
         uses: terraform-linters/setup-tflint@6e87008f9dd1fe3e34e66aca6c97b4a69f72a7f4 # v4
 
       - name: Init TFLint
+        # Authenticate the ruleset-plugin fetch. `tflint --init` calls the
+        # GitHub API for plugin release metadata; unauthenticated, it uses the
+        # 60/hr shared per-IP limit, which on shared runners is exhausted by
+        # other tenants. The throttled response is mishandled by tflint (nil
+        # panic in VerifyAttestations) and reddens terraform-lint repo-wide.
+        # Passing GITHUB_TOKEN moves the call to the per-token rate limit.
+        # Issue #1691; see tflint docs "Avoiding rate limiting".
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: tflint --init --config "${GITHUB_WORKSPACE}/.tflint.hcl"
 
       - name: Run TFLint

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -7,6 +7,14 @@ plugin "google" {
   enabled = true
   version = "0.31.0"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
+
+  # Verify the plugin via its PGP signature instead of GitHub artifact
+  # attestations. A GitHub-side change to attestation bundles makes tflint's
+  # attestation verifier nil-panic during `tflint --init` (sigstore-go
+  # bundle.TlogEntries), which reddens terraform-lint repo-wide. This is the
+  # maintainer-recommended interim workaround; remove once tflint ships the
+  # fix. Upstream: terraform-linters/tflint#2591 (fix PR #2593). Issue #1691.
+  signature = "pgp"
 }
 
 # Start with rules that are actionable in the current tree. The repo has


### PR DESCRIPTION
## Summary

- **What changed:** Add `signature = "pgp"` to the `google` plugin block in `.tflint.hcl`.
- **Why:** `tflint --init` nil-panics in `sigstore-go`'s `bundle.TlogEntries` while verifying the plugin's GitHub artifact attestation, crashing the `Quality / Lint (terraform)` gate **repo-wide including on `dev`**. This is upstream bug terraform-linters/tflint#2591: a GitHub-side change to attestation bundles (`bundle` is now `null`) that breaks every recent tflint (v0.61–v0.63.1) for all official rulesets, with and without `GITHUB_TOKEN`. Forcing PGP signature verification bypasses the broken attestation path while keeping supply-chain verification. Maintainer-recommended interim workaround; revert once the upstream fix (PR terraform-linters/tflint#2593) ships. Fixes #1691.

Verified locally (tflint 0.62.0, in the crash matrix): with a fresh plugin dir `tflint --init` panics without the change and installs cleanly (exit 0) with `signature = "pgp"`.

> Note: the first commit on this branch tried authenticating the fetch with `GITHUB_TOKEN`; that was disproven — the panic reproduces authenticated, and a set token is a documented *trigger*. It is reverted; the net diff is `.tflint.hcl` only.

## ADR Impact

- [x] No ADR impact
- [ ] Existing ADRs updated
- [ ] New ADR added
- [ ] Temporary exception added to `docs/adr/exceptions.yaml`

ADRs touched: none — CI tooling workaround, no enforcement/guardrail policy change.

Exceptions added or renewed: none

## Guardrail Changes

- [ ] No guardrail files changed
- [ ] Guardrail files changed and matching docs were updated

`.tflint.hcl` is in the ADR-guard scope but ADR-002-R1 does not flag this change and requires no docs update: it is a plugin-verification-mode workaround, not an enforcement-rule change. `adr_guard.py --all --level ci` passes.

## Verification

- [x] `python3 scripts/adr_guard/adr_guard.py --all --level ci` (pass)
- [x] Stack-native checks: `tflint --init`/`tflint` parse+run clean with the config; `pre-commit run --files .tflint.hcl .github/workflows/_quality.yml` (pass); local repro confirms the panic is fixed
- [x] Relevant tests (n/a — tflint config change)
- [x] Docs updated where behavior or enforcement changed (n/a)
